### PR TITLE
Temporarily disable Turbo in new session form

### DIFF
--- a/bullet_train/app/views/devise/sessions/new.html.erb
+++ b/bullet_train/app/views/devise/sessions/new.html.erb
@@ -2,7 +2,8 @@
   <% p.content_for :title, t('devise.headers.sign_in') %>
   <% p.content_for :body do %>
     <% within_fields_namespace(:self) do %>
-      <%= form_for resource, as: resource_name, url: two_factor_authentication_enabled? ? users_pre_otp_path : session_path(resource_name), remote: two_factor_authentication_enabled?, html: {class: 'form'}, authenticity_token: true, data: {turbo: !user_return_to_is_oauth} do |form| %>
+      <%# TODO: Turbo is set to `false` for now, but we may want to only bypass Turbo for JavaScript-based requests in the future. %>
+      <%= form_for resource, as: resource_name, url: two_factor_authentication_enabled? ? users_pre_otp_path : session_path(resource_name), remote: two_factor_authentication_enabled?, html: {class: 'form'}, authenticity_token: true, data: {turbo: false} do |form| %>
         <% with_field_settings form: form do %>
           <%= render 'account/shared/notices', form: form %>
           <%= render 'account/shared/forms/errors', form: form %>


### PR DESCRIPTION
This pull request that we merged recently sets Turbo to `false` for all oauth-related requests: https://github.com/bullet-train-co/bullet_train-base/pull/102

However, this was causing issues when trying to login with two-factor authentication.

## Details
When trying to login with 2FA, we get the following error when entering an email and clicking "Next":

```
Completed 406 Not Acceptable in 132305ms (ActiveRecord: 13.5ms | Allocations: 103247)


  
ActionController::UnknownFormat (ActionController::UnknownFormat):
  
actionpack (7.0.4) lib/action_controller/metal/mime_responds.rb:217:in `respond_to'
local/bullet_train-core/bullet_train/app/controllers/concerns/sessions/controller_base.rb:9:in `pre_otp'
```

Afterwards, we get redirected back to the same page we were on.

After prying into `bullet_train/app/controllers/concerns/sessions/controller_base.rb`, I found the following:
```
[1] pry(#<SessionsController>)> request.format
=> #<Mime::Type:0x00007feef8f865a8 @hash=-2803793485411078298, @string="text/vnd.turbo-stream.html", @symbol=:turbo_stream, @synonyms=[]>
```

After making the fix in this pull request, we now get the following Mime type:
```
[1] pry(#<SessionsController>)> request.format
=> #<Mime::Type:0x00007f896169f2e8
 @hash=-527293942972601367,
 @string="text/javascript",
 @symbol=:js,
 @synonyms=["application/javascript", "application/x-javascript"]>
```

## Issue with JavaScript requests

I think the common denominator here is JavaScript-based requests.
As the title of the issue mentioned above says, <b>JavaScript</b> based navigation breaks. I don't think the best solution is to simply disable Turbo, and although that's what I've done here, we might want to write a method that bypasses JavaScript-based requests as opposed to only oauth requests in the future, so I left a TODO here in case we want to re-visit it soon.