### PR TITLE
Extract check boxes and radio buttons to `option_tag`

### DIFF
--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_options.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_options.html.erb
@@ -76,18 +76,8 @@ end
 
           <label class="relative flex items-start mb-3">
             <div class="flex items-center h-5">
-
-              <% if multiple %>
-                <% checked_value = form.object.send(method).nil? ? nil : form.object.send(method).map(&:to_s).include?(value.to_s) %>
-                <%= form.check_box method, {
-                  multiple: multiple, checked: checked_value,
-                  data: option_field_options[:data],
-                  class: "focus:ring-blue h-4 w-4 text-blue border-slate-300 rounded"
-                }, value, "" %>
-              <% else %>
-                <%= form.radio_button method, value, {class: "focus:ring-blue h-4 w-4 text-blue border-slate-300", data: option_field_options[:data]} %>
-              <% end %>
-
+              <% option_tag_options = {value: value, data: option_field_options[:data]} %>
+              <%= options_tag(method, form: form, options: option_tag_options, multiple: multiple) %>
             </div>
             <div class="ml-2.5 text-sm">
               <div class="select-none"><%= label %></div>

--- a/bullet_train-themes/app/helpers/options_helper.rb
+++ b/bullet_train-themes/app/helpers/options_helper.rb
@@ -1,0 +1,27 @@
+module OptionsHelper
+  # This tag provides a polymorphic way to handle the different types of options we support.
+  # Please refer to the Ruby on Rails API for details concerning the methods and parameters we use here.
+  #
+  # check_box: https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-check_box
+  # check_box_tag: https://api.rubyonrails.org/classes/ActionView/Helpers/FormTagHelper.html#method-i-check_box_tag
+  # radio_button: https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-radio_button
+  def options_tag(method, form:, options:, multiple:)
+    options[:class] ||= "focus:ring-blue h-4 w-4 text-blue border-slate-300 dark:bg-slate-700#{" rounded" if multiple}"
+    value = options.delete(:value)
+
+    if multiple
+      options[:multiple] = multiple
+      options[:checked] = form.object.send(method).nil? ? nil : form.object.send(method).map(&:to_s).include?(value.to_s)
+      unchecked_value = options.delete(:unchecked_value) || ""
+
+      if form
+        form.check_box method, options, value, unchecked_value
+      else
+        checked = !!options[:checked].delete
+        check_box_tag method, checked, options
+      end
+    else
+      form.radio_button method, value, options
+    end
+  end
+end

--- a/bullet_train-themes/app/helpers/options_helper.rb
+++ b/bullet_train-themes/app/helpers/options_helper.rb
@@ -11,7 +11,7 @@ module OptionsHelper
 
     if multiple
       options[:multiple] = multiple
-      options[:checked] = form.object.send(method).nil? ? nil : form.object.send(method).map(&:to_s).include?(value.to_s)
+      options[:checked] = form.object.send(method)&.map(&:to_s)&.include?(value.to_s)
       unchecked_value = options.delete(:unchecked_value) || ""
 
       if form


### PR DESCRIPTION
## Details
This PR seeks to place all of the same logic we implement for check boxes and radio buttons into one place. For example, here are a few things that overlap concerning different check box methods and the `radio_button` method:
1. `value`: The value of the check box or radio button we're making
2. `class`: Where we put tailwind styles, etc.
3. `multiple`: I added this as a keyword argument so developers can add this if necessary or skip it if they just want a radio button.

## Another `options` partial
I wanted to make this a partial at first, but we already have the `_options.html.erb` partial, and I thought it would be more intuitive to use `<%= options_tag() %>` since this is similar to writing `<%= form.check_box() %>` or `<%= check_box_tag() %>`.

I'm not entirely sure if we can call this "polymorphic," but I've written the comments as such. I can re-write those too if necessary.

I'm opening this as a draft pull request because there are some other places where I'd like to use `options_tag`.