### PR TITLE
Show a list of the field partials with `bin/super-scaffold`

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/script.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/script.rb
@@ -87,7 +87,7 @@ end
 
 def show_usage
   puts ""
-  puts "🚅  usage: bin/super-scaffold [type] (... | --help)"
+  puts "🚅  usage: bin/super-scaffold [type] (... | --help | --field-partials)"
   puts ""
   puts "Supported types of scaffolding:"
   puts ""
@@ -114,9 +114,51 @@ elsif argv.count > 1
   show_usage
 else
   if ARGV.first.present?
-    puts ""
-    puts "Invalid scaffolding type \"#{ARGV.first}\".".red
-  end
+    case ARGV.first
+    when "--field-partials"
+      puts "Bullet Train uses the following field partials for Super Scaffolding".blue
+      puts ""
+      field_partials = {
+        boolean: "boolean",
+        buttons: "string",
+        cloudinary_image: "string",
+        color_picker: "",
+        date_and_time_field: "datetime",
+        date_field: "date_field",
+        email_field: "string",
+        emoji_field: "string",
+        file_field: "attachment",
+        options: "string",
+        password_field: "string",
+        phone_field: "string",
+        super_select: "string",
+        text_area: "text",
+        text_field: "string",
+        number_field: "integer",
+        trix_editor: "text"
+      }
 
-  show_usage
+      max_name_length = 0
+      field_partials.each do |key, value|
+        if key.to_s.length > max_name_length
+          max_name_length = key.to_s.length
+        end
+      end
+
+      printf "\t%#{max_name_length}s: Data Type\n".bold, "Field Partial Name"
+
+      field_partials.each do |key, value|
+        printf "\t%#{max_name_length}s:#{value}\n", key
+      end
+
+      puts ""
+      puts "For more details, check out the documentation:"
+      puts "https://bullettrain.co/docs/field-partials"
+    when "--help"
+      show_usage
+    else
+      puts "Invalid scaffolding type \"#{ARGV.first}\".".red
+      show_usage
+    end
+  end
 end

--- a/bullet_train-super_scaffolding/lib/scaffolding/script.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/script.rb
@@ -145,7 +145,7 @@ elsif ARGV.first.present?
     end
 
     printf "\t%#{max_name_length}s:Data Type\n".bold, "Field Partial Name"
-    field_partials.each {|key, value| printf "\t%#{max_name_length}s:#{value}\n", key}
+    field_partials.each { |key, value| printf "\t%#{max_name_length}s:#{value}\n", key }
 
     puts ""
     puts "For more details, check out the documentation:"

--- a/bullet_train-super_scaffolding/lib/scaffolding/script.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/script.rb
@@ -121,7 +121,7 @@ elsif ARGV.first.present?
       boolean: "boolean",
       buttons: "string",
       cloudinary_image: "string",
-      color_picker: "",
+      color_picker: "string",
       date_and_time_field: "datetime",
       date_field: "date_field",
       email_field: "string",

--- a/bullet_train-super_scaffolding/lib/scaffolding/script.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/script.rb
@@ -112,53 +112,51 @@ elsif argv.count > 1
   puts "To use the original Super Scaffolding that you know and love, use the `crud` option.".yellow
 
   show_usage
-else
-  if ARGV.first.present?
-    case ARGV.first
-    when "--field-partials"
-      puts "Bullet Train uses the following field partials for Super Scaffolding".blue
-      puts ""
-      field_partials = {
-        boolean: "boolean",
-        buttons: "string",
-        cloudinary_image: "string",
-        color_picker: "",
-        date_and_time_field: "datetime",
-        date_field: "date_field",
-        email_field: "string",
-        emoji_field: "string",
-        file_field: "attachment",
-        options: "string",
-        password_field: "string",
-        phone_field: "string",
-        super_select: "string",
-        text_area: "text",
-        text_field: "string",
-        number_field: "integer",
-        trix_editor: "text"
-      }
+elsif ARGV.first.present?
+  case ARGV.first
+  when "--field-partials"
+    puts "Bullet Train uses the following field partials for Super Scaffolding".blue
+    puts ""
+    field_partials = {
+      boolean: "boolean",
+      buttons: "string",
+      cloudinary_image: "string",
+      color_picker: "",
+      date_and_time_field: "datetime",
+      date_field: "date_field",
+      email_field: "string",
+      emoji_field: "string",
+      file_field: "attachment",
+      options: "string",
+      password_field: "string",
+      phone_field: "string",
+      super_select: "string",
+      text_area: "text",
+      text_field: "string",
+      number_field: "integer",
+      trix_editor: "text"
+    }
 
-      max_name_length = 0
-      field_partials.each do |key, value|
-        if key.to_s.length > max_name_length
-          max_name_length = key.to_s.length
-        end
+    max_name_length = 0
+    field_partials.each do |key, value|
+      if key.to_s.length > max_name_length
+        max_name_length = key.to_s.length
       end
-
-      printf "\t%#{max_name_length}s: Data Type\n".bold, "Field Partial Name"
-
-      field_partials.each do |key, value|
-        printf "\t%#{max_name_length}s:#{value}\n", key
-      end
-
-      puts ""
-      puts "For more details, check out the documentation:"
-      puts "https://bullettrain.co/docs/field-partials"
-    when "--help"
-      show_usage
-    else
-      puts "Invalid scaffolding type \"#{ARGV.first}\".".red
-      show_usage
     end
+
+    printf "\t%#{max_name_length}s: Data Type\n".bold, "Field Partial Name"
+
+    field_partials.each do |key, value|
+      printf "\t%#{max_name_length}s:#{value}\n", key
+    end
+
+    puts ""
+    puts "For more details, check out the documentation:"
+    puts "https://bullettrain.co/docs/field-partials"
+  when "--help"
+    show_usage
+  else
+    puts "Invalid scaffolding type \"#{ARGV.first}\".".red
+    show_usage
   end
 end

--- a/bullet_train-super_scaffolding/lib/scaffolding/script.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/script.rb
@@ -144,11 +144,8 @@ elsif ARGV.first.present?
       end
     end
 
-    printf "\t%#{max_name_length}s: Data Type\n".bold, "Field Partial Name"
-
-    field_partials.each do |key, value|
-      printf "\t%#{max_name_length}s:#{value}\n", key
-    end
+    printf "\t%#{max_name_length}s:Data Type\n".bold, "Field Partial Name"
+    field_partials.each {|key, value| printf "\t%#{max_name_length}s:#{value}\n", key}
 
     puts ""
     puts "For more details, check out the documentation:"


### PR DESCRIPTION
I tend to forget which data types should be used for our field partials, so I added a flag to list all the information via the terminal:

```
> bin/super-scaffold --field-partials
```

## The result

![image](https://user-images.githubusercontent.com/10546292/223641769-b746784c-6474-408b-a29b-c53fcd08f547.png)
