### PR TITLE
Add back the opening HTML tag on the devise layout

### DIFF
--- a/bullet_train-themes-light/app/views/themes/light/layouts/_devise.html.erb
+++ b/bullet_train-themes-light/app/views/themes/light/layouts/_devise.html.erb
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html class="theme-<%= BulletTrain::Themes::Light.color %> <%= "theme-secondary-#{BulletTrain::Themes::Light.secondary_color}" if BulletTrain::Themes::Light.secondary_color %> <%= "theme-logo-color-shift" if BulletTrain::Themes::Light.logo_color_shift %>">
   <head>
     <%= render 'shared/layouts/head' %>
   </head>

--- a/bullet_train-themes-light/app/views/themes/light/layouts/_devise.html.erb
+++ b/bullet_train-themes-light/app/views/themes/light/layouts/_devise.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="theme-<%= BulletTrain::Themes::Light.color %> <%= "theme-secondary-#{BulletTrain::Themes::Light.secondary_color}" if BulletTrain::Themes::Light.secondary_color %> <%= "theme-logo-color-shift" if BulletTrain::Themes::Light.logo_color_shift %>">
+<html class="theme-<%= BulletTrain::Themes::Light.color %> <%= "theme-secondary-#{BulletTrain::Themes::Light.secondary_color}" if BulletTrain::Themes::Light.secondary_color %>">
   <head>
     <%= render 'shared/layouts/head' %>
   </head>


### PR DESCRIPTION
I think this was accidentally removed in #106 (https://github.com/bullet-train-co/bullet_train-core/pull/106/files#diff-1fc68ed0b53bacc67d976dbe546254e88c0e4016a29ec3396680ce86505ce4a4L2)

This makes the opening html tag match the opening tag in the `_account` layout.

Fixes #112 