### PR TITLE
Update message when running super-scaffold crud

### DIFF
--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb
@@ -55,6 +55,9 @@ module BulletTrain
             puts ""
             puts "#{index + 1}. #{message}".send(color)
           end
+
+          puts ""
+          puts "Testing the Bullet Train contribution process."
           puts ""
         end
       end


### PR DESCRIPTION
This PR adds the message `Testing the Bullet Train contribution process.` at the end of the running of `bin/super-scaffold crud ...`.

Closes "Part3" of https://gist.github.com/andrewculver/774a4d7aae98fd28727d17c367e01398