### PR TITLE
Add Webhooks::Outgoing::Events to API

### DIFF
--- a/bullet_train-api/app/controllers/api/open_api_controller.rb
+++ b/bullet_train-api/app/controllers/api/open_api_controller.rb
@@ -66,9 +66,9 @@ module OpenApiHelper
         indent("    " + parameters_output.to_yaml.gsub("---", "#{model.name.gsub("::", "")}Parameters:"), 3)
       ).html_safe
     else
-      (
-        indent(attributes_output.to_yaml.gsub("---", "#{model.name.gsub("::", "")}Attributes:"), 3)
-      ).html_safe
+
+      indent(attributes_output.to_yaml.gsub("---", "#{model.name.gsub("::", "")}Attributes:"), 3)
+        .html_safe
     end
   end
 

--- a/bullet_train-api/app/controllers/concerns/api/v1/users/controller_base.rb
+++ b/bullet_train-api/app/controllers/concerns/api/v1/users/controller_base.rb
@@ -42,4 +42,10 @@ module Api::V1::Users::ControllerBase
   # GET /api/v1/users/:id
   def show
   end
+
+  # PUT /api/v1/users/:id
+  # TODO: Implement this!
+  def update
+    raise "Not implemented"
+  end
 end

--- a/bullet_train-outgoing_webhooks/app/controllers/api/v1/webhooks/outgoing/events_controller.rb
+++ b/bullet_train-outgoing_webhooks/app/controllers/api/v1/webhooks/outgoing/events_controller.rb
@@ -10,4 +10,24 @@ class Api::V1::Webhooks::Outgoing::EventsController < Api::V1::ApplicationContro
   def show
     render json: @event.payload
   end
+
+  private
+
+  module StrongParameters
+    # Only allow a list of trusted parameters through.
+    def event_params
+      strong_params = params.require(:webhooks_outgoing_event).permit(
+        *permitted_fields,
+        # 🚅 super scaffolding will insert new fields above this line.
+        *permitted_arrays,
+      # 🚅 super scaffolding will insert new arrays above this line.
+        )
+
+      process_params(strong_params)
+
+      strong_params
+    end
+  end
+
+  include StrongParameters
 end

--- a/bullet_train-outgoing_webhooks/app/controllers/api/v1/webhooks/outgoing/events_controller.rb
+++ b/bullet_train-outgoing_webhooks/app/controllers/api/v1/webhooks/outgoing/events_controller.rb
@@ -10,24 +10,4 @@ class Api::V1::Webhooks::Outgoing::EventsController < Api::V1::ApplicationContro
   def show
     render json: @event.payload
   end
-
-  private
-
-  module StrongParameters
-    # Only allow a list of trusted parameters through.
-    def event_params
-      strong_params = params.require(:webhooks_outgoing_event).permit(
-        *permitted_fields,
-        # 🚅 super scaffolding will insert new fields above this line.
-        *permitted_arrays,
-        # 🚅 super scaffolding will insert new arrays above this line.
-      )
-
-      process_params(strong_params)
-
-      strong_params
-    end
-  end
-
-  include StrongParameters
 end

--- a/bullet_train-outgoing_webhooks/app/controllers/api/v1/webhooks/outgoing/events_controller.rb
+++ b/bullet_train-outgoing_webhooks/app/controllers/api/v1/webhooks/outgoing/events_controller.rb
@@ -1,0 +1,13 @@
+class Api::V1::Webhooks::Outgoing::EventsController < Api::V1::ApplicationController
+  account_load_and_authorize_resource :event, through: :team, through_association: :webhooks_outgoing_events
+
+  # GET /api/v1/teams/:team_id/webhooks/outgoing/events
+  def index
+    render json: @events.map(&:payload)
+  end
+
+  # GET /api/v1/webhooks/outgoing/events/:id
+  def show
+    render json: @event.payload
+  end
+end

--- a/bullet_train-outgoing_webhooks/app/controllers/api/v1/webhooks/outgoing/events_controller.rb
+++ b/bullet_train-outgoing_webhooks/app/controllers/api/v1/webhooks/outgoing/events_controller.rb
@@ -20,8 +20,8 @@ class Api::V1::Webhooks::Outgoing::EventsController < Api::V1::ApplicationContro
         *permitted_fields,
         # 🚅 super scaffolding will insert new fields above this line.
         *permitted_arrays,
