### PR TITLE
Update TurboDeviseController fix

### DIFF
--- a/bullet_train/app/controllers/turbo_devise_controller.rb
+++ b/bullet_train/app/controllers/turbo_devise_controller.rb
@@ -7,7 +7,7 @@ class TurboDeviseController < ApplicationController
       if get?
         raise error
       elsif has_errors? && default_action
-        render rendering_options.merge(formats: :html, status: :unprocessable_entity)
+        render error_rendering_options.merge(formats: :html, status: :unprocessable_entity)
       else
         redirect_to navigation_location
       end


### PR DESCRIPTION
Closes #99.

@adampal found out that the gem that was giving us trouble is [responders](https://github.com/heartcombo/responders)

## Original Fix before responders v.3.1.0

The TurboDeviseController fix we have in place is a fix I saw in multiple places:
[Example 1](https://betterprogramming.pub/devise-auth-setup-in-rails-7-44240aaed4be)
[Example 2](https://gorails.com/forum/how-to-use-devise-with-hotwire-turbo-js-discussion#forum_post_17983)
[Example 3](https://qiita.com/jnchito/items/48db78c465493837c41f)

## `rendering_options` is now obsolete

However, it is outdated because `rendering_options` was removed from the repository.

[rendering_options](https://github.com/Edouard-chin/responders/blob/c44dd4fd7107bc82b606384ea2fb602904b586d6/lib/action_controller/responder.rb#L301) was initially added in [this PR](https://github.com/heartcombo/responders/pull/176) and looked like this:

```ruby
def rendering_options
  if options[:render]
    options[:render]
  else
    { action: default_action }
  end
end
```

This has simply been named to `error_rendering_options` as you can see in [this PR](https://github.com/heartcombo/responders/pull/223), so I went ahead and changed the name and the tests are passing without an issue.