### PR TITLE
Use parent_association setting rather than hardcoded team

### DIFF
--- a/bullet_train-outgoing_webhooks/app/controllers/api/v1/webhooks/outgoing/endpoints_controller.rb
+++ b/bullet_train-outgoing_webhooks/app/controllers/api/v1/webhooks/outgoing/endpoints_controller.rb
@@ -1,5 +1,7 @@
 class Api::V1::Webhooks::Outgoing::EndpointsController < Api::V1::ApplicationController
-  account_load_and_authorize_resource :endpoint, through: :team, through_association: :webhooks_outgoing_endpoints
+  account_load_and_authorize_resource :endpoint,
+    through: BulletTrain::OutgoingWebhooks.parent_association,
+    through_association: :webhooks_outgoing_endpoints
 
   # GET /api/v1/teams/:team_id/webhooks/outgoing/endpoints
   def index

--- a/bullet_train-outgoing_webhooks/app/controllers/api/v1/webhooks/outgoing/events_controller.rb
+++ b/bullet_train-outgoing_webhooks/app/controllers/api/v1/webhooks/outgoing/events_controller.rb
@@ -1,5 +1,7 @@
 class Api::V1::Webhooks::Outgoing::EventsController < Api::V1::ApplicationController
-  account_load_and_authorize_resource :event, through: :team, through_association: :webhooks_outgoing_events
+  account_load_and_authorize_resource :event,
+    through: BulletTrain::OutgoingWebhooks.parent_association,
+    through_association: :webhooks_outgoing_events
 
   # GET /api/v1/teams/:team_id/webhooks/outgoing/events
   def index

--- a/bullet_train-outgoing_webhooks/app/views/api/v1/webhooks/outgoing/endpoints/_endpoint.json.jbuilder
+++ b/bullet_train-outgoing_webhooks/app/views/api/v1/webhooks/outgoing/endpoints/_endpoint.json.jbuilder
@@ -1,6 +1,6 @@
 json.extract! endpoint,
   :id,
-  :team_id,
+  BulletTrain::OutgoingWebhooks.parent_association.to_s.foreign_key.to_sym,
   :url,
   :name,
   :event_type_ids,


### PR DESCRIPTION
Required to support apps that use an endpoint parent other than team