### PR TITLE
Limit Showcase mount to just development

### DIFF
--- a/bullet_train/config/routes.rb
+++ b/bullet_train/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  mount Showcase::Engine, at: "/docs/showcase" if defined?(Showcase::Engine)
+  mount Showcase::Engine, at: "/docs/showcase" if Rails.env.development?
 
   scope module: "public" do
     root to: "home#index"


### PR DESCRIPTION
Since Showcase is now a hard BulletTrain dependency, and since gemspec dependencies can't specify an environment, we'd up mounting the Showcase routes in production. We shouldn't do that.

Due to a version of Showcase's tests using integration tests, we'd also mount the routes in the test environment, which was the reason for using the defined? check.

We can now just use development?.