### PR TITLE
Fix outgoing webhook delivery for url without trailing slash

### DIFF
--- a/bullet_train-outgoing_webhooks/app/models/concerns/webhooks/outgoing/delivery_attempt_support.rb
+++ b/bullet_train-outgoing_webhooks/app/models/concerns/webhooks/outgoing/delivery_attempt_support.rb
@@ -45,6 +45,11 @@ module Webhooks::Outgoing::DeliveryAttemptSupport
       uri.hostname.downcase
     end
 
+    # Net::HTTP will consider the url invalid (and not deliver the webhook) unless it ends with a '/'
+    unless uri.path.end_with?("/")
+      uri.path = uri.path + "/"
+    end
+
     http = Net::HTTP.new(hostname, uri.port)
     http.use_ssl = true if uri.scheme == "https"
     request = Net::HTTP::Post.new(uri.path)


### PR DESCRIPTION
closes https://github.com/bullet-train-co/bullet_train-core/issues/131

### The root cause and fix
The reason urls without trailing slashes are not delivered is because `Net::HTTP` throws this error `ArgumentError: HTTP request path is empty` for those. When doing URI.parse the endpoint url without trailing slashes end up with an empty string in the `uri.path`. And those are technically considered invalid.

The fix is to add the trailing slash if one does not already exist to the `path` part of the `HTTP::URI`

### Testing Done
Tested with pipedream that both urls with and without trailing slashes (as entered by the user in the webhooks UI) are delivered successfully. And no error in the logs.