### PR TITLE
Make sure password edit form has `form` class

### DIFF
--- a/bullet_train/app/views/devise/passwords/edit.html.erb
+++ b/bullet_train/app/views/devise/passwords/edit.html.erb
@@ -3,7 +3,7 @@
   <% p.content_for :title, @title %>
   <% p.content_for :body do %>
     <% within_fields_namespace(:update_self) do %>
-      <%= form_for(resource, as: resource_name, url: password_path(resource_name), class: 'form', html: { method: :put }) do |f| %>
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { class: 'form', method: :put }) do |f| %>
         <%= f.hidden_field :reset_password_token %>
         <%= render 'account/shared/forms/errors', form: f, attributes: [:reset_password_token] %>
         <%= render 'shared/fields/password_field', form: f, method: :password, options: {autofocus: true, autocomplete: "off"} %>


### PR DESCRIPTION
Adding class - `form` to the form tag fixes the proper spacing issue between form fields

Fixes https://github.com/bullet-train-co/bullet_train-core/issues/4


After fix:
<img width="250" alt="fix-password-reset" src="https://user-images.githubusercontent.com/2105944/208244341-d3c38af3-f522-4dd2-bdd3-816ff88d63a5.png">
