### PR TITLE
Adds multiple file upload

### DIFF
--- a/bullet_train-fields/app/javascript/controllers/fields/file_item_controller.js
+++ b/bullet_train-fields/app/javascript/controllers/fields/file_item_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = [
+    "removeFileFlag",
+    "downloadFileButton",
+    "removeFileButton",
+    "fileName"
+  ];
+
+  static values = { id: Number }
+
+  removeFile() {
+    if (this.hasDownloadFileButtonTarget) {
+      this.downloadFileButtonTarget.classList.add("hidden");
+    }
+
+    this.removeFileButtonTarget.classList.add("hidden");
+    this.fileNameTarget.classList.add("hidden");
+    this.removeFileFlagTarget.value = this.idValue;
+  }
+
+}

--- a/bullet_train-fields/app/javascript/controllers/index.js
+++ b/bullet_train-fields/app/javascript/controllers/index.js
@@ -7,6 +7,7 @@ import ColorPickerController from './fields/color_picker_controller'
 import DateController from './fields/date_controller'
 import EmojiPickerController from './fields/emoji_picker_controller'
 import FileFieldController from './fields/file_field_controller'
+import FileItemController from './fields/file_item_controller'
 import PasswordController from './fields/password_controller'
 import PhoneController from './fields/phone_controller'
 import SuperSelectController from './fields/super_select_controller'
@@ -19,6 +20,7 @@ export const controllerDefinitions = [
   [DateController, 'fields/date_controller.js'],
   [EmojiPickerController, 'fields/emoji_picker_controller.js'],
   [FileFieldController, 'fields/file_field_controller.js'],
+  [FileItemController, 'fields/file_item_controller.js'],
   [PasswordController, 'fields/password_controller.js'],
   [PhoneController, 'fields/phone_controller.js'],
   [SuperSelectController, 'fields/super_select_controller.js'],
@@ -39,6 +41,7 @@ export {
   DateController,
   EmojiPickerController,
   FileFieldController,
+  FileItemController,
   PasswordController,
   PhoneController,
   SuperSelectController,

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -1103,12 +1103,12 @@ class Scaffolding::Transformer
             RUBY
           else
             "json.#{name} url_for(tangible_thing.#{name}) if tangible_thing.#{name}.attached?"
-          end 
+          end
 
           scaffold_add_line_to_file("./app/views/api/v1/scaffolding/completely_concrete/tangible_things/_tangible_thing.json.jbuilder", jbuilder_content, RUBY_FILES_HOOK, prepend: true, suppress_could_not_find: true)
           # We also want to make sure we attach the dummy file in the API test on setup
           file_name = "./test/controllers/api/v1/scaffolding/completely_concrete/tangible_things_controller_test.rb"
-          content = if is_multiple 
+          content = if is_multiple
             <<~RUBY
               @#{child.underscore}.#{name} = [Rack::Test::UploadedFile.new("test/support/foo.txt")]
               @another_#{child.underscore}.#{name} = [Rack::Test::UploadedFile.new("test/support/foo.txt")]

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/attributes/_files.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/attributes/_files.erb
@@ -1,0 +1,13 @@
+<% object ||= current_attributes_object %>
+<% strategy ||= current_attributes_strategy || :none %>
+<% url ||= nil %>
+<% if object.send(attribute).attached? %>
+  <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
+    <% object.send(attribute).each do |file| %>
+      <%= link_to url_for(file), class: 'button download-file' do %>
+        <i class="leading-none mr-2 text-base ti ti-download"></i>
+        <span>Download File</span>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_file_field.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_file_field.html.erb
@@ -4,24 +4,33 @@
 form ||= current_fields_form
 options ||= {}
 other_options ||= {}
+multiple ||= false
+persisted_files = multiple ? form.object.send(method) : [form.object.send(method)]
 %>
 
 <%= render 'shared/fields/field', form: form, method: method, helper: :file_field, options: options, other_options: other_options do %>
   <% content_for :field do %>
     <div class="file-field" data-controller="fields--file-field">
-      <%= form.hidden_field "#{method}_removal".to_sym, value: nil, data: {'fields--file-field-target': 'removeFileFlag'} %>
-      <%= form.file_field method, class: 'file-upload hidden', direct_upload: true, data: {'fields--file-field-target': 'fileField', action: 'change->fields--file-field#handleFileSelected'} %>
+      <%= form.file_field method, class: 'file-upload hidden', multiple: multiple, direct_upload: true, data: {'fields--file-field-target': 'fileField', action: 'change->fields--file-field#handleFileSelected'} %>
       <div>
         <% if form.object.send(method).attached? %>
-          <%= link_to url_for(form.object.send(method)), class: 'button download-file mr-3', data: {'fields--file-field-target': 'downloadFileButton'} do %>
-            <i class="leading-none mr-2 text-base ti ti-download"></i>
-            <span>Download Current Document</span>
-          <% end %>
-        <% end %>
-        <% if form.object.send(method).attached? %>
-          <div class="button-alternative cursor-pointer mr-3" data-action="click->fields--file-field#removeFile" data-fields--file-field-target="removeFileButton">
-            <i class="leading-none mr-2 text-base ti ti-trash"></i>
-            <span>Remove Current Document</span>
+          <div class="divide-y-2 divide-dashed">
+            <% persisted_files.each do |file| %>
+              <div data-controller="fields--file-item" data-fields--file-item-id-value="<%= file.id %>">
+                <%= form.hidden_field "#{method}_removal".to_sym, multiple: multiple, value: nil, data: {'fields--file-item-target': 'removeFileFlag'} %>
+                <span data-fields--file-item-target="fileName" %>
+                  <%= file.blob.filename %>
+                </span>
+                <%= link_to url_for(file), class: 'button download-file mr-3', data: {'fields--file-item-target': 'downloadFileButton'} do %>
+                  <i class="leading-none mr-2 text-base ti ti-download"></i>
+                  <span>Download Document</span>
+                <% end %>
+                <div class="button-alternative cursor-pointer mr-3" data-action="click->fields--file-item#removeFile" data-fields--file-item-target="removeFileButton">
+                  <i class="leading-none mr-2 text-base ti ti-trash"></i>
+                  <span>Remove Document</span>
+                </div>
+              </div>
+            <% end %>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
Fixes https://github.com/bullet-train-co/bullet_train-fields/issues/43

super-scaffold can be used as follows to add multiple file attachments.
```
bin/super-scaffold crud-field Project images:file_field{multiple}
```

### Updates strong params to support an array of attachment IDs staged for removal.
To support the selective removal of attachments we had to use an array to pass the attachment ids, This adds `#{name}_removal: []` to strong params.

### Assign attachments instead of replacing 
Rails by default replace all the attachments with new ones, We are overriding the active storage method (`def #{name}=(attachables)`) to avoid this and ensure rails persist in existing attachments while adding new ones. 


Note - 
@andrewculver Cosmetic changes like UI design of multi-file upload are not part of this PR, Let me know how it feels and if any changes are necessary.