### PR TITLE
Extract team index item into a theme component partial

### DIFF
--- a/bullet_train-themes-light/app/views/themes/light/_team.html.erb
+++ b/bullet_train-themes-light/app/views/themes/light/_team.html.erb
@@ -1,6 +1,7 @@
 <% yield p = np %>
 
 <% link_url ||= "#" %>
+<% memberships ||= [] %>
 
 <li class="bg-white shadow overflow-hidden sm:rounded-md dark:bg-slate-700">
   <%= link_to link_url, class: "group block hover:bg-slate-50 dark:hover:bg-slate-400 dark:text-slate-800" do %>
@@ -12,6 +13,11 @@
               <%= p.content_for :name %>
             </div>
           <% end %>
+        </div>
+        <div class="mt-4 flex-shrink-0 sm:mt-0">
+          <div class="flex overflow-hidden">
+            <%= render 'account/shared/memberships/photos', memberships: memberships %>
+          </div>
         </div>
       </div>
       <div class="ml-5 flex-shrink-0">

--- a/bullet_train-themes-light/app/views/themes/light/_team.html.erb
+++ b/bullet_train-themes-light/app/views/themes/light/_team.html.erb
@@ -1,0 +1,24 @@
+<% yield p = np %>
+
+<% link_url ||= "#" %>
+
+<li class="bg-white shadow overflow-hidden sm:rounded-md dark:bg-slate-700">
+  <%= link_to link_url, class: "group block hover:bg-slate-50 dark:hover:bg-slate-400 dark:text-slate-800" do %>
+    <div class="px-4 py-4 flex items-center sm:pl-8 sm:pr-6">
+      <div class="min-w-0 flex-1 sm:flex sm:items-center sm:justify-between">
+        <div>
+          <% if p.content_for? :name %>
+            <div class="flex text-xl font-semibold text-blue uppercase group-hover:text-blue-800 tracking-widest dark:text-white">
+              <%= p.content_for :name %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+      <div class="ml-5 flex-shrink-0">
+        <svg class="h-5 w-5 text-slate-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+        </svg>
+      </div>
+    </div>
+  <% end %>
+</li>

--- a/bullet_train/app/views/account/teams/_team.html.erb
+++ b/bullet_train/app/views/account/teams/_team.html.erb
@@ -1,4 +1,11 @@
-<li class="bg-white shadow overflow-hidden sm:rounded-md dark:bg-slate-400">
+<%= render 'account/shared/team', link_url: [:account, team] do |p| %>
+  <% p.content_for :name, team.name %>
+<% end %>
+
+
+
+
+<!-- <li class="bg-white shadow overflow-hidden sm:rounded-md dark:bg-slate-700">
   <%= link_to [:account, team], class: "group block hover:bg-slate-50 dark:hover:bg-slate-400 dark:text-slate-800" do %>
     <div class="px-4 py-4 flex items-center sm:pl-8 sm:pr-6">
       <div class="min-w-0 flex-1 sm:flex sm:items-center sm:justify-between">
@@ -20,4 +27,4 @@
       </div>
     </div>
   <% end %>
-</li>
+</li> -->

--- a/bullet_train/app/views/account/teams/_team.html.erb
+++ b/bullet_train/app/views/account/teams/_team.html.erb
@@ -1,30 +1,3 @@
-<%= render 'account/shared/team', link_url: [:account, team] do |p| %>
+<%= render 'account/shared/team', link_url: [:account, team], memberships: team.memberships.current_and_invited.first(10)  do |p| %>
   <% p.content_for :name, team.name %>
 <% end %>
-
-
-
-
-<!-- <li class="bg-white shadow overflow-hidden sm:rounded-md dark:bg-slate-700">
-  <%= link_to [:account, team], class: "group block hover:bg-slate-50 dark:hover:bg-slate-400 dark:text-slate-800" do %>
-    <div class="px-4 py-4 flex items-center sm:pl-8 sm:pr-6">
-      <div class="min-w-0 flex-1 sm:flex sm:items-center sm:justify-between">
-        <div>
-          <div class="flex text-xl font-semibold text-blue uppercase group-hover:text-blue-800 tracking-widest dark:text-white">
-            <%= team.name %>
-          </div>
-        </div>
-        <div class="mt-4 flex-shrink-0 sm:mt-0">
-          <div class="flex overflow-hidden">
-            <%= render 'account/shared/memberships/photos', memberships: team.memberships.current_and_invited.first(10) %>
-          </div>
-        </div>
-      </div>
-      <div class="ml-5 flex-shrink-0">
-        <svg class="h-5 w-5 text-slate-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-          <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
-        </svg>
-      </div>
-    </div>
-  <% end %>
-</li> -->


### PR DESCRIPTION
Goal of this change is to create a team component and move all of the styling from bullet_train/app/views/account/teams/_team.html.erb into the component.

I've just learned about Nice Partials as part of this change (like this concept! as a lightweight to ViewComponent) so feel free to suggest corrections to how I've done the 'slots' and 'locals', made my best guesses here!

I also updated the dark bg color as it looked a little 'light'. Here is a pic of before and after, feel free to revert if the original shade was intentional. I have no strong opinions about design 😅 

Before:
<img width="1504" alt="Screen Shot 2023-02-17 at 2 15 25 PM" src="https://user-images.githubusercontent.com/1966473/219785622-c0abfdf6-e11c-4069-84b2-58139cb23d6c.png">
After:
<img width="1501" alt="Screen Shot 2023-02-17 at 2 14 38 PM" src="https://user-images.githubusercontent.com/1966473/219785643-24c81d23-6e83-431c-8d61-da4228b9b193.png">


Closes https://github.com/bullet-train-co/bullet_train-core/issues/87