### PR TITLE
Fix docs navigation for the 'application-options' link

### DIFF
--- a/bullet_train/app/views/layouts/docs.html.erb
+++ b/bullet_train/app/views/layouts/docs.html.erb
@@ -147,7 +147,7 @@
                   <% end %>
                 <% end %>
 
-                <%= render 'account/shared/menu/item', url: 'docs/application-options.md', label: 'Application Options' do |p| %>
+                <%= render 'account/shared/menu/item', url: '/docs/application-options', label: 'Application Options' do |p| %>
                   <% p.content_for :icon do %>
                     <i class="fal fa-gear ti ti-settings"></i>
                   <% end %>


### PR DESCRIPTION
In the docs, the link to the application options doesn't work. This should fix it. 