### PR TITLE
Refactor `platform_agent_access_tokens` db query

### DIFF
--- a/bin/checkout-and-link-starter-repo
+++ b/bin/checkout-and-link-starter-repo
@@ -7,7 +7,7 @@ STARTER_REPO_BRANCH="main"
 CI_BRANCH=$CIRCLE_BRANCH
 if [[ -v CI_BRANCH ]]
 then
-  BRANCH_RESPONSE=$(curl --verbose -H "Accept: application.vnd.github+json" https://api.github.com/repos/bullet-train-co/bullet_train-core/branches/$CI_BRANCH)
+  BRANCH_RESPONSE=$(curl --verbose -H "Accept: application.vnd.github+json" https://api.github.com/repos/bullet-train-co/bullet_train/branches/$CI_BRANCH)
 
   echo "Branch response ===================="
   echo $BRANCH_RESPONSE

--- a/bullet_train/app/models/concerns/teams/base.rb
+++ b/bullet_train/app/models/concerns/teams/base.rb
@@ -35,7 +35,7 @@ module Teams::Base
   end
 
   def platform_agent_access_tokens
-    Platform::AccessToken.joins(:application).where(resource_owner_id: memberships.platform_agents)
+    Platform::AccessToken.joins(:application).where(resource_owner_id: users.where.not(platform_agent_of_id: nil))
   end
 
   def admins

--- a/bullet_train/app/models/concerns/teams/base.rb
+++ b/bullet_train/app/models/concerns/teams/base.rb
@@ -35,7 +35,7 @@ module Teams::Base
   end
 
   def platform_agent_access_tokens
-    Platform::AccessToken.joins(:application).where(resource_owner_id: users.where.not(platform_agent_of_id: nil))
+    Platform::AccessToken.joins(:application).where(resource_owner_id: users.where.not(platform_agent_of_id: nil), application: {team: nil})
   end
 
   def admins

--- a/bullet_train/app/models/concerns/teams/base.rb
+++ b/bullet_train/app/models/concerns/teams/base.rb
@@ -35,9 +35,7 @@ module Teams::Base
   end
 
   def platform_agent_access_tokens
-    # TODO This could be written better.
-    platform_agent_user_ids = memberships.platform_agents.map(&:user_id).compact
-    Platform::AccessToken.joins(:application).where(resource_owner_id: platform_agent_user_ids, application: {team: nil})
+    Platform::AccessToken.joins(:application).where(resource_owner_id: memberships.platform_agents)
   end
 
   def admins


### PR DESCRIPTION
Addresses the TODO in `bullet_train/app/models/concerns/teams/base.rb`.

## Details

Since we're ultimately looking for `User` ids, I thought it would be quicker/clearer to make a query directly to the `User` model. `User` has an attribute called `platform_agent_of_id`, so with this we can tell if the `User` is a dummy for the Application or an actual person:

```ruby
users.where.not(platform_agent_of_id: nil)
```

Since we have access to the `users` variable, we can be sure the users are scoped to the Team making the query.

## Logs
With the previous code:
```
Team Load (0.6ms)  SELECT "teams".* FROM "teams" ORDER BY "teams"."id" ASC LIMIT $1  [["LIMIT", 1]]
Membership Load (0.4ms)  SELECT "memberships".* FROM "memberships" WHERE "memberships"."team_id" = $1 AND "memberships"."platform_agent_of_id" IS NOT NULL  [["team_id", 1]]
Platform::AccessToken Load (1.4ms)  SELECT "oauth_access_tokens".* FROM "oauth_access_tokens" INNER JOIN "oauth_applications" "application" ON "application"."id" = "oauth_access_tokens"."application_id" WHERE "oauth_access_tokens"."resource_owner_id" IN ($1, $2) AND "application"."team_id" IS NULL  [["resource_owner_id", 2], ["resource_owner_id", 4]]
```

With the new code:
```
Team Load (0.8ms)  SELECT "teams".* FROM "teams" ORDER BY "teams"."id" ASC LIMIT $1  [["LIMIT", 1]]
Platform::AccessToken Load (1.6ms)  SELECT "oauth_access_tokens".* FROM "oauth_access_tokens" INNER JOIN "oauth_applications" "application" ON "application"."id" = "oauth_access_tokens"."application_id" WHERE "oauth_access_tokens"."resource_owner_id" IN (SELECT "users"."id" FROM "users" INNER JOIN "memberships" ON "users"."id" = "memberships"."user_id" WHERE "memberships"."team_id" = $1 AND "users"."platform_agent_of_id" IS NOT NULL) AND "application"."team_id" IS NULL  [["team_id", 1]]
```

## Application Team is `nil`
I can't say I'm 100% sure why `application: {team: nil}` is a part of the query. I think I'll have to look over the tests to be sure, but either way the `resource_owner_id` being a `User` that is connect to a Platform Agent makes sense to me.