### PR TITLE
Skip updating for content that already exists and has been transformed

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/file_manipulator.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/file_manipulator.rb
@@ -23,7 +23,7 @@ module Scaffolding::FileManipulator
       return false
     end
 
-    if target_file_content.include?(content)
+    if options[:content_replacement_transformed] && target_file_content.include?(content)
       puts "No need to update '#{file}'. It already has '#{content}'."
     else
       puts "Updating '#{file}'." unless silence_logs?

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -421,11 +421,13 @@ class Scaffolding::Transformer
     add_line_to_file(file, content, hook, options)
   end
 
-  def scaffold_replace_line_in_file(file, content, in_place_of)
+  def scaffold_replace_line_in_file(file, content, content_to_replace)
     file = resolve_target_path(transform_string(file))
     # we specifically don't transform the content, we assume a builder function created this content.
-    in_place_of = transform_string(in_place_of)
-    Scaffolding::FileManipulator.replace_line_in_file(file, content, in_place_of, suppress_could_not_find: suppress_could_not_find)
+    transformed_content_to_replace = transform_string(content_to_replace)
+    content_replacement_transformed = content_to_replace != transformed_content_to_replace
+    options = {suppress_could_not_find: suppress_could_not_find, content_replacement_transformed: content_replacement_transformed}
+    Scaffolding::FileManipulator.replace_line_in_file(file, content, transformed_content_to_replace, **options)
   end
 
   # if class_name isn't specified, we use `child`.


### PR DESCRIPTION
In https://github.com/bullet-train-pro/bullet_train-action_models/pull/46 we were trying to remove a `has_one` association from a model like this:

```ruby
scaffold_replace_line_in_file(
  "./app/models/scaffolding/completely_concrete/tangible_things/foo.rb",
  "",
  "has_one :team, through: :team",
)
```

`""` becomes a variable called `content`, and since we have the following `if` statement in the [FileManipulator](https://github.com/bullet-train-co/bullet_train-core/blob/0680b1f48fd32b88648a189c43a88109d324df36/bullet_train-super_scaffolding/lib/scaffolding/file_manipulator.rb#L26), it's skipping the file update altogether:
```ruby
if target_file_content.include?(content)
  puts "No need to update '#{file}'. It already has '#{content}'."
else
  puts "Updating '#{file}'." unless silence_logs?
  target_file_content.gsub!(in_place_of, content)
  File.write(file, target_file_content)
  end
end
```

We should only really be doing a check like this for content that has been transformed (i.e. - when we have a model like `Foo` and we use `TangibleThingsController` to change it to `FoosController`), and not all other general strings, so I've ensured we only skip updating when the content is transformed content and already exists in the target file.