### PR TITLE
Extract doorkeeper config in starter repository to `bullet_train-api`

### DIFF
--- a/bullet_train-api/lib/bullet_train/api.rb
+++ b/bullet_train-api/lib/bullet_train/api.rb
@@ -30,5 +30,15 @@ module BulletTrain
     def self.all_versions
       (initial_version_numeric..current_version_numeric).map { |version| "v#{version}".to_sym }
     end
+
+    def self.set_configuration(application_class)
+      application_class.config.to_prepare do
+        Doorkeeper::ApplicationController.layout "devise"
+
+        if Doorkeeper::TokensController
+          require_relative "../tokens_controller"
+        end
+      end
+    end
   end
 end

--- a/bullet_train-api/lib/tokens_controller.rb
+++ b/bullet_train-api/lib/tokens_controller.rb
@@ -1,0 +1,20 @@
+# TODO Is there a better way to implement this?
+# This monkey patch is required to ensure the OAuth2 token includes which team was connected to.
+
+class Doorkeeper::TokensController
+  def create
+    headers.merge!(authorize_response.headers)
+
+    user = if authorize_response.is_a?(Doorkeeper::OAuth::ErrorResponse)
+      nil
+    else
+      User.find(authorize_response.token.resource_owner_id)
+    end
+
+    # Add the selected `team_id` to this response.
+    render json: authorize_response.body.merge(user&.teams&.one? ? {"team_id" => user.team_ids.first} : {}),
+      status: authorize_response.status
+  rescue Doorkeeper::Errors::DoorkeeperError => e
+    handle_token_exception(e)
+  end
+end

--- a/bullet_train-api/lib/tokens_controller.rb
+++ b/bullet_train-api/lib/tokens_controller.rb
@@ -1,5 +1,6 @@
 # TODO Is there a better way to implement this?
 # This monkey patch is required to ensure the OAuth2 token includes which team was connected to.
+# It gets required by BulletTrain::Api.set_configuration.
 
 class Doorkeeper::TokensController
   def create


### PR DESCRIPTION
Joint PR:
- https://github.com/bullet-train-co/bullet_train/pull/639

As far as I can tell the monkey patched class isn't included until we require it in the `set_configuration` method I wrote here, but if we want to handle this in a different way I can think over another way to load the class.

I've also written more details in the Joint PR, so feel free to check out the information there too.

