### PR TITLE
Delete unneeded Super Scaffolding hook

### DIFF
--- a/bullet_train/app/views/account/teams/_form.html.erb
+++ b/bullet_train/app/views/account/teams/_form.html.erb
@@ -13,7 +13,6 @@
     <% end %>
 
     <%= render "account/teams/fields", team: team, form: form %>
-    <%# 🚅 super scaffolding will insert new fields above this line. %>
   <% end %>
 
   <div class="buttons">


### PR DESCRIPTION
We can add a crud-field to a Team like this:

```
> rails g migration add_detail_to_teams detail:string
> bin/super-scaffold crud-field Team detail:text_field
```

However, we already have a super scaffolding hook here in the starter repository which adds a new field to the Teams form:

https://github.com/bullet-train-co/bullet_train/blob/d4499407e552123c99495ad06d48e98f93fb4b68/app/views/account/teams/_fields.html.erb#L1

This caused the attribute to be doubled on the form.

Deleting the hook here ensures the attribute just shows up once on the form, and now looks like this:

![image](https://user-images.githubusercontent.com/10546292/223410746-c01a74a0-075e-4f97-b9ce-131986dc2e74.png)
