### PR TITLE
Prevent duplicate variable generation in Super Scaffolded index partials

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -931,6 +931,20 @@ class Scaffolding::Transformer
           scaffold_add_line_to_file("./app/views/account/scaffolding/completely_concrete/tangible_things/_index.html.erb", field_content, "<%# 🚅 super scaffolding will insert new field headers above this line. %>", prepend: true)
         end
 
+        # If these strings are the same, we get duplicate variable names in the _index.html.erb partial,
+        # so we account for that here. Run the Super Scaffolding test setup script and check the index partial
+        # of models with namespaced parents for reference (i.e. - Objective, Projects::Step).
+        transformed_abstract_str = transform_string("absolutely_abstract_creative_concept")
+        transformed_concept_str = transform_string("creative_concept")
+        transformed_file_name = transform_string("./app/views/account/scaffolding/completely_concrete/tangible_things/_index.html.erb")
+        if (transformed_abstract_str == transformed_concept_str) && File.exist?(transformed_file_name)
+          replace_in_file(
+            transformed_file_name,
+            "#{transformed_abstract_str} = @#{transformed_abstract_str} || @#{transformed_concept_str}",
+            "#{transformed_abstract_str} = @#{transformed_concept_str}"
+          )
+        end
+
         table_cell_options = []
 
         if first_table_cell


### PR DESCRIPTION
Closes #97.

This will ensure we don't get duplicate variable names in Super Scaffolded index partials (specifically on line 2 with the current code we have):

```erb
<%# Before %>
<% team = @team || @team %>

<%# After %>
<% team = @team %>
```

It also ensures that the two variables are properly scaffolded when the model's parent is namespaced (for example, `Objective` which belongs to `Projects::Step`):

```erb
<%# In `app/views/account/objectives/_index.html.erb` %>
<% projects_step = @projects_step || @step %>
```

## Failing CircleCI test
Also, I'm not sure why but I'm getting the same test failure here as I'm getting in #96 in CircleCI only although the two PRs seem completely unrelated:
```
NameError: undefined local variable or method `rendering_options' for #<TurboDeviseController::Responder:0x00007fca7c10bff0 ...
```
