### PR TITLE
Suppress error for show page which doesn't exist

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -914,7 +914,8 @@ class Scaffolding::Transformer
           field_content.gsub!(/\s%>/, ", options: { password: true } %>")
         end
 
-        scaffold_add_line_to_file("./app/views/account/scaffolding/completely_concrete/tangible_things/show.html.erb", field_content.strip, ERB_NEW_FIELDS_HOOK, prepend: true)
+        show_page_doesnt_exist = child == "User"
+        scaffold_add_line_to_file("./app/views/account/scaffolding/completely_concrete/tangible_things/show.html.erb", field_content.strip, ERB_NEW_FIELDS_HOOK, prepend: true, suppress_could_not_find: show_page_doesnt_exist)
 
       end
 


### PR DESCRIPTION
Closes https://github.com/bullet-train-co/bullet_train/issues/634.

## Details

I suppressed the error here because the `User` model doesn't have a show page that we need to scaffold to. I also saved the value to a variable explicitly first so we know WHY we're suppressing the error, instead of just writing it like this:

```ruby
suppress_could_not_find: child == "User"
```

## Problem with Devise
Unit tests fail without a problem, but this doesn't work with devise, and even if we try to save the new crud field on the Account Details page, it won't persist to the database.

I'm assuming this is because we need to register any custom parameters we want to use for registration, etc.

From the devise docs:
```ruby
class ApplicationController < ActionController::Base
  before_action :configure_permitted_parameters, if: :devise_controller?

  protected

  def configure_permitted_parameters
    devise_parameter_sanitizer.permit(:sign_up, keys: [:username])
  end
end
```

I'm not quite sure how to approach this and I feel like it could get sticky since our user controller definitions are in the base package, but if it's worth looking into I can open up a new issue and try to implement it so our developers can add custom attributes for their users.