### PR TITLE
Fix documentation Tailwind styling

### DIFF
--- a/bullet_train/app/views/layouts/docs.html.erb
+++ b/bullet_train/app/views/layouts/docs.html.erb
@@ -32,9 +32,9 @@
     <meta property="og:url" content="<%= request.base_url + request.path %>" />
     <meta property="og:description" content="<%= description.truncate(200) %>" />
   </head>
-  <body class="bg-light-gradient text-slate-700 text-sm font-normal dark:bg-800-gradient dark:text-slate-300">
-    <div class="md:p-5">
-      <div class="h-screen md:h-auto overflow-hidden md:rounded-lg flex shadow"
+  <body class="min-h-screen <%= BulletTrain::Themes::Light.background || "bg-gradient-to-br from-secondary-200 to-primary-400 dark:from-primary-900 dark:to-primary-600" %> text-slate-700 text-sm font-normal dark:text-slate-300">
+    <div class="md:p-5 main-container-padding">
+      <div class="h-screen md:h-auto md:rounded-lg flex shadow main-container"
         data-controller="mobile-menu"
         data-mobile-menu-hidden-class="hidden"
       >
@@ -308,7 +308,7 @@
               data-transition-leave-start="translate-x-0"
               data-transition-leave-end="-translate-x-full"
 
-              class="relative flex-1 flex flex-col max-w-xs w-full pb-4 bg-800-gradient shadow-xl"
+              class="hidden relative flex-1 flex flex-col max-w-xs w-full pb-4 bg-gradient-to-b from-primary-700 to-primary-800 dark:from-slate-700 dark:to-slate-800 shadow-xl"
             >
               <%= menu %>
             </div>


### PR DESCRIPTION
## Details

After the change to Tailwind default colors, the documentation's styling needing updating so I just recycled the styles we already had in these files:

1. `bullet_train-themes-light/app/views/themes/light/layouts/_account.html.erb`
2. `bullet_train-themes-light/app/views/themes/light/menu/_mobile.html.erb`

## Before
### Main Page
![image](https://user-images.githubusercontent.com/10546292/223650108-5354d368-918a-465f-9e8f-f044a2526735.png)

### Mobile Menu
![image](https://user-images.githubusercontent.com/10546292/223650157-01af3f4e-656a-489d-8092-516c3a457080.png)

## After
### Main Page
![image](https://user-images.githubusercontent.com/10546292/223649818-f57065a2-e7d5-40e6-a730-f3c7f8b47fff.png)

### Mobile Menu
![image](https://user-images.githubusercontent.com/10546292/223649903-de7bdd4b-a0f2-42a9-a53a-e6b7077e637d.png)
