### PR TITLE
Fix spacing in Super Scaffolded API test setup

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/block_manipulator.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/block_manipulator.rb
@@ -214,7 +214,7 @@ module Scaffolding
             # If we're shifting a block to the left, we want to safeguard
             # the String so it doesn't delete any excess characters.
             if direction == :left
-              amount.times { line = line.gsub(/^\s/, "") }
+              amount.times { line = line.gsub(/^ /, "") }
             elsif direction == :right
               line = "\s" * amount + line
             end

--- a/bullet_train-super_scaffolding/lib/scaffolding/file_manipulator.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/file_manipulator.rb
@@ -3,7 +3,7 @@ require "scaffolding/block_manipulator"
 # TODO: If we move this and the BlockManipulator into their own gems,
 # we can probably call these methods with something shorter without `Scaffolding::`.
 module Scaffolding::FileManipulator
-  def self.find(lines, needle, within = nil)
+  def self.find(lines, needle, within = 0)
     lines_within(lines, within).each_with_index do |line, line_number|
       return (within + (within ? 1 : 0) + line_number) if line.match?(needle)
     end

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -1398,10 +1398,17 @@ class Scaffolding::Transformer
     unless cli_options["skip-api"]
       test_name = transform_string("./test/controllers/api/v1/scaffolding/completely_concrete/tangible_things_controller_test.rb")
       test_lines = File.open(test_name).readlines
-      hook_index = Scaffolding::FileManipulator.find(test_lines, RUBY_FACTORY_SETUP_HOOK)
-      hook_indentation = Scaffolding::BlockManipulator.indentation_of(hook_index, test_lines)
-      indented_factory_lines = build_factory_setup.map { |line| "#{hook_indentation}#{line}\n" }
-      scaffold_replace_line_in_file(test_name, indented_factory_lines.join, test_lines[hook_index])
+
+      # Shift contents of controller test after skipping `unless scaffolding_things_disabled?` block.
+      class_block_index = Scaffolding::FileManipulator.find(test_lines, "class #{transform_string("Api::V1::Scaffolding::CompletelyConcrete::TangibleThingsControllerTest")}")
+      new_lines = Scaffolding::BlockManipulator.shift_block(lines: test_lines, block_start: test_lines[class_block_index], shift_contents_only: true)
+      Scaffolding::FileManipulator.write(test_name, new_lines)
+
+      # Ensure variables built with factories are indented properly.
+      factory_hook_index = Scaffolding::FileManipulator.find(new_lines, RUBY_FACTORY_SETUP_HOOK)
+      factory_hook_indentation = Scaffolding::BlockManipulator.indentation_of(factory_hook_index, new_lines)
+      indented_factory_lines = build_factory_setup.map { |line| "#{factory_hook_indentation}#{line}\n" }
+      scaffold_replace_line_in_file(test_name, indented_factory_lines.join, new_lines[factory_hook_index])
     end
 
     # add children to the show page of their parent.

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -1400,7 +1400,7 @@ class Scaffolding::Transformer
       test_lines = File.open(test_name).readlines
       hook_index = Scaffolding::FileManipulator.find(test_lines, RUBY_FACTORY_SETUP_HOOK)
       hook_indentation = Scaffolding::BlockManipulator.indentation_of(hook_index, test_lines)
-      indented_factory_lines = build_factory_setup.map {|line| "#{hook_indentation}#{line}\n"}
+      indented_factory_lines = build_factory_setup.map { |line| "#{hook_indentation}#{line}\n" }
       scaffold_replace_line_in_file(test_name, indented_factory_lines.join, test_lines[hook_index])
     end
 


### PR DESCRIPTION
## Setup data
```
rails g model Foo team:references title:string && \
bin/super-scaffold crud Foo Team title:text_field --sidebar="ti.ti-world" && \
rails g model Bar foo:references title:string && \
bin/super-scaffold crud Bar Foo,Team title:text_field && \
rails g model Baz bar:references title:string && \
bin/super-scaffold crud Baz Bar,Foo,Team title:text_field
```

## The problem
When Super Scaffolding a model directly off of `Team`, `@foo` gets scaffolded as a factory to the API controller `setup` method like this:

```ruby
class Api::V1::FoosControllerTest < Api::Test
    def setup
      # See `test/controllers/api/test.rb` for common set up for API tests.
      super

      @foo = build(:foo, team: @team)
      @other_foos = create_list(:foo, 3)
```

However, for any nested models, the variables don't get indented properly:
```ruby
    def setup
      # See `test/controllers/api/test.rb` for common set up for API tests.
      super

      @foo = create(:foo, team: @team)
@bar = create(:bar, foo: @foo)
@baz = build(:baz, bar: @bar)
      @other_bazs = create_list(:baz, 3)
```

This was happening because we use `gsub!` to replace the Super Scaffolding hook in this file in [the Transformer](https://github.com/bullet-train-co/bullet_train-core/blob/fab77efab57126c083e0041f97c0e716560a2ffe/bullet_train-super_scaffolding/lib/scaffolding/file_manipulator.rb#L35):

```ruby
target_file_content.gsub!(in_place_of, content)
```

## The fix
`gsub!` starts replacing after the indentation where it matches the hook, but doesn't add indentation for any of the lines afterwards. We could technically just add space to `join` in the original code:

```ruby
build_factory_setup.join("  \n")
```

Since we already have the file/block manipulators in place though, I thought it would be better to use those instead. I also wrote things this way because the spacing in the file itself might change (I plan on opening a PR about that here in a minute). I know that taking an extra step to open the file just to read the lines and then replace the content afterwards is slower, but I think this makes the code easier to understand, and we can edit indentation more easily.

## The result
Now the setup block looks like this when scaffolding the three models:
```ruby
class Api::V1::BazsControllerTest < Api::Test
    def setup
      # See `test/controllers/api/test.rb` for common set up for API tests.
      super

      @foo = create(:foo, team: @team)
      @bar = create(:bar, foo: @foo)
      @baz = build(:baz, bar: @bar)
      @other_bazs = create_list(:baz, 3)
```