### PR TITLE
Define User strong parameters based on attributes being updated

### DIFF
--- a/bullet_train-api/app/controllers/concerns/api/v1/users/controller_base.rb
+++ b/bullet_train-api/app/controllers/concerns/api/v1/users/controller_base.rb
@@ -4,7 +4,6 @@ module Api::V1::Users::ControllerBase
   module StrongParameters
     # Only allow a list of trusted parameters through.
     def user_params
-      selected_fields = []
       password_fields = [
         :password,
         :current_password,
@@ -21,7 +20,7 @@ module Api::V1::Users::ControllerBase
       selected_fields = if params.is_a?(BulletTrain::Api::StrongParametersReporter)
         password_fields + general_fields
       else
-	params["commit"] == t(".buttons.update_password") ? password_fields : general_fields
+        (params["commit"] == t(".buttons.update_password")) ? password_fields : general_fields
       end
 
       strong_params = params.require(:user).permit(

--- a/bullet_train-api/app/controllers/concerns/api/v1/users/controller_base.rb
+++ b/bullet_train-api/app/controllers/concerns/api/v1/users/controller_base.rb
@@ -4,25 +4,29 @@ module Api::V1::Users::ControllerBase
   module StrongParameters
     # Only allow a list of trusted parameters through.
     def user_params
-      general_fields = if params["commit"] == t(".buttons.update_password")
-        [
-          :password,
-          :current_password,
-          :password_confirmation
-        ]
+      selected_fields = []
+      password_fields = [
+        :password,
+        :current_password,
+        :password_confirmation
+      ]
+      general_fields = [
+        :email,
+        :first_name,
+        :last_name,
+        :time_zone,
+        :locale
+      ]
+
+      selected_fields = if params.is_a?(BulletTrain::Api::StrongParametersReporter)
+        password_fields + general_fields
       else
-        [
-          :email,
-          :first_name,
-          :last_name,
-          :time_zone,
-          :locale
-        ]
+	params["commit"] == t(".buttons.update_password") ? password_fields : general_fields
       end
 
       strong_params = params.require(:user).permit(
         *permitted_fields,
-        *general_fields,
+        *selected_fields,
         # 🚅 super scaffolding will insert new fields above this line.
         *permitted_arrays,
         # 🚅 super scaffolding will insert new arrays above this line.

--- a/bullet_train-api/app/controllers/concerns/api/v1/users/controller_base.rb
+++ b/bullet_train-api/app/controllers/concerns/api/v1/users/controller_base.rb
@@ -4,7 +4,7 @@ module Api::V1::Users::ControllerBase
   module StrongParameters
     # Only allow a list of trusted parameters through.
     def user_params
-      general_fields = if params["commit"] == t('.buttons.update_password')
+      general_fields = if params["commit"] == t(".buttons.update_password")
         [
           :password,
           :current_password,

--- a/bullet_train-api/app/controllers/concerns/api/v1/users/controller_base.rb
+++ b/bullet_train-api/app/controllers/concerns/api/v1/users/controller_base.rb
@@ -4,16 +4,25 @@ module Api::V1::Users::ControllerBase
   module StrongParameters
     # Only allow a list of trusted parameters through.
     def user_params
+      general_fields = if params["commit"] == t('.buttons.update_password')
+        [
+          :password,
+          :current_password,
+          :password_confirmation
+        ]
+      else
+        [
+          :email,
+          :first_name,
+          :last_name,
+          :time_zone,
+          :locale
+        ]
+      end
+
       strong_params = params.require(:user).permit(
         *permitted_fields,
-        :email,
-        :first_name,
-        :last_name,
-        :time_zone,
-        :locale,
-        :current_password,
-        :password,
-        :password_confirmation,
+        *general_fields,
         # 🚅 super scaffolding will insert new fields above this line.
         *permitted_arrays,
         # 🚅 super scaffolding will insert new arrays above this line.


### PR DESCRIPTION
Moving https://github.com/bullet-train-co/bullet_train-api/pull/32 over here.
I used I18n in response to the review in that PR.

## Details

I had to edit the code a little bit now that we have OpenAPI, because when creating the documentation the `params` object becomes a `BulletTrain::Api::StrongParametersReporter`. Just to be safe, I added all of the fields to the to the strong parameters when that's the case.