### PR TITLE
Prevent user from clicking team more than once in connection workflow

### DIFF
--- a/bullet_train-api/app/views/account/platform/connections/new.html.erb
+++ b/bullet_train-api/app/views/account/platform/connections/new.html.erb
@@ -27,7 +27,7 @@
           <% end %>
 
           <% if can? :connect, team %>
-            <%= link_to request.url + "&team_id=#{team.id}", class: "group block hover:bg-gray-50 dark:hover:bg-sealBlue-400 dark:text-sealBlue-800" do %>
+            <%= link_to request.url + "&team_id=#{team.id}", class: "group block hover:bg-gray-50 dark:hover:bg-sealBlue-400 dark:text-sealBlue-800", data: {controller: "connection-workflow", action: "connection-workflow#disableTeamButton"} do %>
               <%= body %>
             <% end %>
           <% else %>

--- a/bullet_train/app/javascript/controllers/connection_workflow_controller.js
+++ b/bullet_train/app/javascript/controllers/connection_workflow_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  disableTeamButton(event) {
+    document.body.style.pointerEvents = "none";
+  }
+}

--- a/bullet_train/app/javascript/controllers/index.js
+++ b/bullet_train/app/javascript/controllers/index.js
@@ -7,6 +7,7 @@ import FormController from './form_controller'
 import MobileMenuController from './mobile_menu_controller'
 import TextToggleController from './text_toggle_controller'
 import SelectAllController from './select_all_controller'
+import ConnectionWorkflowController from './connection_workflow_controller'
 
 export const controllerDefinitions = [
   [BulkActionFormController, 'bulk_action_form_controller.js'],
@@ -16,6 +17,7 @@ export const controllerDefinitions = [
   [MobileMenuController, 'mobile_menu_controller.js'],
   [TextToggleController, 'text_toggle_controller.js'],
   [SelectAllController, 'select_all_controller.js'],
+  [ConnectionWorkflowController, 'connection_workflow_controller.js'],
 ].map(function(d) {
   const key = d[1]
   const controller = d[0]


### PR DESCRIPTION
Closes https://github.com/bullet-train-co/bullet_train/issues/578

## Details
I primarily wanted to write this in the Stimulus controller:

```JavaScript
disableTeamButton(event) {
  event.target.style.pointerEvents = "none";
  event.href = "javascript:void(0)"
}
```

I found that this was working for other links added to the page, but not with the team links for some reason, and I was still able to click a team multiple times.

I decided to disable all pointer events for the entire page for a couple of reasons:
1. If the user clicks a team, there's no reason for them to fire any other click pointer events on the page.
2. The previous code only disabled `event.target` (only one team), whereas this code prevents the user from clicking ALL teams after one is clicked.
