### PR TITLE
Add `super-scaffold` command

### DIFF
--- a/bullet_train-super_scaffolding/bullet_train-super_scaffolding.gemspec
+++ b/bullet_train-super_scaffolding/bullet_train-super_scaffolding.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     Dir["{app,config,db,exe,lib,docs}/**/*", "MIT-LICENSE", "Rakefile", "README.md", ".bt-link"]
-    spec.bindir = "exe"
-    spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   end
+  spec.bindir = "exe"
+  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
 
   spec.add_development_dependency "standard"
 
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
 
   # For Super Scaffolding: "select *a* team member" vs. "select *an* option".
   spec.add_dependency "indefinite_article"
-  spec.add_dependecy "colorize"
+  spec.add_dependency "colorize"
 end

--- a/bullet_train-super_scaffolding/bullet_train-super_scaffolding.gemspec
+++ b/bullet_train-super_scaffolding/bullet_train-super_scaffolding.gemspec
@@ -19,7 +19,9 @@ Gem::Specification.new do |spec|
   # spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    Dir["{app,config,db,lib,docs}/**/*", "MIT-LICENSE", "Rakefile", "README.md", ".bt-link"]
+    Dir["{app,config,db,exe,lib,docs}/**/*", "MIT-LICENSE", "Rakefile", "README.md", ".bt-link"]
+    spec.bindir = "exe"
+    spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   end
 
   spec.add_development_dependency "standard"
@@ -29,4 +31,5 @@ Gem::Specification.new do |spec|
 
   # For Super Scaffolding: "select *a* team member" vs. "select *an* option".
   spec.add_dependency "indefinite_article"
+  spec.add_dependecy "colorize"
 end

--- a/bullet_train-super_scaffolding/config/routes.rb
+++ b/bullet_train-super_scaffolding/config/routes.rb
@@ -1,4 +1,4 @@
-require "scaffolding/utiles"
+require "scaffolding/utils"
 
 Rails.application.routes.draw do
   extend Scaffolding::Utils

--- a/bullet_train-super_scaffolding/config/routes.rb
+++ b/bullet_train-super_scaffolding/config/routes.rb
@@ -1,4 +1,8 @@
+require "scaffolding/utiles"
+
 Rails.application.routes.draw do
+  extend Scaffolding::Utils
+
   # See `config/routes.rb` for details.
   collection_actions = [:index, :new, :create]
   extending = {only: []}

--- a/bullet_train-super_scaffolding/exe/super-scaffold
+++ b/bullet_train-super_scaffolding/exe/super-scaffold
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+require "bullet_train/super_scaffolding"
+BulletTrain::SuperScaffolding::Runner.new.run

--- a/bullet_train-super_scaffolding/exe/super-scaffold
+++ b/bullet_train-super_scaffolding/exe/super-scaffold
@@ -1,3 +1,5 @@
 #!/usr/bin/env ruby
+require "rails/engine"
 require "bullet_train/super_scaffolding"
+require "bullet_train/api"
 BulletTrain::SuperScaffolding::Runner.new.run

--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding.rb
@@ -8,10 +8,12 @@ require "bullet_train/super_scaffolding/scaffolders/join_model_scaffolder"
 require "bullet_train/super_scaffolding/scaffolders/oauth_provider_scaffolder"
 
 require "indefinite_article"
+require "colorize"
+require "fileutils"
 
 module BulletTrain
   module SuperScaffolding
-    mattr_accessor :template_paths, default: []
+    mattr_accessor :template_paths, default: [File.expand_path("../..", __dir__), Dir.pwd]
     mattr_accessor :scaffolders, default: {
       "crud" => "BulletTrain::SuperScaffolding::Scaffolders::CrudScaffolder",
       "crud-field" => "BulletTrain::SuperScaffolding::Scaffolders::CrudFieldScaffolder",

--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/engine.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/engine.rb
@@ -1,6 +1,7 @@
 require "active_support"
 require "rails/engine"
 require "scaffolding"
+require "jbuilder"
 
 module BulletTrain
   module SuperScaffolding

--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/engine.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/engine.rb
@@ -1,3 +1,7 @@
+require "active_support"
+require "rails/engine"
+require "scaffolding"
+
 module BulletTrain
   module SuperScaffolding
     class Engine < ::Rails::Engine
@@ -5,9 +9,6 @@ module BulletTrain
         # Templates from the application itself should always be highest priority.
         # This allows application developers to locally overload any template from any package.
         BulletTrain::SuperScaffolding.template_paths << Rails.root.to_s
-
-        # Register the base path of this package with the Super Scaffolding engine.
-        BulletTrain::SuperScaffolding.template_paths << File.expand_path("../../../..", __FILE__)
       end
 
       initializer "bullet_train.super_scaffolding.register" do |app|

--- a/bullet_train-super_scaffolding/lib/scaffolding.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding.rb
@@ -26,3 +26,7 @@ module Scaffolding
     ].include?(type.gsub(/{.*}/, "")) # Pop off curly brackets such as `super_select{class_name=Membership}`
   end
 end
+
+require_relative "scaffolding/transformer"
+require_relative "scaffolding/class_names_transformer"
+require_relative "scaffolding/routes_file_manipulator"

--- a/bullet_train-super_scaffolding/lib/scaffolding/utils.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/utils.rb
@@ -1,0 +1,8 @@
+module Scaffolding
+  module Utils
+    # TODO: This should probably go in `bullet_train-core/bullet_train/lib/bullet_train.rb`
+    def scaffolding_things_disabled?
+      ENV["HIDE_THINGS"].present? || ENV["HIDE_EXAMPLES"].present?
+    end
+  end
+end


### PR DESCRIPTION
Originally here: https://github.com/bullet-train-co/bullet_train-super_scaffolding/pull/6
and continued here: https://github.com/bullet-train-co/bullet_train-super_scaffolding/pull/41

I decided to open a new PR since we migrated to `bullet_train-core`.

## Command example
```
> rails g model Foo team:references title:string
> bundle exec super-scaffold crud Foo Team title:text_field
```

## Details
All of the code is the same, except I found I had to require a couple of libraries to make things work properly:
```ruby
# In bullet_train-super_scaffolding/exe/super-scaffold
require "rails/engine"
require "bullet_train/api"

# In bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/engine.rb
require "jbuilder"
```

## Credit
I wasn't able to pull over @indirect's commits, but if we want to rebase it off of those then I can try to open with another PR.