-      # 🚅 super scaffolding will insert new arrays above this line.
-        )
+        # 🚅 super scaffolding will insert new arrays above this line.
+      )
 
       process_params(strong_params)
 

--- a/bullet_train-outgoing_webhooks/app/views/api/v1/open_api/index.yaml.erb
+++ b/bullet_train-outgoing_webhooks/app/views/api/v1/open_api/index.yaml.erb
@@ -16,6 +16,7 @@ components:
       scheme: bearer
   schemas:
     <%= automatic_components_for Webhooks::Outgoing::Endpoint %>
+    <%= automatic_components_for Webhooks::Outgoing::Event %>
     <%# 🚅 super scaffolding will insert new components above this line. %>
   parameters:
     id:
@@ -28,4 +29,5 @@ security:
   - BearerAuth: []
 paths:
   <%= automatic_paths_for Webhooks::Outgoing::Endpoint, Team %>
+  <%= automatic_paths_for Webhooks::Outgoing::Event, Team, except: %i[create update delete] %>
   <%# 🚅 super scaffolding will insert new paths above this line. %>

--- a/bullet_train-outgoing_webhooks/app/views/api/v1/webhooks/outgoing/events/_event.json.jbuilder
+++ b/bullet_train-outgoing_webhooks/app/views/api/v1/webhooks/outgoing/events/_event.json.jbuilder
@@ -1,12 +1,12 @@
-json.data do
-  json.id schema: {type: :integer}
-  json.name schema: {type: :string, required: true}
-  json.description schema: {type: :string}
-  json.created_at schema: {type: :string, format: "date-time"}
-  json.created_at schema: {type: :string, format: "date-time"}
+json.data schema: {object: OpenStruct.new, object_title: I18n.t('webhooks/outgoing/events.fields.data.heading'), object_description: I18n.t('webhooks/outgoing/events.fields.data.heading')} do
+  json.id schema: {type: :integer, description: I18n.t('webhooks/outgoing/events.fields.data.id.heading')}
+  json.name schema: {type: :string, description: I18n.t('webhooks/outgoing/events.fields.data.name.heading')}
+  json.description schema: {type: :string, description: I18n.t('webhooks/outgoing/events.fields.data.description.heading')}
+  json.created_at schema: {type: :string, format: "date-time", description: I18n.t('webhooks/outgoing/events.fields.data.created_at.heading')}
+  json.updated_at schema: {type: :string, format: "date-time", description: I18n.t('webhooks/outgoing/events.fields.data.updated_at.heading')}
 end
 
-json.event_id schema: {type: :string}
-json.event_type schema: {type: :integer}
-json.subject_id schema: {type: :integer}
-json.subject_type schema: {type: :string}
+json.event_id schema: {type: :string, description: I18n.t('webhooks/outgoing/events.fields.event_id.heading')}
+json.event_type schema: {type: :integer, description: I18n.t('webhooks/outgoing/events.fields.event_type.heading')}
+json.subject_id schema: {type: :integer, description: I18n.t('webhooks/outgoing/events.fields.subject_id.heading')}
+json.subject_type schema: {type: :string, description: I18n.t('webhooks/outgoing/events.fields.subject_type.heading')}

