### PR TITLE
Add default message for token's `last_used_at` attribute

### DIFF
--- a/bullet_train-api/app/views/account/platform/access_tokens/_index.html.erb
+++ b/bullet_train-api/app/views/account/platform/access_tokens/_index.html.erb
@@ -36,14 +36,7 @@
                     <%= render "shared/tables/checkbox", object: access_token %>
                     <td><%= render 'shared/attributes/code', attribute: :token, secret: true %></td>
                     <td><%= render 'shared/attributes/text', attribute: :description %></td>
-                    <td>
-                      <% if access_token.last_used_at %>
-                        <%= render 'shared/attributes/date_and_time', attribute: :last_used_at %>
-                      <% else %>
-                        <% # TODO Make it so we can just define a `default` key for `last_used_at` in the locale file and it will us that when present. %>
-                        Never
-                      <% end %>
-                    </td>
+                    <td><%= render 'shared/attributes/date_and_time', attribute: :last_used_at %></td>
                     <%# 🚅 super scaffolding will insert new fields above this line. %>
                     <td><%= render 'shared/attributes/date_and_time', attribute: :created_at %></td>
                     <td class="buttons">

--- a/bullet_train-themes/app/views/themes/base/attributes/_date.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_date.html.erb
@@ -1,9 +1,12 @@
 <% object ||= current_attributes_object %>
 <% strategy ||= current_attributes_strategy || :none %>
 <% url ||= nil %>
+<% default_message = local_assigns[:default_message] || t('global.formats.timestamp_unavailable') %>
 
 <% if object.send(attribute).present? %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
     <%= display_date(object.send(attribute), local_assigns[:date_format]) %>
   <% end %>
+<% else %>
+  <%= default_message %>
 <% end %>

--- a/bullet_train-themes/app/views/themes/base/attributes/_date_and_time.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_date_and_time.html.erb
@@ -1,9 +1,12 @@
 <% object ||= current_attributes_object %>
 <% strategy ||= current_attributes_strategy || :none %>
 <% url ||= nil %>
+<% default_message = local_assigns[:default_message] || t('global.formats.timestamp_unavailable') %>
 
 <% if object.send(attribute).present? %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
     <%= display_date_and_time(object.send(attribute), local_assigns[:date_format], local_assigns[:time_format]) %>
   <% end %>
+<% else %>
+  <%= default_message %>
 <% end %>


### PR DESCRIPTION
Moving the PR from https://github.com/bullet-train-co/bullet_train-themes/pull/20 to here.

Again, here's how it looks like in the browser:

![image](https://user-images.githubusercontent.com/10546292/208603116-463962fa-de68-4119-a63d-708d322e34b1.png)
