### PR TITLE
Delete `silence_logs?` definitions outside of `lib/bullet_train.rb`

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/file_manipulator.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/file_manipulator.rb
@@ -15,11 +15,6 @@ module Scaffolding::FileManipulator
     lines[(within + 1)..(Scaffolding::BlockManipulator.find_block_end(starting_from: within, lines: lines) + 1)]
   end
 
-  # TODO I was running into an error in a downstream application where it couldn't find silence_logs? We should implement it in this package.
-  def self.silence_logs?
-    ENV["SILENCE_LOGS"].present?
-  end
-
   def self.replace_line_in_file(file, content, in_place_of, options = {})
     begin
       target_file_content = File.read(file)

--- a/bullet_train-super_scaffolding/lib/scaffolding/oauth_providers.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/oauth_providers.rb
@@ -10,11 +10,6 @@ def legacy_resolve_template_path(file)
   end.compact.first || raise("Couldn't find the Super Scaffolding template for `#{file}` in any of the following locations:\n\n#{BulletTrain::SuperScaffolding.template_paths.join("\n")}")
 end
 
-# TODO I was running into an error in a downstream application where it couldn't find silence_logs? We should implement it in this package.
-def silence_logs?
-  ENV["SILENCE_LOGS"].present?
-end
-
 def legacy_replace_in_file(file, before, after)
   puts "Replacing in '#{file}'." unless silence_logs?
   target_file_content = File.read(file)

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -251,11 +251,6 @@ class Scaffolding::Transformer
     transformed_file_content.join
   end
 
-  # TODO I was running into an error in a downstream application where it couldn't find silence_logs? We should implement it in this package.
-  def silence_logs?
-    ENV["SILENCE_LOGS"].present?
-  end
-
   def scaffold_file(file, overrides: false)
     transformed_file_content = get_transformed_file_content(file)
     transformed_file_name = transform_string(file)


### PR DESCRIPTION
I don't think we need these anymore because we have all of the gems in one place now, as opposed to when they were all each within their own repository (`bullet_train-super_scaffolding`, `bullet_train-api`, etc.)

I ran the Super Scaffolding tests and the OAuth provider scaffolder and everything ran fine.

I'm not sure where the scripts were failing last time, so if there are certain commands you want me to test this with, just let me know!