### PR TITLE
Skip menu item scaffolding for non-top-level models

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -23,6 +23,16 @@ class Scaffolding::Transformer
     "Team"
   end
 
+  def top_level_model?
+    parent == "Team" || no_parent?
+  end
+
+  # We write an explicit method here so we know we
+  # aren't handling `parent` in this situation as `nil`.
+  def no_parent?
+    parent == "None"
+  end
+
   def update_action_models_abstract_class(targets_n)
   end
 
@@ -290,6 +300,9 @@ class Scaffolding::Transformer
 
     Dir.foreach(resolve_template_path(directory)) do |file|
       file = "#{directory}/#{file}"
+
+      next if file.match?("/_menu_item.html.erb") && !top_level_model?
+
       unless File.directory?(resolve_template_path(file))
         scaffold_file(file)
       end
@@ -305,6 +318,9 @@ class Scaffolding::Transformer
     if override_path
       Dir.foreach(override_path) do |file|
         file = "#{directory}_overrides/#{file}"
+
+        next if file.match?("/_menu_item.html.erb") && !top_level_model?
+
         unless File.directory?(resolve_template_path(file))
           scaffold_file(file, overrides: true)
         end
@@ -1523,7 +1539,7 @@ class Scaffolding::Transformer
 
     unless cli_options["skip-parent"]
 
-      if parent == "Team" || parent == "None"
+      if top_level_model?
         icon_name = nil
         if cli_options["sidebar"].present?
           icon_name = cli_options["sidebar"]


### PR DESCRIPTION
## Details
We currently Super Scaffold the [_menu_item.html.erb](https://github.com/bullet-train-co/bullet_train-core/blob/main/bullet_train-super_scaffolding/app/views/account/scaffolding/completely_concrete/tangible_things/_menu_item.html.erb) partial for models that aren't directly scoped off of a Team. For example:

```
# Imagine we have a parent model already called Foo.
> rails g model Bar foo:references title:string
> bin/super-scaffold crud Bar Foo,Team title:text_field
```

However, we tell the developers when Super Scaffolding directly off of `Team` (or nothing) that only these models are eligible for adding a menu item to their navigation bar:

https://github.com/bullet-train-co/bullet_train-core/blob/7cf007def6104e2f95a445e218f76148ce249db1/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb#L1532

Even if it's not used, I think Super Scaffolding `_menu_item.html.erb` for deeply nested models (in this case `Bar`) will be confusing because developers might assume that they can use the partial without any issues if it exists in the directory. For that reason I have skipped scaffolding the file, and all the tests are passing.

## `parent == "None"`
Since this already existed in the code, I added a method for readability that uses `"None"`. However, I'm not entirely sure where this is coming from, or if it's an option developers type when running a command. I haven't seen anything in the documentation about it, so I can write what it's used for in this PR if necessary.