### PR TITLE
Fix various dark mode styles

### DIFF
--- a/bullet_train-api/app/views/account/platform/connections/new.html.erb
+++ b/bullet_train-api/app/views/account/platform/connections/new.html.erb
@@ -3,7 +3,7 @@
   <% p.content_for :body do %>
     <ul class="space-y" data-turbo="false">
       <% @teams.each do |team| %>
-        <li class="bg-white border overflow-hidden sm:rounded-md dark:bg-sealBlue-400">
+        <li class="bg-white border overflow-hidden sm:rounded-md dark:bg-darkPrimary-800">
           <% body = capture do %>
             <div class="px-4 py-4 flex items-center sm:pl-8 sm:pr-6">
               <div class="min-w-0 flex-1 sm:flex sm:items-center sm:justify-between">
@@ -27,11 +27,11 @@
           <% end %>
 
           <% if can? :connect, team %>
-            <%= link_to request.url + "&team_id=#{team.id}", class: "group block hover:bg-gray-50 dark:hover:bg-sealBlue-400 dark:text-sealBlue-800" do %>
+            <%= link_to request.url + "&team_id=#{team.id}", class: "group block hover:bg-gray-50 dark:text-darkPrimary-800 dark:hover:bg-black dark:hover:bg-opacity-10" do %>
               <%= body %>
             <% end %>
           <% else %>
-            <div class="block dark:text-sealBlue-800">
+            <div class="block dark:text-darkPrimary-800">
               <%= body %>
             </div>
           <% end %>

--- a/bullet_train-themes-light/app/assets/stylesheets/light/tailwind/dark-mode.css
+++ b/bullet_train-themes-light/app/assets/stylesheets/light/tailwind/dark-mode.css
@@ -227,5 +227,10 @@
         }
       }
     }
+
+    /* Pagy */
+    .pagy-nav > .page > a:hover {
+      @apply bg-opacity-10;
+    }
   }
 }

--- a/bullet_train-themes-light/app/views/themes/light/menu/_account.html.erb
+++ b/bullet_train-themes-light/app/views/themes/light/menu/_account.html.erb
@@ -7,7 +7,7 @@
     <div class="absolute top-0 left-0 right-0 z-50">
       <%= render "account/shared/menu/user" %>
     </div>
-    <div class="absolute transition duration-150 scale-95 group-hover:scale-100 translate-y-1 group-hover:translate-y-0 bg-primary-700 -top-0 left-0 right-0 -m-2 p-2 rounded-lg z-40 shadow">
+    <div class="absolute transition duration-150 scale-95 group-hover:scale-100 translate-y-1 group-hover:translate-y-0 bg-primary-700 dark:bg-darkPrimary-700 -top-0 left-0 right-0 -m-2 p-2 rounded-lg z-40 shadow">
       <div class="invisible">
         <%= render "account/shared/menu/user", expand: expand %>
       </div>

--- a/bullet_train-themes-light/app/views/themes/light/menu/_subsection.html.erb
+++ b/bullet_train-themes-light/app/views/themes/light/menu/_subsection.html.erb
@@ -22,7 +22,7 @@
       <div class="invisible absolute group-hover:visible transition duration-200 scale-90 group-hover:scale-100 z-40
         <%= @menu_orientation == :top ? "group-hover:translate-x-3 top-100 left-0 -ml-10 -mt-2 pt-4" : "group-hover:translate-x-3 top-0 left-full -mt-3 -ml-5 pl-4" %>
       ">
-        <div class="bg-primary-700 rounded-lg py-3 px-4 w-56 shadow">
+        <div class="bg-primary-700 dark:bg-darkPrimary-700 rounded-lg py-3 px-4 w-56 shadow">
           <% @last_menu_orientation = @menu_orientation %>
           <% @menu_orientation = :side %>
           <%= yield %>

--- a/bullet_train/app/views/account/teams/_team.html.erb
+++ b/bullet_train/app/views/account/teams/_team.html.erb
@@ -1,5 +1,5 @@
-<li class="bg-white shadow overflow-hidden sm:rounded-md dark:bg-sealBlue-400">
-  <%= link_to [:account, team], class: "group block hover:bg-gray-50 dark:hover:bg-sealBlue-400 dark:text-sealBlue-800" do %>
+<li class="bg-white shadow overflow-hidden sm:rounded-md dark:bg-darkPrimary-700">
+  <%= link_to [:account, team], class: "group block hover:bg-gray-50 dark:hover:bg-black dark:hover:bg-opacity-10" do %>
     <div class="px-4 py-4 flex items-center sm:pl-8 sm:pr-6">
       <div class="min-w-0 flex-1 sm:flex sm:items-center sm:justify-between">
         <div>


### PR DESCRIPTION
Closes https://github.com/bullet-train-co/bullet_train/issues/600

I also noticed the fly out menus only had the primary blue style for light mode, so I added `darkPrimary` for those too.

### Changes
1. Hover background of Team index records.
2. Hover background of Pagy navigation buttons.
3. Background of new fly out menus.

# Before

https://user-images.githubusercontent.com/10546292/211246574-1c31cb8d-1157-49f0-96a2-7be871c0cb17.mov

https://user-images.githubusercontent.com/10546292/211246680-e253f4f0-322f-4a19-b40f-74326345e3cf.mov

# After

https://user-images.githubusercontent.com/10546292/211246788-eb001d66-741a-4317-b619-eed1783ad1a1.mov

https://user-images.githubusercontent.com/10546292/211246801-02c143e9-f95c-4e91-9fe3-99789dd422a0.mov

# Styling decisions
I decided to style things this way because I saw that the active buttons (like the `Dashboard` button in the menu in this screenshot) use `dark:bg-black dark:bg-opacity-10`.

<img width="958" alt="Active Button Style" src="https://user-images.githubusercontent.com/10546292/211246964-fa455007-0f02-44a6-84c8-76101a7b45ce.png">
