### PR TITLE
Handle invitation for invited user signing up with omniauth

### DIFF
--- a/bullet_train-integrations/app/controllers/concerns/account/oauth/omniauth_callbacks/controller_base.rb
+++ b/bullet_train-integrations/app/controllers/concerns/account/oauth/omniauth_callbacks/controller_base.rb
@@ -149,4 +149,22 @@ module Account::Oauth::OmniauthCallbacks::ControllerBase
       redirect_to new_user_session_path, notice: t("omniauth.user.account_not_found", provider: t(auth.provider))
     end
   end
+
+  private
+
+  def handle_outstanding_invitation
+    # was this user registering to claim an invitation?
+    if session[:invitation_uuid].present?
+
+      # try to find the invitation, if it still exists.
+      invitation = Invitation.find_by_uuid(session[:invitation_uuid])
+
+      # if the invitation was found, claim it for this user.
+      invitation&.accept_for(current_user)
+
+      # remove the uuid from the session.
+      session.delete(:invitation_uuid)
+
+    end
+  end
 end


### PR DESCRIPTION
Closes #71.

## Details
Our OAuth sign up/sign in workflow was failing because the method `handle_outstanding_invitation` hadn't been migrated to `bullet_train-core`.

I also decided to add the method directly to this file as a private method instead of via a helper like before because this is the only place where the method appears.

I was able to invite a new user and sign up with Spotify, so this one should be good to go.