### PR TITLE
Prevent duplicate lines in `roles.yml`

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -508,7 +508,8 @@ class Scaffolding::Transformer
       default_role_placements.each do |role_placement|
         stringified_role_placement = role_placement.map { |placement| placement.to_s }
         if roles_hash.dig(*stringified_role_placement)[model_name].nil?
-          Scaffolding::FileManipulator.add_line_to_yml_file(role_file, "#{model_name}: read", role_placement)
+          role_type = role_placement.first == :admin ? "manage" : "read"
+          Scaffolding::FileManipulator.add_line_to_yml_file(role_file, "#{model_name}: #{role_type}", role_placement)
         end
       end
     end

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -508,7 +508,7 @@ class Scaffolding::Transformer
       default_role_placements.each do |role_placement|
         stringified_role_placement = role_placement.map { |placement| placement.to_s }
         if roles_hash.dig(*stringified_role_placement)[model_name].nil?
-          role_type = role_placement.first == :admin ? "manage" : "read"
+          role_type = (role_placement.first == :admin) ? "manage" : "read"
           Scaffolding::FileManipulator.add_line_to_yml_file(role_file, "#{model_name}: #{role_type}", role_placement)
         end
       end

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -498,9 +498,19 @@ class Scaffolding::Transformer
   def add_ability_line_to_roles_yml(class_names = nil)
     model_names = class_names || [child]
     role_file = "./config/models/roles.yml"
+    roles_hash = YAML.load_file(role_file)
+    default_role_placements = [
+      [:default, :models],
+      [:admin, :models]
+    ]
+
     model_names.each do |model_name|
-      Scaffolding::FileManipulator.add_line_to_yml_file(role_file, "#{model_name}: read", [:default, :models])
-      Scaffolding::FileManipulator.add_line_to_yml_file(role_file, "#{model_name}: manage", [:admin, :models])
+      default_role_placements.each do |role_placement|
+        stringified_role_placement = role_placement.map { |placement| placement.to_s }
+        if roles_hash.dig(*stringified_role_placement)[model_name].nil?
+          Scaffolding::FileManipulator.add_line_to_yml_file(role_file, "#{model_name}: read", role_placement)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Closes https://github.com/bullet-train-co/bullet_train/issues/623.

This PR ensures the ability line is only written once when Super Scaffolding the model in question.