### PR TITLE
Watch JS serially in `bin/hack`

### DIFF
--- a/bullet_train/lib/tasks/bullet_train_tasks.rake
+++ b/bullet_train/lib/tasks/bullet_train_tasks.rake
@@ -211,7 +211,7 @@ namespace :bullet_train do
     # Revert to using the original bullet_train npm package after the developer enters `Ctrl + C`.
     puts "Reverting to original npm package...".blue
     puts "If you cancel out of this process early, just run `bin/hack --clean-js bullet_train` to revert to your original npm package.".blue
-    set_npm_packages("--clean-js", bt_package)
+    set_npm_package("--clean-js", bt_package)
 
     puts ""
     puts "OK, here's a list of things this script still doesn't do you for you:".yellow

--- a/bullet_train/lib/tasks/bullet_train_tasks.rake
+++ b/bullet_train/lib/tasks/bullet_train_tasks.rake
@@ -269,7 +269,7 @@ namespace :bullet_train do
         # Provide a help message after the developer kills the process with `Ctrl + C`.
         puts "Run `bin/hack --clean-js #{name}` to revert to using the original npm package in your application.".blue
       elsif flag == "--clean-js"
-        puts "Going back to using original `#{name}` in application.".blue
+        puts "Going back to using original `#{name}` npm package in application.".blue
         puts ""
 
         system "yarn yalc remove #{details[:npm]}"

--- a/bullet_train/lib/tasks/bullet_train_tasks.rake
+++ b/bullet_train/lib/tasks/bullet_train_tasks.rake
@@ -120,12 +120,12 @@ namespace :bullet_train do
             stream "bundle install"
           when "--watch-js", "--clean-js"
             package_name = process[:values].pop
-            framework_package = framework_packages.select {|k, v| k.to_s == package_name }
+            framework_package = framework_packages.select { |k, v| k.to_s == package_name }
             if framework_package.empty?
               puts "Sorry, we couldn't find the package you're looking for.".red
               puts ""
 
-              npm_packages = framework_packages.select {|name, details| details[:npm].present?}
+              npm_packages = framework_packages.select { |name, details| details[:npm].present? }
               puts "Please enter one of the following package names when running `bin/hack --watch-js` or `bin/hack --clean-js`:"
               npm_packages.each_with_index do |package, idx|
                 puts "#{idx + 1}. #{package.first}"

--- a/bullet_train/lib/tasks/bullet_train_tasks.rake
+++ b/bullet_train/lib/tasks/bullet_train_tasks.rake
@@ -208,11 +208,6 @@ namespace :bullet_train do
     bt_package = framework_packages.select { |k, v| k == :bullet_train }
     set_npm_package("--watch-js", bt_package)
 
-    # Revert to using the original bullet_train npm package after the developer enters `Ctrl + C`.
-    puts "Reverting to original npm package...".blue
-    puts "If you cancel out of this process early, just run `bin/hack --clean-js bullet_train` to revert to your original npm package.".blue
-    set_npm_package("--clean-js", bt_package)
-
     puts ""
     puts "OK, here's a list of things this script still doesn't do you for you:".yellow
     puts "1. It doesn't clean up the repository that was cloned into `local`.".yellow


### PR DESCRIPTION
Closes #39.

## Details
JavaScript changes weren't being reflected in the browser when watching multiple npm packages in parallel, so I simplified the script and made it so we can only watch one npm package at a time.

The downside is that developers can only adjust the JavaScript for the package that they're watching. This is the same as what we were doing before we migrated to `bullet_train-core` when using `bin/develop`, so I'd rather fall back to that interface if it's what developers are already expecting.

We also have the commit history if we ever want to try running the processes in parallel again, but as I mentioned in the issue, I don't think it's worth the effort right now (maybe if we get developers saying they're having a hard time trying to develop in JS files across packages).