### PR TITLE
Fix Devise + BulletTrain engine loading order issue without runtime m…

### DIFF
--- a/bullet_train-themes-light/lib/bullet_train/themes/light.rb
+++ b/bullet_train-themes-light/lib/bullet_train/themes/light.rb
@@ -13,7 +13,7 @@ module BulletTrain
       mattr_accessor :logo_color_shift, default: false
       mattr_accessor :show_logo_in_account, default: false
       mattr_accessor :navigation, default: :top
-      mattr_accessor :original_devise_path
+      mattr_accessor :original_devise_path # TODO: Obsolete: remove after shipping a new BulletTrain version with usage removed.
 
       class Theme < BulletTrain::Themes::TailwindCss::Theme
         def directory_order

--- a/bullet_train-themes/app/helpers/theme_helper.rb
+++ b/bullet_train-themes/app/helpers/theme_helper.rb
@@ -1,39 +1,3 @@
-# Our custom devise views are housed in `bullet_train-base`, but they're overwritten
-# by devise's standard views if the devise gem is declared after `bullet_train`.
-# To ensure we use our custom views, we temporarily unregister the original devise
-# views path from the FileSystemResolver, add our custom path, and find the views that way.
-module ActionView
-  class LookupContext
-    module ViewPaths
-      def find(name, prefixes = [], partial = false, keys = [], options = {})
-        name, prefixes = normalize_name(name, prefixes)
-        details, details_key = detail_args_for(options)
-
-        devise_view = false
-        prefixes.each do |prefix|
-          if prefix.match?(/devise/)
-            devise_view = true
-            break
-          end
-        end
-
-        resolver = if name == "devise" || devise_view
-          original_devise_view_path = BulletTrain::Themes::Light.original_devise_path
-          bullet_train_resolver = @view_paths.paths.reject do |resolver|
-            resolver.path.match?(original_devise_view_path)
-          end
-          PathSet.new(bullet_train_resolver)
-        else
-          @view_paths
-        end
-
-        resolver.find(name, prefixes, partial, details, details_key, keys)
-      end
-      alias_method :find_template, :find
-    end
-  end
-end
-
 module ThemeHelper
   def current_theme_object
     @current_theme_object ||= "BulletTrain::Themes::#{current_theme.to_s.classify}::Theme".constantize.new

--- a/bullet_train/lib/bullet_train/engine.rb
+++ b/bullet_train/lib/bullet_train/engine.rb
@@ -1,3 +1,18 @@
+begin
+  # We hoist the Devise engine, so its app/views directory is always after ours in a Rails app's view_paths.
+  #
+  # This is a quirk of how Rails engines compose, since engines `prepend_view_path` with their views:
+  # https://github.com/rails/rails/blob/9f141a423d551f7f421f54d1372e65ef6ed1f0be/railties/lib/rails/engine.rb#L606
+  #
+  # If users put devise after bullet_train in their Gemfile, Bundler requires the gems in that order,
+  # and devise's `prepend_view_path` would be called last, thus being prepended ahead of BulletTrain when Rails looks up views.
+  #
+  # Note: if this breaks down in the future, we may want to look into config.railties_order.
+  require "devise"
+rescue LoadError
+  # Devise isn't in the Gemfile, and we don't have any other load order dependencies.
+end
+
 module BulletTrain
   class Engine < ::Rails::Engine
   end


### PR DESCRIPTION
…onkey patches

The added comment elaborates a bit on the previous context as well. But the general idea is to reframe this as a, potentially, common Engine loading order issue and not a Devise one-off.

With this patch we still get the same behavior:

```
>> ActionController::Base.view_paths.map(&:path)
=>
["/Users/kasperhansen/code/bullet-train-co/bullet_train-core/bullet_train/app/views",
 "/Users/kasperhansen/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/devise-4.8.1/app/views"]
```

Versus without any patch, Devise is before BulletTrain:

```
>> ActionController::Base.view_paths.map(&:path)
=>
["/Users/kasperhansen/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/devise-4.8.1/app/views",
 "/Users/kasperhansen/code/bullet-train-co/bullet_train-core/bullet_train/app/views"]
```

- [ ] Merge https://github.com/bullet-train-co/bullet_train/pull/575 after shipping a new release.

<details>
  <summary>Alternative future patch if Rails Engines loading order needs general tweaking</summary>

I've also explored a more general purpose patch to deal with engine loading order in general, but I don't know if it's viable or valuable yet.

```ruby
class BulletTrain::Engine < ::Rails::Engine
  # Lets us move our initialization to after a dependent engine/railtie, to remove the Gemfile ordering having an impact.
  initialize_after :devise # Could also be `ensure_initialized`?
end

module RailtieInitializationOrdering
  ::Rails::Railtie.extend self # Engine inherits from Railtie

  def initialize_after?(railtie)
    @initialize_afters&.include? railtie.module_parent_name
  end

  def initialize_after(*railties)
    (@initialize_afters ||= []).concat railties.map { _1.to_s.classify }
  end
end

module OrderedRailtiesWithInitializationOrdering
  ::Rails::Application.prepend self

  def ordered_railties
    railties = super
    TSort.tsort railties.to_enum,
      # We're reusing similar logic that Rails' initializeres work with, but this select probably doesn't work yet.
      ->(railtie, &block) { railties.select { _1.initialize_after? railtie }.each(&block) }
  end
end
```

</details>