### PR TITLE
Write file attributes in Open API documentation

### DIFF
--- a/bullet_train-api/app/controllers/api/open_api_controller.rb
+++ b/bullet_train-api/app/controllers/api/open_api_controller.rb
@@ -61,7 +61,7 @@ module OpenApiHelper
         attribute_name = reflection.first
 
         attributes_output["properties"][attribute_name] = {
-          "type" => "attachment",
+          "type" => "object",
           "description" => attribute_name.titleize.to_s
         }
 

--- a/bullet_train-api/app/controllers/api/open_api_controller.rb
+++ b/bullet_train-api/app/controllers/api/open_api_controller.rb
@@ -101,7 +101,6 @@ module OpenApiHelper
     heading = t("#{current_model.name.underscore.pluralize}.fields.#{attribute}.heading")
     attribute_data = current_model.columns_hash[attribute.to_s]
 
-    # TODO: File fields don't show up in the columns_hash. How should we handle these?
     # Default to `string` when the type returns nil.
     type = attribute_data.nil? ? "string" : attribute_data.type
 

--- a/bullet_train-api/app/controllers/api/open_api_controller.rb
+++ b/bullet_train-api/app/controllers/api/open_api_controller.rb
@@ -60,16 +60,12 @@ module OpenApiHelper
       model.attachment_reflections.each do |reflection|
         attribute_name = reflection.first
 
-        attributes_output["properties"].merge!(
-          {
-            "#{attribute_name}" => {
-              "type" => "attachment",
-              "description" => "#{attribute_name.titleize}"
-            }
-          }
-        )
+        attributes_output["properties"][attribute_name] = {
+          "type" => "attachment",
+          "description" => attribute_name.titleize.to_s
+        }
 
-        attributes_output["example"].merge!({"#{attribute_name}" => nil})
+        attributes_output["example"].merge!({attribute_name.to_s => nil})
       end
     end
 


### PR DESCRIPTION
Addresses the TODO about writing file field attributes in the Open API documentation.

## Find attribute by reflection
Rails models have `attachment_reflections`, a method in which the return value's first key is the name of the attribute which has the reflection:
```ruby
pry(#<#<Class:0x00007fec00d6f5a8>>)> model.attachment_reflections
=> {"file_field_value"=>
  #<ActiveStorage::Reflection::HasOneAttachedReflection:0x00007febfbc9b050
   @active_record=
    Scaffolding::CompletelyConcrete::TangibleThing(id: integer, absolutely_abstract_creative_concept_id: integer, text_field_value: string, button_value: string, cloudinary_image_value: string, date_field_value: date, email_field_value: string, password_field_value: string, phone_field_value: string, super_select_value: string, text_area_value: text, created_at: datetime, updated_at: datetime, sort_order: integer, date_and_time_field_value: datetime, multiple_button_values: jsonb, multiple_super_select_values: jsonb, color_picker_value: string, boolean_button_value: boolean, option_value: string, multiple_option_values: jsonb),
   @klass=nil,
   @name=:file_field_value,
   @options={:dependent=>:purge_later, :service_name=>nil},
   @plural_name="file_field_values",
   @scope=nil>}
```

I decided to use this key to populate the API attributes where attachments exist.

## Which type to use
Open API standards only allow us to use certain types when defining attributes. I got this error when trying to use `attachment` for the attribute type:
```
`type` can be one of the following only: "object", "array", "string", "number", "integer", "boolean", "null".
```

I decided to go with `object`, but I can change this if another option is more suitable.

## Example
Since Tangible Things have a file field, you can see that they show up in the documentation. Here's an example with another model though just in case you wanted to see what it looks like:

```
rails g model Foo team:references title:string test_file:attachment
bin/super-scaffold crud Foo Team title:text_field test_file:file_field
```

```yaml
FooAttributes:
  type: object
  title: Foos
  description: Foos
  required:
  - id
  - title
  properties:
    id:
      type: string
      description: Foo ID
    team_id:
      type: string
      description: Team ID
    title:
      type: string
      description: Title
    created_at:
      type: string
      description: Added
    updated_at:
      type: string
      description: Updated
    test_file:
      type: object
      description: Test File
```