### PR TITLE
Replace custom path logic with `render` prefixes

### DIFF
--- a/bullet_train-themes/app/helpers/theme_helper.rb
+++ b/bullet_train-themes/app/helpers/theme_helper.rb
@@ -41,7 +41,8 @@ module ThemeHelper
 
   def render(options = {}, locals = {}, &block)
     if (theme_path = BulletTrain::Themes.theme_invocation_path_for(options))
-      options = current_theme_object.resolved_partial_path_for(@lookup_context, options, locals) || options
+      partial = current_theme_object.resolved_partial_path_for(@lookup_context, options, locals)
+      options = partial ? partial.virtual_path.gsub("/_", "/") : options
     end
 
     # This is where we try to just lean on Rails default behavior. If someone renders `shared/box` and also has a

--- a/bullet_train-themes/app/helpers/theme_helper.rb
+++ b/bullet_train-themes/app/helpers/theme_helper.rb
@@ -40,7 +40,9 @@ module ThemeHelper
   end
 
   def render(options = {}, locals = {}, &block)
-    options = current_theme_object.resolved_partial_path_for(@lookup_context, options, locals) || options
+    if (theme_path = BulletTrain::Themes.theme_invocation_path_for(options))
+      options = current_theme_object.resolved_partial_path_for(@lookup_context, options, locals) || options
+    end
 
     # This is where we try to just lean on Rails default behavior. If someone renders `shared/box` and also has a
     # `app/views/shared/_box.html.erb`, then no error will be thrown and we will have never interfered in the normal

--- a/bullet_train-themes/app/helpers/theme_helper.rb
+++ b/bullet_train-themes/app/helpers/theme_helper.rb
@@ -41,20 +41,19 @@ module ThemeHelper
 
   def render(options = {}, locals = {}, &block)
     if (theme_path = BulletTrain::Themes.theme_invocation_path_for(options))
-      partial = @lookup_context.find_all(theme_path, current_theme_object.prefixes, true, locals.keys).first
-      options = partial ? partial.virtual_path.gsub("/_", "/") : options
+      super(partial: theme_path, prefixes: current_theme_object.prefixes, locals: locals, &block)
+    else
+      # This is where we try to just lean on Rails default behavior. If someone renders `shared/box` and also has a
+      # `app/views/shared/_box.html.erb`, then no error will be thrown and we will have never interfered in the normal
+      # Rails behavior.
+      #
+      # We also don't do anything special if someone renders `shared/box` and we've already previously resolved that
+      # partial to be served from `themes/light/box`. In that case, we've already replaced `shared/box` with the
+      # actual path of the partial, and Rails will do the right thing from this point.
+      #
+      # However, if one of those two situations isn't true, then this call here will throw an exception and we can
+      # perform the appropriate magic to figure out where amongst the themes the partial should be rendering from.
+      super
     end
-
-    # This is where we try to just lean on Rails default behavior. If someone renders `shared/box` and also has a
-    # `app/views/shared/_box.html.erb`, then no error will be thrown and we will have never interfered in the normal
-    # Rails behavior.
-    #
-    # We also don't do anything special if someone renders `shared/box` and we've already previously resolved that
-    # partial to be served from `themes/light/box`. In that case, we've already replaced `shared/box` with the
-    # actual path of the partial, and Rails will do the right thing from this point.
-    #
-    # However, if one of those two situations isn't true, then this call here will throw an exception and we can
-    # perform the appropriate magic to figure out where amongst the themes the partial should be rendering from.
-    super
   end
 end

--- a/bullet_train-themes/app/helpers/theme_helper.rb
+++ b/bullet_train-themes/app/helpers/theme_helper.rb
@@ -41,7 +41,9 @@ module ThemeHelper
 
   def render(options = {}, locals = {}, &block)
     if (theme_path = BulletTrain::Themes.theme_invocation_path_for(options))
-      super(partial: theme_path, prefixes: current_theme_object.prefixes, locals: locals, &block)
+      # Rails may have a bug here. Don't understand why `partial:` is set to `layout:` when it hasn't been passed in?
+      # https://github.com/rails/rails/blob/a7902034089e8b6bff747c08d93eeac4b1377032/actionview/lib/action_view/helpers/rendering_helper.rb#L35
+      super(partial: theme_path, layout: theme_path, prefixes: current_theme_object.prefixes, locals: locals, &block)
     else
       # This is where we try to just lean on Rails default behavior. If someone renders `shared/box` and also has a
       # `app/views/shared/_box.html.erb`, then no error will be thrown and we will have never interfered in the normal

--- a/bullet_train-themes/app/helpers/theme_helper.rb
+++ b/bullet_train-themes/app/helpers/theme_helper.rb
@@ -41,7 +41,7 @@ module ThemeHelper
 
   def render(options = {}, locals = {}, &block)
     if (theme_path = BulletTrain::Themes.theme_invocation_path_for(options))
-      partial = current_theme_object.resolved_partial_path_for(@lookup_context, options, locals)
+      partial = @lookup_context.find_all(theme_path, current_theme_object.prefixes, true, locals.keys).first
       options = partial ? partial.virtual_path.gsub("/_", "/") : options
     end
 

--- a/bullet_train-themes/lib/bullet_train/themes.rb
+++ b/bullet_train-themes/lib/bullet_train/themes.rb
@@ -26,10 +26,14 @@ module BulletTrain
           ["base"]
         end
 
+        def prefixes
+          @prefixes ||= directory_order.map { "themes/#{_1}" }
+        end
+
         def resolved_partial_path_for(lookup_context, path, locals)
           if (theme_path = BulletTrain::Themes.theme_invocation_path_for(path))
             # TODO directory_order should probably come from the `Current` model.