--- a/bullet_train-outgoing_webhooks/app/views/api/v1/webhooks/outgoing/events/_event.json.jbuilder
+++ b/bullet_train-outgoing_webhooks/app/views/api/v1/webhooks/outgoing/events/_event.json.jbuilder
@@ -1,12 +1,12 @@
-json.data schema: {object: OpenStruct.new, object_title: I18n.t('webhooks/outgoing/events.fields.data.heading'), object_description: I18n.t('webhooks/outgoing/events.fields.data.heading')} do
-  json.id schema: {type: :integer, description: I18n.t('webhooks/outgoing/events.fields.data.id.heading')}
-  json.name schema: {type: :string, description: I18n.t('webhooks/outgoing/events.fields.data.name.heading')}
-  json.description schema: {type: :string, description: I18n.t('webhooks/outgoing/events.fields.data.description.heading')}
-  json.created_at schema: {type: :string, format: "date-time", description: I18n.t('webhooks/outgoing/events.fields.data.created_at.heading')}
-  json.updated_at schema: {type: :string, format: "date-time", description: I18n.t('webhooks/outgoing/events.fields.data.updated_at.heading')}
+json.data schema: {object: OpenStruct.new, object_title: I18n.t("webhooks/outgoing/events.fields.data.heading"), object_description: I18n.t("webhooks/outgoing/events.fields.data.heading")} do
+  json.id schema: {type: :integer, description: I18n.t("webhooks/outgoing/events.fields.data.id.heading")}
+  json.name schema: {type: :string, description: I18n.t("webhooks/outgoing/events.fields.data.name.heading")}
+  json.description schema: {type: :string, description: I18n.t("webhooks/outgoing/events.fields.data.description.heading")}
+  json.created_at schema: {type: :string, format: "date-time", description: I18n.t("webhooks/outgoing/events.fields.data.created_at.heading")}
+  json.updated_at schema: {type: :string, format: "date-time", description: I18n.t("webhooks/outgoing/events.fields.data.updated_at.heading")}
 end
 
-json.event_id schema: {type: :string, description: I18n.t('webhooks/outgoing/events.fields.event_id.heading')}
-json.event_type schema: {type: :integer, description: I18n.t('webhooks/outgoing/events.fields.event_type.heading')}
-json.subject_id schema: {type: :integer, description: I18n.t('webhooks/outgoing/events.fields.subject_id.heading')}
-json.subject_type schema: {type: :string, description: I18n.t('webhooks/outgoing/events.fields.subject_type.heading')}
+json.event_id schema: {type: :string, description: I18n.t("webhooks/outgoing/events.fields.event_id.heading")}
+json.event_type schema: {type: :integer, description: I18n.t("webhooks/outgoing/events.fields.event_type.heading")}
+json.subject_id schema: {type: :integer, description: I18n.t("webhooks/outgoing/events.fields.subject_id.heading")}
+json.subject_type schema: {type: :string, description: I18n.t("webhooks/outgoing/events.fields.subject_type.heading")}

--- a/bullet_train-outgoing_webhooks/app/views/api/v1/webhooks/outgoing/events/_event.json.jbuilder
+++ b/bullet_train-outgoing_webhooks/app/views/api/v1/webhooks/outgoing/events/_event.json.jbuilder
@@ -1,0 +1,12 @@
+json.data do
+  json.id schema: {type: :integer}
+  json.name schema: {type: :string, required: true}
+  json.description schema: {type: :string}
+  json.created_at schema: {type: :string, format: "date-time"}
+  json.created_at schema: {type: :string, format: "date-time"}
+end
+
+json.event_id schema: {type: :string}
+json.event_type schema: {type: :integer}
+json.subject_id schema: {type: :integer}
+json.subject_type schema: {type: :string}

--- a/bullet_train-outgoing_webhooks/app/views/api/v1/webhooks/outgoing/events/index.json.jbuilder
+++ b/bullet_train-outgoing_webhooks/app/views/api/v1/webhooks/outgoing/events/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @events, partial: "api/v1/webhooks/outgoing/events/event", as: :event

--- a/bullet_train-outgoing_webhooks/app/views/api/v1/webhooks/outgoing/events/show.json.jbuilder
+++ b/bullet_train-outgoing_webhooks/app/views/api/v1/webhooks/outgoing/events/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "api/v1/webhooks/outgoing/events/event", event: @event

--- a/bullet_train-outgoing_webhooks/config/locales/en/webhooks/outgoing/events.en.yml
+++ b/bullet_train-outgoing_webhooks/config/locales/en/webhooks/outgoing/events.en.yml
@@ -52,6 +52,11 @@ en:
         heading: *subject_type
 
       short_uuid:
-        _: &event_id Short UUID
-        label: *event_id
-        heading: *event_id
+        _: &short_uuid Short UUID
+        label: *short_uuid
+        heading: *short_uuid
+
+      event_type_name:
+        _: &event_type_name Event Type Name
+        label: *event_type_name
+        heading: *event_type_name

