### PR TITLE
Set `@team` to `nil` when loading resources with no association to a team

### DIFF
--- a/bullet_train-super_load_and_authorize_resource/app/controllers/concerns/loads_and_authorizes_resource.rb
+++ b/bullet_train-super_load_and_authorize_resource/app/controllers/concerns/loads_and_authorizes_resource.rb
@@ -7,8 +7,14 @@ module LoadsAndAuthorizesResource
     end
 
     def load_team
-      # Sometimes `@team` has already been populated by earlier `before_action` steps.
-      @team ||= @child_object&.team || @parent_object&.team
+      # Not all objects that need to be authorized belong to a team,
+      # so we give @team a nil value if no association is found.
+      begin
+        # Sometimes `@team` has already been populated by earlier `before_action` steps.
+        @team ||= @child_object&.team || @parent_object&.team
+      rescue NoMethodError
+        @team = nil
+      end
 
       # Update current attributes.
       Current.team = @team


### PR DESCRIPTION
Closes #79.

## Details
The reason this was breaking for the OAuth account show page was because we were trying to pull a `team` association from either the `@child_object` or `@parent_object` here:

https://github.com/bullet-train-co/bullet_train-core/blob/fab77efab57126c083e0041f97c0e716560a2ffe/bullet_train-super_load_and_authorize_resource/app/controllers/concerns/loads_and_authorizes_resource.rb#L11

However, the `@child_object` is an `Account::Oauth::` object, and the `@parent_object` is a `User`, neither of which have `team`:

```
# Using Spotify as an OAuth provider.

> @child_object
=> #<Oauth::SpotifyAccount:0x00007ff959c8e060
 id: 1,
 uid: "gazayas",
 data:
  {"uid"=>"gazayas",
   "info"=>
    {"name"=>"gazayas",

  ...
```

`User` records have a `current_team`, but I didn't want to edit the code to work only when `@parent_object` is a `User` record.

## The fix
`User` has `current_team` available, but I felt like this problem is bigger than the scope of just `User`. If we're handling objects that aren't scoped to a specific team, then maybe we just shouldn't try to set `@team` in the first place, which is why I set it to `nil` here. If my thinking is off on this one though, I'd be glad to revisit it and think through a better solution.

Also, there is some logic later down in this method that updates the User's current_team, but as far as I can tell, setting `@team` to nil doesn't affect this.