### PR TITLE
Skip `OTHER_TARGETS` when it is `nil`

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -192,9 +192,11 @@ class Scaffolding::Transformer
     # If the file exists in the application repository, we want to target it there.
     return file if File.exist?(file)
 
-    ENV["OTHER_TARGETS"].split(",").each do |possible_target|
-      candidate_path = "#{possible_target}/#{file}".gsub("//", "/")
-      return candidate_path if File.exist?(candidate_path)
+    if !ENV["OTHER_TARGETS"].nil?
+      ENV["OTHER_TARGETS"].split(",").each do |possible_target|
+        candidate_path = "#{possible_target}/#{file}".gsub("//", "/")
+        return candidate_path if File.exist?(candidate_path)
+      end
     end
 
     "#{ENV["TARGET"]}/#{file}".gsub("//", "/")

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -192,11 +192,9 @@ class Scaffolding::Transformer
     # If the file exists in the application repository, we want to target it there.
     return file if File.exist?(file)
 
-    if !ENV["OTHER_TARGETS"].nil?
-      ENV["OTHER_TARGETS"].split(",").each do |possible_target|
-        candidate_path = "#{possible_target}/#{file}".gsub("//", "/")
-        return candidate_path if File.exist?(candidate_path)
-      end
+    ENV["OTHER_TARGETS"]&.split(",")&.each do |possible_target|
+      candidate_path = "#{possible_target}/#{file}".gsub("//", "/")
+      return candidate_path if File.exist?(candidate_path)
     end
 
     "#{ENV["TARGET"]}/#{file}".gsub("//", "/")


### PR DESCRIPTION
When using `TARGET` without `OTHER_TARGETS` for Super Scaffolding, we get the following error:

```
> TARGET=local/bullet_train-core/bullet_train bin/super-scaffold crud-field Membership detail:text_field
rake aborted!
NoMethodError: undefined method `split' for nil:NilClass
/home/gazayas/work/bt/bullet_train/local/bullet_train-core/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb:195:in `resolve_target_path'
```

This fix just skips checking for other targets when the variable is `nil`.