### PR TITLE
Prevent developers from Super Scaffolding the same content twice

### DIFF
--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/crud_field_scaffolder.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/crud_field_scaffolder.rb
@@ -29,6 +29,7 @@ module BulletTrain
           check_required_options_for_attributes("crud-field", attributes, child)
 
           transformer = Scaffolding::Transformer.new(child, parents, @options)
+          transformer.check_if_has_been_scaffolded(options: {attributes: attributes})
           transformer.add_attributes_to_various_views(attributes, type: :crud_field)
 
           transformer.additional_steps.uniq.each_with_index do |additional_step, index|

--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb
@@ -48,8 +48,9 @@ module BulletTrain
           check_required_options_for_attributes("crud", attributes, child, parent)
 
           transformer = Scaffolding::Transformer.new(child, parents, @options)
-          transformer.scaffold_crud(attributes)
+          transformer.check_if_has_been_scaffolded
 
+          transformer.scaffold_crud(attributes)
           transformer.additional_steps.each_with_index do |additional_step, index|
             color, message = additional_step
             puts ""

--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/oauth_provider_scaffolder.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/oauth_provider_scaffolder.rb
@@ -52,6 +52,11 @@ module BulletTrain
             return
           end
 
+          # Since bin/super-scaffold oauth-provider creates this base module,
+          # we instantiante a transformer with this string as a child to check if it exists already or not.
+          blank_transformer = Scaffolding::Transformer.new(oauth_transform_string("Oauth::StripeAccounts::Base", options), "")
+          blank_transformer.check_if_has_been_scaffolded
+
           icon_name = nil
           if @options["icon"].present?
             icon_name = @options["icon"]

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -77,7 +77,7 @@ class Scaffolding::Transformer
       form_contents = File.open(child_model_form).readlines
       duplicate_fields = options[:attributes].select do |attribute|
         name, field_partial_type = attribute.split(":")
-        form_contents.find {|line| line.match?("<%= render 'shared/fields/#{field_partial_type}', method: :#{name} %>")}
+        form_contents.find { |line| line.match?("<%= render 'shared/fields/#{field_partial_type}', method: :#{name} %>") }
       end
       duplicate_fields.any?
     when "join-model" # TODO


### PR DESCRIPTION
## Details
Developers can technically run the same Super Scaffolding command multiple times, and this was causing duplicate lines to show up in specific files (https://github.com/bullet-train-co/bullet_train/issues/623).

As mentioned in https://github.com/bullet-train-co/bullet_train/issues/623, Rails prevents duplicate model generation, so I think we should have something similar in Bullet Train. However, Rails does this by checking if the constant already exists or not in a method called `class_collisions`:
https://github.com/rails/rails/blob/6e127924b690ead14e058225290c2a7f5b1e1335/railties/lib/rails/generators/base.rb#L278-L281.

We unfortunately can't use this since `bin/super-scaffold` depends on running `rails g model` beforehand and it also does different things depending on the scaffolding type (`crud`, `crud-field`, etc.), so I had to think through what ways make the most sense to check if a developer has Super Scaffolded some content already.

## Thoughts about what to check
Although I don't think this is the most conventional way to prevent developers from running the same command twice, I wrote what makes the most sense to me according to my current knowledge of the scaffolders. This included checking for certain files, the existence of certain modules, etc.

## join-model
Although I want to use `primary_parent` and `secondary_parent` to check for the presence of `has_many :foo, through: :bar` in each respective model, I'm still not entirely sure how to approach this one due to the `class_name` and how it's being defined in models. For example, we use `Project::AppliedTags` in the example from the docs, and because this changes to `:applied_tags` and defines `class_name: 'Project::AppliedTags'` earlier on in the model, I'd have to think through how check for this using the input from the command line. 
