### PR TITLE
Update the Ruby Standard gem

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -30,3 +30,5 @@ ignore:
     - Lint/UselessAssignment
   - '*/app/helpers/theme_helper.rb':
     - Style/GlobalVars
+  - '*/app/models/concerns/webhooks/outgoing/uri_filtering.rb':
+    - Lint/ShadowedException

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
     rainbow (3.1.1)
     regexp_parser (2.6.1)
     rexml (3.2.5)
-    rubocop (1.39.0)
+    rubocop (1.40.0)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.1.2.1)
@@ -26,14 +26,15 @@ GEM
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.11.0)
-    standard (1.19.1)
+    standard (1.20.0)
       language_server-protocol (~> 3.17.0.2)
-      rubocop (= 1.39.0)
+      rubocop (= 1.40.0)
       rubocop-performance (= 1.15.1)
     unicode-display_width (2.3.0)
 
 PLATFORMS
   arm64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   standard

--- a/bullet_train-fields/app/helpers/fields_helper.rb
+++ b/bullet_train-fields/app/helpers/fields_helper.rb
@@ -1,6 +1,6 @@
 module FieldsHelper
   def current_fields_form
-    @_fields_helper_forms ? @_fields_helper_forms.last : nil
+    @_fields_helper_forms&.last
   end
 
   def with_field_settings(options)

--- a/bullet_train/app/helpers/attributes_helper.rb
+++ b/bullet_train/app/helpers/attributes_helper.rb
@@ -1,10 +1,10 @@
 module AttributesHelper
   def current_attributes_object
-    @_attributes_helper_objects ? @_attributes_helper_objects.last : nil
+    @_attributes_helper_objects&.last
   end
 
   def current_attributes_strategy
-    @_attributes_helper_strategies ? @_attributes_helper_strategies.last : nil
+    @_attributes_helper_strategies&.last
   end
 
   def with_attribute_settings(options)


### PR DESCRIPTION
The Standard gem was previously v1.19.1 and didn't pick up on some Standard Ruby failures.
I updated the gem to v1.20.0 and made the fixes.

## `Lint/ShadowedException`
We had this line in `bullet_train-outgoing_webhooks/app/models/concerns/webhooks/outgoing/uri_filtering.rb`:
```ruby
rescue IPAddr::InvalidAddressError, ArgumentError # standard:disable Lint/ShadowedException
```

Since the comment to disable this check was there, I decided to add this to `.standard.yml`. I added it under the set of files under the TODO in `.standard.yml` just in case we need to look over it again and adjust this line accordingly.

## Gemfile.lock has `x86_64-linux`
I remember this being unfavorable way back before the Great Unbundling, so I just wanted to bring it up in case we wanted to remove this or handle it in another way.