### PR TITLE
Update sand theme colors

### DIFF
--- a/bullet_train-themes-light/app/assets/stylesheets/light/tailwind/colors.css
+++ b/bullet_train-themes-light/app/assets/stylesheets/light/tailwind/colors.css
@@ -275,7 +275,7 @@
   --light-gradient-from: #f0ddca;
   --light-gradient-to: #83674c;
   --dark-gradient-from: #ceb8a0;
-  --dark-gradient-to : #857a70;
+  --dark-gradient-to: #857a70;
 }
 
 .theme-secondary-blue {

--- a/bullet_train-themes-light/app/assets/stylesheets/light/tailwind/colors.css
+++ b/bullet_train-themes-light/app/assets/stylesheets/light/tailwind/colors.css
@@ -47,15 +47,21 @@
   --theme-gray-800: #2b344e;
   --theme-gray-900: #232942;
 
-  /* TOOD Kind of yuck? */
-  --theme-sand-300: #e8d9cc;
-  --theme-sand-400: #c7ac9f;
-  --theme-sand-500: #947E77;
-  --theme-sand-600: #6F564D;
-  --theme-sand-700: #583c32;
-  --theme-sand-800: #4e342b;
-  --theme-sand-900: #422923;
-  
+  --theme-sand-300: #eed7b5;
+  --theme-sand-400: #e7cea7;
+  --theme-sand-500: #ad8e71;
+  --theme-sand-600: #9b7d61;
+  --theme-sand-700: #927559;
+  --theme-sand-800: #7e644b;
+  --theme-sand-900: #705841;
+
+  --theme-dark-sand-300: #aa9485;
+  --theme-dark-sand-400: #a08b7b;
+  --theme-dark-sand-500: #928b86;
+  --theme-dark-sand-600: #867b73;
+  --theme-dark-sand-700: #817061;
+  --theme-dark-sand-800: #725e4d;
+  --theme-dark-sand-900: #685545;
 }
 
 :root, .theme-blue {
@@ -229,6 +235,47 @@
   --light-gradient-to: #F165A8;
   --dark-gradient-from: #6728ab;
   --dark-gradient-to: #633d7d;
+}
+
+.theme-sand {
+  --primary-300: var(--theme-sand-300);
+  --primary-400: var(--theme-sand-400);
+  --primary-500: var(--theme-sand-500);
+  --primary-600: var(--theme-sand-600);
+  --primary-700: var(--theme-sand-700);
+  --primary-800: var(--theme-sand-800);
+  --primary-900: var(--theme-sand-900);
+
+  --secondary-300: var(--theme-sand-300);
+  --secondary-400: var(--theme-sand-400);
+  --secondary-500: var(--theme-sand-500);
+  --secondary-600: var(--theme-sand-600);
+  --secondary-700: var(--theme-sand-700);
+  --secondary-800: var(--theme-sand-800);
+  --secondary-900: var(--theme-sand-900);
+
+  --dark-primary-300: var(--theme-dark-sand-300);
+  --dark-primary-400: var(--theme-dark-sand-400);
+  --dark-primary-500: var(--theme-dark-sand-500);
+  --dark-primary-600: var(--theme-dark-sand-600);
+  --dark-primary-700: var(--theme-dark-sand-700);
+  --dark-primary-800: var(--theme-dark-sand-800);
+  --dark-primary-900: var(--theme-dark-sand-900);
+
+  --dark-secondary-300: var(--theme-dark-sand-300);
+  --dark-secondary-400: var(--theme-dark-sand-400);
+  --dark-secondary-500: var(--theme-dark-sand-500);
+  --dark-secondary-600: var(--theme-dark-sand-600);
+  --dark-secondary-700: var(--theme-dark-sand-700);
+  --dark-secondary-800: var(--theme-dark-sand-800);
+  --dark-secondary-900: var(--theme-dark-sand-900);
+
+  --dark-accent-201: #705841;
+
+  --light-gradient-from: #f0ddca;
+  --light-gradient-to: #83674c;
+  --dark-gradient-from: #ceb8a0;
+  --dark-gradient-to : #857a70;
 }
 
 .theme-secondary-blue {


### PR DESCRIPTION
Addresses the TODO in `bullet_train-themes-light/app/assets/stylesheets/light/tailwind/colors.css`.

## Details
I wanted to use a sand theme for a BT app that I want to work on, so I took some time to find colors I like for this theme.

I noticed some of the text for the dark theme isn't showing up as the customized primary color, but I haven't looked into how to change that yet.

Anyways, here are some videos and screenshots of what it looks like.

# Light
https://user-images.githubusercontent.com/10546292/212297551-534faa74-c16c-42b6-9340-21e8f646ed30.mov

<img width="1438" alt="Sand Theme Login" src="https://user-images.githubusercontent.com/10546292/212297611-3d6ac40a-acf4-4aff-8a5f-8a435aaab9a0.png">

# Dark
https://user-images.githubusercontent.com/10546292/212297710-38cf7054-2c47-40aa-b48a-46f3cccb3ce7.mov

<img width="1435" alt="Dark Sand Theme Login" src="https://user-images.githubusercontent.com/10546292/212297743-9c5b30d6-2a57-44ba-a470-9073db034ca8.png">
