### PR TITLE
Enable 2FA automatically when credentials are set

### DIFF
--- a/bullet_train/app/models/concerns/users/base.rb
+++ b/bullet_train/app/models/concerns/users/base.rb
@@ -3,7 +3,7 @@ module Users::Base
 
   included do
     if two_factor_authentication_enabled?
-      devise :two_factor_authenticatable, :two_factor_backupable, otp_secret_encryption_key: ENV["TWO_FACTOR_ENCRYPTION_KEY"]
+      devise :two_factor_authenticatable, :two_factor_backupable
     else
       devise :database_authenticatable
     end

--- a/bullet_train/lib/bullet_train.rb
+++ b/bullet_train/lib/bullet_train.rb
@@ -115,7 +115,7 @@ def cloudinary_enabled?
 end
 
 def two_factor_authentication_enabled?
-  ENV["TWO_FACTOR_ENCRYPTION_KEY"].present?
+  Rails.application.credentials.active_record_encryption.primary_key
 end
 
 # Don't redefine this if an application redefines it locally.

--- a/bullet_train/lib/bullet_train.rb
+++ b/bullet_train/lib/bullet_train.rb
@@ -115,7 +115,7 @@ def cloudinary_enabled?
 end
 
 def two_factor_authentication_enabled?
-  Rails.application.credentials.active_record_encryption.primary_key
+  Rails.application.credentials.active_record_encryption&.primary_key.present?
 end
 
 # Don't redefine this if an application redefines it locally.


### PR DESCRIPTION
Found by @eadz and also mentioned in https://github.com/bullet-train-co/bullet_train/pull/519#issuecomment-1340037608

## Backwards compatibility
I've decided to not consider backwards compatibility here because of [this comment](https://github.com/bullet-train-co/bullet_train/pull/519#issuecomment-1339992627), but we can use the following like @eadz suggested if we want to check for either the old environment variable or the Rails 7 credentials value:

```ruby
ENV['TWO_FACTOR_ENCRYPION_KEY'].present? || Rails.application.credentials.active_record_enc
ryption.present?
```

## Turbo issue
We still need to fix the turbo-related issue, but for now you can refer to #50 if you want to test out the logic manually in the browser.