### PR TITLE
Application-options.md url was missing a /

### DIFF
--- a/bullet_train/app/views/layouts/docs.html.erb
+++ b/bullet_train/app/views/layouts/docs.html.erb
@@ -147,7 +147,7 @@
                   <% end %>
                 <% end %>
 
-                <%= render 'account/shared/menu/item', url: 'docs/application-options.md', label: 'Application Options' do |p| %>
+                <%= render 'account/shared/menu/item', url: '/docs/application-options.md', label: 'Application Options' do |p| %>
                   <% p.content_for :icon do %>
                     <i class="fal fa-gear ti ti-settings"></i>
                   <% end %>


### PR DESCRIPTION
Causing a Rails error on the documentation site.

The fix should make the url
https://bullettrain.co/docs/application-options.md
and not
https://bullettrain.co/docs/docs/application-options.md