### PR TITLE
Update doorkeeper token according to user time zone

### DIFF
--- a/bullet_train-api/app/controllers/concerns/api/controllers/base.rb
+++ b/bullet_train-api/app/controllers/concerns/api/controllers/base.rb
@@ -75,7 +75,12 @@ module Api::Controllers::Base
     # TODO Make this logic configurable so that downstream developers can write different methods for this column getting updated.
     if doorkeeper_token
       begin
-        doorkeeper_token.update(last_used_at: Time.zone.now)
+        current_time = unless @current_user.time_zone.nil?
+          ActiveSupport::TimeZone.all.find {|time_zone| time_zone.name == @current_user.time_zone }.now
+        else
+          Time.zone.now
+        end
+        doorkeeper_token.update(last_used_at: current_time)
       rescue ActiveRecord::StatementInvalid => _
       end
     end

--- a/bullet_train-api/app/controllers/concerns/api/controllers/base.rb
+++ b/bullet_train-api/app/controllers/concerns/api/controllers/base.rb
@@ -75,10 +75,10 @@ module Api::Controllers::Base
     # TODO Make this logic configurable so that downstream developers can write different methods for this column getting updated.
     if doorkeeper_token
       begin
-        current_time = unless @current_user.time_zone.nil?
-          ActiveSupport::TimeZone.all.find {|time_zone| time_zone.name == @current_user.time_zone }.now
-        else
+        current_time = if @current_user.time_zone.nil?
           Time.zone.now
+        else
+          ActiveSupport::TimeZone.all.find { |time_zone| time_zone.name == @current_user.time_zone }.now
         end
         doorkeeper_token.update(last_used_at: current_time)
       rescue ActiveRecord::StatementInvalid => _


### PR DESCRIPTION
I originally set out to fix this TODO:

```
# TODO Make this logic configurable so that downstream developers can write different methods for this column getting updated.
```

I mulled over it for a bit and I don't think I'm 100% sure I understand this TODO and how we want to make this part configurable (maybe by accepting `params[:time_zone]` and updating the column with that?), but I saw that we just use `Time.zone.now` to update the column, so I figured it might be good to update it according to the user's time zone if it exists.

If there's a certain way we want to make this configurable, I'd be glad to look over this section again sometime soon.