-            if (partial = lookup_context.find_all(theme_path, directory_order.map { "themes/#{_1}" }, true, locals.keys).first)
+            if (partial = lookup_context.find_all(theme_path, prefixes, true, locals.keys).first)
               partial.virtual_path.gsub("/_", "/")
             end
           end

--- a/bullet_train-themes/lib/bullet_train/themes.rb
+++ b/bullet_train-themes/lib/bullet_train/themes.rb
@@ -9,8 +9,6 @@ module BulletTrain
     mattr_accessor :themes, default: {}
     mattr_accessor :logo_height, default: 54
 
-    mattr_reader :partial_paths, default: {}
-
     # TODO Do we want this to be configurable by downstream applications?
     INVOCATION_PATTERNS = Regexp.union(
       /^account\/shared\//, # ❌ This path is included for legacy purposes, but you shouldn't reference partials like this in new code.
@@ -29,20 +27,10 @@ module BulletTrain
         end
 
         def resolved_partial_path_for(lookup_context, path, locals)
-          # We disable partial path caching in development so new templates are taken into account without restarting the server.
-          partial_paths = {}
-
-          BulletTrain::Themes.partial_paths.fetch(path) do
-            if (theme_path = BulletTrain::Themes.theme_invocation_path_for(path))
-              # TODO directory_order should probably come from the `Current` model.
-              if (partial = lookup_context.find_all(theme_path, directory_order.map { "themes/#{_1}" }, true, locals.keys).first)
-                resolved_partial = partial.virtual_path.gsub("/_", "/")
-                if Rails.env.development?
-                  partial_paths[path] = resolved_partial
-                else
-                  BulletTrain::Themes.partial_paths[path] = resolved_partial
-                end
-              end
+          if (theme_path = BulletTrain::Themes.theme_invocation_path_for(path))
+            # TODO directory_order should probably come from the `Current` model.
+            if (partial = lookup_context.find_all(theme_path, directory_order.map { "themes/#{_1}" }, true, locals.keys).first)
+              partial.virtual_path.gsub("/_", "/")
             end
           end
         end

--- a/bullet_train-themes/lib/bullet_train/themes.rb
+++ b/bullet_train-themes/lib/bullet_train/themes.rb
@@ -31,11 +31,9 @@ module BulletTrain
         end
 
         def resolved_partial_path_for(lookup_context, path, locals)
-          if (theme_path = BulletTrain::Themes.theme_invocation_path_for(path))
-            # TODO directory_order should probably come from the `Current` model.
-            if (partial = lookup_context.find_all(theme_path, prefixes, true, locals.keys).first)
-              partial.virtual_path.gsub("/_", "/")
-            end
+          # TODO directory_order should probably come from the `Current` model.
+          if (partial = lookup_context.find_all(theme_path, prefixes, true, locals.keys).first)
+            partial.virtual_path.gsub("/_", "/")
           end
         end
       end

--- a/bullet_train-themes/lib/bullet_train/themes.rb
+++ b/bullet_train-themes/lib/bullet_train/themes.rb
@@ -32,9 +32,7 @@ module BulletTrain
 
         def resolved_partial_path_for(lookup_context, path, locals)
           # TODO directory_order should probably come from the `Current` model.
-          if (partial = lookup_context.find_all(theme_path, prefixes, true, locals.keys).first)
-            partial.virtual_path.gsub("/_", "/")
-          end
+          lookup_context.find_all(theme_path, prefixes, true, locals.keys).first
         end
       end
     end

--- a/bullet_train-themes/lib/bullet_train/themes.rb
+++ b/bullet_train-themes/lib/bullet_train/themes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bullet_train/themes/version"
 require "bullet_train/themes/engine"
 # require "bullet_train/themes/base/theme"
@@ -10,19 +12,14 @@ module BulletTrain
     mattr_reader :partial_paths, default: {}
 
     # TODO Do we want this to be configurable by downstream applications?
-    INVOCATION_PATTERNS = [
-      # ❌ This path is included for legacy purposes, but you shouldn't reference partials like this in new code.
-      /^account\/shared\//,
-
-      # ✅ This is the correct path to generically reference theme component partials with.
-      /^shared\//,
-    ]
+    INVOCATION_PATTERNS = Regexp.union(
+      /^account\/shared\//, # ❌ This path is included for legacy purposes, but you shouldn't reference partials like this in new code.
+      /^shared\//, # ✅ This is the correct path to generically reference theme component partials with.
+    )
 
     def self.theme_invocation_path_for(path)
       # Themes only support `<%= render 'shared/box' ... %>` style calls to `render`, so check `path` is a string first.
-      if path.is_a?(String) && (pattern = INVOCATION_PATTERNS.find { _1.match? path })
-        path.remove(pattern)
-      end
+      path.dup.gsub!(INVOCATION_PATTERNS, "") if path.is_a?(String)
     end
 
     module Base

--- a/bullet_train-themes/lib/bullet_train/themes.rb
+++ b/bullet_train-themes/lib/bullet_train/themes.rb
@@ -29,11 +29,6 @@ module BulletTrain
         def prefixes
           @prefixes ||= directory_order.map { "themes/#{_1}" }
         end
-
-        def resolved_partial_path_for(lookup_context, path, locals)
-          # TODO directory_order should probably come from the `Current` model.
-          lookup_context.find_all(theme_path, prefixes, true, locals.keys).first
-        end
       end
     end
   end


### PR DESCRIPTION
The idea is that a theme render gets converted from `render "shared/fields/text_field"` to

```ruby
render "fields/text_field", prefixes: ["themes/light", "themes/tailwind_css", "themes/base"]
```

So we can trim a lot of the custom rendering logic.