### PR TITLE
Add `class_name` to attribute when model is namespaced

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -571,8 +571,8 @@ class Scaffolding::Transformer
   def add_has_many_association
     has_many_line = ["has_many :completely_concrete_tangible_things"]
 
-    # TODO I _think_ this is the right way to check for whether we need `class_name` to specify the name of the model.
-    unless transform_string("completely_concrete_tangible_things").classify == child
+    # Specify the class name if the model is namespaced.
+    if child.match?("::")
       has_many_line << "class_name: \"Scaffolding::CompletelyConcrete::TangibleThing\""
     end
 

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -578,8 +578,8 @@ class Scaffolding::Transformer
 
     has_many_line << "dependent: :destroy"
 
-    # TODO I _think_ this is the right way to check for whether we need `foreign_key` to specify the name of the model.
-    unless transform_string("absolutely_abstract_creative_concept_id") == "#{parent.underscore}_id"
+    # Specify the foreign key if the parent is namespaced.
+    if parent.match?("::")
       has_many_line << "foreign_key: :absolutely_abstract_creative_concept_id"
 
       # And if we need `foreign_key`, we should also specify `inverse_of`.


### PR DESCRIPTION
Revisiting https://github.com/bullet-train-co/bullet_train-super_scaffolding/issues/63

## Check if model is namespaced

Reading through the Rails docs, it looks like the two most common situations to use `class_name` are:
1. ([docs](https://guides.rubyonrails.org/association_basics.html#self-joins)) When you want to use a specific class for an attribute, but want to give the attribute itself a custom name
2. ([docs](https://guides.rubyonrails.org/association_basics.html#controlling-association-scope)) When the attribute lives in a different namespace

The situation we're handling here is the second one.

In the `if` statement I used here, we simply check if the entire model name is namespaced. It's simple, but I think this it's enough to check if we need to add `class_name` to the attribute in the parent model.

### Example

```
> rails g model Projects::Step team:references name:string
> bin/super-scaffold crud Projects::Step Team name:text_field description:trix_editor --sidebar="ti.ti-world"
```

```
[1] pry(#<Scaffolding::Transformer>)> transform_string("scaffolding_completely_concrete_tangible_things")
=> "projects_steps"
[2] pry(#<Scaffolding::Transformer>)> child.tableize
=> "projects/steps"
```

We need to add `class_name` here because if not, I'm assuming Rails will try to find the model by the attribute name. This would mean changing `project_steps` to `ProjectStep` because attributes don't use `/`, yielding an error like this:
```
ActionView::Template::Error: Rails couldn't find a valid model for ProjectsStep association.
```

On the other hand if we scaffold the following, `foo_bars` will simply give us `FooBar`, so we can skip adding `class_name` and all the tests will still pass.
```
> rails g model FooBar team:references title:string
> bin/super-scaffold crud FooBar Team title:text_field
```

```
[1] pry(#<Scaffolding::Transformer>)> transform_string("scaffolding_completely_concrete_tangible_things")
=> "foo_bars"
[2] pry(#<Scaffolding::Transformer>)> child.tableize
=> "foo_bars"
```
