### PR TITLE
Fix Profile Image Background Color

### DIFF
--- a/bullet_train/bullet_train.gemspec
+++ b/bullet_train/bullet_train.gemspec
@@ -41,6 +41,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bullet_train-themes"
   spec.add_dependency "bullet_train-routes"
   spec.add_dependency "devise"
+  spec.add_dependency "xxhash"
+
 
   # This has been broken since Rails 7.
   # spec.add_dependency "devise-two-factor"

--- a/bullet_train/lib/bullet_train.rb
+++ b/bullet_train/lib/bullet_train.rb
@@ -13,6 +13,7 @@ require "colorizer"
 require "bullet_train/core_ext/string_emoji_helper"
 
 require "devise"
+require "xxhash"
 # require "devise-two-factor"
 # require "rqrcode"
 require "cancancan"

--- a/bullet_train/lib/colorizer.rb
+++ b/bullet_train/lib/colorizer.rb
@@ -11,7 +11,7 @@ module Colorizer
   end
 
   def colorize_similarly(object, saturation, lightness)
-    rnd = ((object.hash * 7) % 100) * 0.01
+    rnd = ((XXhash.xxh64(object) * 7) % 100) * 0.01
     hsl_to_rgb(rnd, saturation, lightness)
   end
 


### PR DESCRIPTION
https://github.com/bullet-train-co/bullet_train/issues/577

We get different profile image colors when we are restarting the application as we were using the String Hash method to get the hash of the email which produces different results for different instances. 
![image](https://user-images.githubusercontent.com/23139057/211860861-c5ddc588-4e40-4954-886f-98190ce8395f.png)

As a solution, I used [xxhasg](https://github.com/nashby/xxhash) gem to get the hash of the email which is consistents 