### PR TITLE
Fix duplicate rendering issue

### DIFF
--- a/bullet_train-api/app/views/account/platform/access_tokens/_index.html.erb
+++ b/bullet_train-api/app/views/account/platform/access_tokens/_index.html.erb
@@ -7,7 +7,7 @@
 <% access_tokens = access_tokens.order(:id) unless has_order?(access_tokens) %>
 <% pagy, access_tokens = pagy(access_tokens, page_param: :access_tokens_page) %>
 
-<%= action_model_select_controller do %>
+<% content = capture do %>
   <%= updates_for context, collection do %>
     <%= render 'account/shared/box', pagy: pagy do |p| %>
       <% p.content_for :title, t(".contexts.#{context.class.name.underscore}.header") %>
@@ -89,3 +89,5 @@
     <% end %>
   <% end %>
 <% end %>
+
+<%= render_with_action_model_check(content) %>

--- a/bullet_train-super_scaffolding/app/helpers/super_scaffolding_helper.rb
+++ b/bullet_train-super_scaffolding/app/helpers/super_scaffolding_helper.rb
@@ -1,13 +1,2 @@
 module SuperScaffoldingHelper
-  unless defined?(BulletTrain::ActionModels)
-    # action_model_select_controller is originally a method
-    # in the Action Models package, but we can't simply
-    # remove this method from Super Scaffolded index partials
-    # when the package isn't present. Since we keep
-    # action_model_select_controller in our views, we need
-    # this method so we don't get a NoMethodError.
-    def action_model_select_controller
-      yield
-    end
-  end
 end

--- a/bullet_train-super_scaffolding/app/views/account/scaffolding/completely_concrete/tangible_things/_index.html.erb
+++ b/bullet_train-super_scaffolding/app/views/account/scaffolding/completely_concrete/tangible_things/_index.html.erb
@@ -8,8 +8,8 @@
 <% pagy ||= nil %>
 <% pagy, tangible_things = pagy(tangible_things, page_param: :tangible_things_page) unless pagy %>
 
-<%= action_model_select_controller do %>
-  <% updates_for context, collection do %>
+<% content = capture do %>
+  <%= updates_for context, collection do %>
     <%= render 'account/shared/box', pagy: pagy do |p| %>
       <% p.content_for :title, t(".contexts.#{context.class.name.underscore}.header") %>
       <% p.content_for :description do %>
@@ -67,3 +67,5 @@
     <% end %>
   <% end %>
 <% end %>
+
+<%= render_with_action_model_check(content) %>

--- a/bullet_train/app/helpers/base_helper.rb
+++ b/bullet_train/app/helpers/base_helper.rb
@@ -7,4 +7,19 @@ module BaseHelper
       false
     end
   end
+
+  # If developers are using Action Models, this method will
+  # add the "Select Multiple" functionality to their html.
+  # Since the Action Model select controller needs to be
+  # rendered as well, we build the content here first before
+  # passing it back to <%= ... %> as a whole.
+  def render_with_action_model_check(content)
+    if action_models_enabled?
+      action_model_select_controller do
+        content
+      end
+    else
+      content
+    end
+  end
 end

--- a/bullet_train/lib/bullet_train.rb
+++ b/bullet_train/lib/bullet_train.rb
@@ -83,6 +83,10 @@ def stripe_enabled?
   ENV["STRIPE_CLIENT_ID"].present?
 end
 
+def action_models_enabled?
+  defined?(BulletTrain::ActionModels)
+end
+
 # 🚅 super scaffolding will insert new oauth providers above this line.
 
 def webhooks_enabled?


### PR DESCRIPTION
Closes https://github.com/bullet-train-co/bullet_train/issues/550

## Details

We were wrapping content with the `action_model_select_controller` method which simply calls `yield` when the developer doesn't have Action Models enabled. How we add content to this block can cause it to duplicate content.

## Duplicating with a vanilla Rails app
We get duplicate content if we do the same thing like this:

```ruby
# Write this method in a helper
def foo
  yield
end
```

```erb
# Call a partial named "bar" in any view
<%= foo do %>
  <%= render "bar" do %>
    Duplicated content
  <% end %>
<% end %>
```

```erb
# Yield the content in the `_bar.html.erb` partial
<%= yield %>
```

## CHANGELOG (Option 1)
1. Tell <b>all</b> the developers to update their Super Scaffolded views with this `capture` fix.

## CHANGELOG (Option 2)
1. Tell developers who aren't using Action Models to simply delete the `action_model_select_controller` block
2. Tell developers who already use Action Models to update their views to use the `capture` fix in this PR.

## My opinion
Option 1 is probably best because, although all developers will have to update their Super Scaffolded views with this `capture` fix even if they don't use Action Models, once it's set they won't have to think about it if they decide to upgrade to Action Models in the future. I'm also assuming that there's a reason for having the action model select controller code here even if Action Models isn't defined, so I decided to leave the logic there.

If there is a specific path you'd like to take concerning the CHANGELOG, I'd be glad to write it.