### PR TITLE
Ensure custom namespace routes are scaffolded properly

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -1490,7 +1490,7 @@ class Scaffolding::Transformer
           collection_actions = [:index, :new, :create]
 
           # 🚅 Don't remove this block, it will break Super Scaffolding.
-          begin do
+          begin
             namespace :#{routes_namespace} do
               shallow do
                 resources :teams do
@@ -1505,9 +1505,33 @@ class Scaffolding::Transformer
 
       begin
         routes_manipulator.apply([routes_namespace])
-        Scaffolding::FileManipulator.write("config/routes.rb", routes_manipulator.lines)
+        Scaffolding::FileManipulator.write(routes_path, routes_manipulator.lines)
       rescue => _
         add_additional_step :red, "We weren't able to automatically add your `#{routes_namespace}` routes for you. In theory this should be very rare, so if you could reach out on Slack, you could probably provide context that will help us fix whatever the problem was. In the meantime, to add the routes manually, we've got a guide at https://blog.bullettrain.co/nested-namespaced-rails-routing-examples/ ."
+      end
+
+      # If we're using a custom namespace, we have to make sure the newly
+      # scaffolded routes are drawn in the `config/routes.rb` and API routes files.
+      if cli_options["namespace"]
+        draw_line = "draw \"#{routes_namespace}\""
+
+        [
+          "config/routes.rb",
+          "config/routes/api/#{BulletTrain::Api.current_version}.rb"
+        ].each do |routes_file|
+          original_lines = File.readlines(routes_file)
+
+          # Define which line we want to place the draw line under in the original routes files.
+          insert_line = if routes_file.match?("api")
+            draw_line = "  #{draw_line}" # Add necessary indentation.
+            "namespace :v1 do"
+          else
+            "draw \"sidekiq\""
+          end
+
+          new_lines = Scaffolding::BlockManipulator.insert(draw_line, lines: original_lines, within: insert_line)
+          Scaffolding::FileManipulator.write(routes_file, new_lines)
+        end
       end
 
       unless cli_options["skip-api"]


### PR DESCRIPTION
Closes https://github.com/bullet-train-co/bullet_train/issues/428

Previously https://github.com/bullet-train-co/bullet_train-super_scaffolding/pull/80

## Details

I wanted to use `RoutesFileManipulator#apply` to add the routes, but since we're using `draw`, I don't think we'll be able to scaffold the routes properly with it because `apply` depends on parent blocks. We've already written the proper routes within the new custom namespace file, so I just added the `draw` lines to each original routes file.

## Example
```
> rails g model Job team:references title:string
> bin/super-scaffold crud Job Team title:text_field --namespace=client
```

## `config/routes.rb`
```ruby
Rails.application.routes.draw do
  # See `config/routes/*.rb` to customize these configurations.
  draw "concerns"
  draw "devise"
  draw "sidekiq"
  draw "client"

  ...
end
```

### `config/routes/api/v1.rb`
```ruby
# See `config/routes.rb` for details.
collection_actions = [:index, :new, :create] # standard:disable Lint/UselessAssignment
extending = {only: []}

shallow do
  namespace :v1 do
    draw "client"

    ...
  end
end
```

## Example `rails routes --expanded` output
```
Prefix            | 
Verb              | POST
URI               | /client/teams/:team_id/jobs(.:format)
Controller#Action | client/jobs#create
```

```
Prefix            | 
Verb              | POST
URI               | /api/v1/client/teams/:team_id/jobs(.:format)
Controller#Action | api/v1/client/jobs#create
```