--- a/bullet_train-outgoing_webhooks/config/locales/en/webhooks/outgoing/events.en.yml
+++ b/bullet_train-outgoing_webhooks/config/locales/en/webhooks/outgoing/events.en.yml
@@ -50,3 +50,8 @@ en:
         _: &subject_type Subject Type
         label: *subject_type
         heading: *subject_type
+
+      short_uuid:
+        _: &event_id Short UUID
+        label: *event_id
+        heading: *event_id

--- a/bullet_train-outgoing_webhooks/config/locales/en/webhooks/outgoing/events.en.yml
+++ b/bullet_train-outgoing_webhooks/config/locales/en/webhooks/outgoing/events.en.yml
@@ -1,10 +1,52 @@
 en:
-  webhooks/outgoing/events:
-    fields:
-      uuid: &uuid
-        heading: Event UUID
-      short_uuid: *uuid
-      event_type_name:
-        heading: Event Type
-      payload:
-        heading: JSON Payload
+  webhooks/outgoing/events: &events
+    label: &label Webhooks Events
+    fields: &fields
+      data:
+        _: &data Event Data
+        label: *data
+        heading: *data
+
+        id:
+          _: &id Event ID
+          label: *id
+          heading: *id
+
+        name:
+          _: &name Event Name
+          label: *name
+          heading: *name
+
+        description:
+          _: &description Event Description
+          label: *description
+          heading: *description
+
+        created_at:
+          _: &created_at DateTime Event was added
+          label: *created_at
+          heading: *created_at
+        updated_at:
+          _: &updated_at DateTime Event was updated
+          label: *updated_at
+          heading: *updated_at
+
+      event_id:
+        _: &event_id Event UUID
+        label: *event_id
+        heading: *event_id
+
+      event_type:
+        _: &event_type Event Type
+        label: *event_type
+        heading: *event_type
+
+      subject_id:
+        _: &subject_id Subject ID
+        label: *subject_id
+        heading: *subject_id
+
+      subject_type:
+        _: &subject_type Subject Type
+        label: *subject_type
+        heading: *subject_type

--- a/bullet_train-outgoing_webhooks/config/locales/en/webhooks/outgoing/events.en.yml
+++ b/bullet_train-outgoing_webhooks/config/locales/en/webhooks/outgoing/events.en.yml
@@ -51,6 +51,16 @@ en:
         label: *subject_type
         heading: *subject_type
 
+      payload:
+        _: &payload Payload
+        label: *payload
+        heading: *payload
+
+      uuid:
+        _: &uuid UUID
+        label: *uuid
+        heading: *uuid
+
       short_uuid:
         _: &short_uuid Short UUID
         label: *short_uuid

--- a/bullet_train-outgoing_webhooks/config/routes.rb
+++ b/bullet_train-outgoing_webhooks/config/routes.rb
@@ -6,10 +6,9 @@ Rails.application.routes.draw do
       resources BulletTrain::OutgoingWebhooks.parent_resource do
         namespace :webhooks do
           namespace :outgoing do
-            resources :events
             resources :endpoints do
-              resources :deliveries, only: [:index, :show] do
-                resources :delivery_attempts, only: [:index, :show]
+              resources :deliveries, only: %i[index show] do
+                resources :delivery_attempts, only: %i[index show]
               end
             end
           end
@@ -25,6 +24,7 @@ Rails.application.routes.draw do
           namespace :webhooks do
             namespace :outgoing do
               resources :endpoints, defaults: {format: :json}
+              resources :events, only: %i[index show], defaults: {format: :json}
             end
           end
         end


### PR DESCRIPTION
Kinda closes https://github.com/bullet-train-co/bullet_train-outgoing_webhooks/issues/15

After discussion with @andrewculver we made a conclusion that endpoints information cannot be placed into OpenAPI docs as they're different from Team to Team. What we can do is give information about what's being sent to webhook (payload of `Webhooks::Outgoing::Event` object). So here we add to urls in API just to show those events:

```
/api/v1/teams/:team_id/webhooks/outgoing/events
/api/v1/webhooks/outgoing/events/:id
```

Also `bullet_train-api` now checks if a controller has `:create` or `:update` actions and only then generates corresponding `...Parameters` block in OpenAPI. It also implements _empty_ `update` action for `Api::V1::Users::ControllerBase` so that it has `UserParameters` section in OpenAPI, mentioned in it's `_paths` file.