### PR TITLE
Remove unneeded branch from Gemfile

### DIFF
--- a/bullet_train-super_scaffolding/Gemfile
+++ b/bullet_train-super_scaffolding/Gemfile
@@ -8,8 +8,8 @@ gem "sqlite3"
 
 gem "sprockets-rails"
 
-gem "bullet_train", git: "git@github.com:bullet-train-co/bullet_train-base.git", branch: "ci-strong-params"
-gem "bullet_train-api", git: "git@github.com:bullet-train-co/bullet_train-api.git", branch: "ci-strong-params"
+gem "bullet_train"
+gem "bullet_train-api"
 
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"


### PR DESCRIPTION
I added this specific branch in the Gemfile in [this PR](https://github.com/bullet-train-co/bullet_train-super_scaffolding/pull/79) to prove that the tests were passing, but since we aren't splitting PRs across multiple repositories like before I don't think we'll need this here.