### PR TITLE
Fix Billing Usage Limits Integration

### DIFF
--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/limits/_form.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/limits/_form.html.erb
@@ -1,1 +1,14 @@
-<%= yield %>
+<% model ||= form.object %>
+<% count ||= 1 %>
+<% color ||= "red" %>
+<% cancel_path ||= nil %>
+
+<% if model.persisted? || current_limits.can?(:create, model.class, count: count) %>
+  <%= yield %>
+<% else %>
+  <%= render "shared/limits/error", action: :create, model: model.class, count: count, color: color, cancel_path: cancel_path %>
+
+  <fieldset class="form-wrapper pt-2" disabled>
+    <%= yield %>
+  </fieldset>
+<% end %>

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/limits/_index.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/limits/_index.html.erb
@@ -1,0 +1,8 @@
+<% model ||= @records.model %>
+<% color ||= "red" %>
+
+<% if current_limits.exhausted?(model) %>
+  <div class="pt-3">
+    <%= render "shared/limits/error", model: model, color: color, count: 0 %>
+  </div>
+<% end %>

--- a/bullet_train/app/models/billing/mock_limiter.rb
+++ b/bullet_train/app/models/billing/mock_limiter.rb
@@ -9,4 +9,8 @@ class Billing::MockLimiter
   def can?(action, model)
     true
   end
+
+  def exhausted?(model)
+    false
+  end
 end

--- a/bullet_train/app/models/billing/mock_limiter.rb
+++ b/bullet_train/app/models/billing/mock_limiter.rb
@@ -6,7 +6,7 @@ class Billing::MockLimiter
     []
   end
 
-  def can?(action, model)
+  def can?(action, model, count: 1)
     true
   end
 


### PR DESCRIPTION
This PR fixes an issue where adding the [bullet_train-billing-usage gem](https://github.com/bullet-train-pro/bullet_train-billing-usage) and following all of the instructions did not render the broken limits for products.

This allowed a user to add a resource to a hard-enforced product limit through the interface.

The issue is that BT is not rendering the correct partials from the gem and just using the one found in [bullet_train-themes-tailwind_css](https://github.com/bullet-train-co/bullet_train-core/tree/main/bullet_train-themes-tailwind_css). I am unsure yet why BT is not rendering the partial from the billing-usage gem but it may be because it is part of the BT pro gem.

In order to fix this for now, the views for the index and the form from the billing-usage gem were copied to the limits view in the tailwind_css gem. This will display the error in the billing usage gem if the current limits are broken. This will never happen in a project that is not using the billing-usage gem and it will instead use the `Billing::MockLimiter` which was updated to match the duck typing of the `Billing::Usage::Limiter`. This is a temporary update as there are plans to merge the billing-usage gem.
