### PR TITLE
Ruby 3.2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ruby: circleci/ruby@0.1.2
+  ruby: circleci/ruby@2.0.0
   node: circleci/node@5.1.0
   browser-tools: circleci/browser-tools@1.4.1
 aliases:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,5 @@
 version: 2.1
 orbs:
-  ruby: circleci/ruby@0.1.2
   node: circleci/node@5.1.0
   browser-tools: circleci/browser-tools@1.4.1
 aliases:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
   browser-tools: circleci/browser-tools@1.4.1
 aliases:
   - &ruby_node_browsers_docker_image
-      - image: cimg/ruby:3.2.0-browsers
+      - image: cimg/ruby:3.2.1-browsers
         environment:
           PGHOST: localhost
           PGUSER: untitled_application

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ruby: circleci/ruby@2.0.0
+  ruby: circleci/ruby@0.1.2
   node: circleci/node@5.1.0
   browser-tools: circleci/browser-tools@1.4.1
 aliases:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,7 @@ jobs:
       - browser-tools/install-browser-tools:
           firefox-version: 108.0.1
 
+      # TODO: This is a workaround to get `git clone` working, but it shouldn't be here.
       # https://github.com/CircleCI-Public/browser-tools-orb/issues/62
       - run:
           command: rm LICENSE.chromedriver
@@ -114,6 +115,11 @@ jobs:
           path: ~/project
       - browser-tools/install-browser-tools:
           firefox-version: 108.0.1
+
+      # TODO: This is a workaround to get `git clone` working, but it shouldn't be here.
+      # https://github.com/CircleCI-Public/browser-tools-orb/issues/62
+      - run:
+          command: rm LICENSE.chromedriver
 
       - run: ../../bin/checkout-and-link-starter-repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,6 @@
 version: 2.1
 orbs:
+  ruby: circleci/ruby@0.1.2
   node: circleci/node@5.1.0
   browser-tools: circleci/browser-tools@1.4.1
 aliases:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,10 @@ jobs:
       - browser-tools/install-browser-tools:
           firefox-version: 108.0.1
 
+      # https://github.com/CircleCI-Public/browser-tools-orb/issues/62
+      - run:
+          command: rm LICENSE.chromedriver
+
       - run: ../../bin/checkout-and-link-starter-repo
 
       - ruby/install-deps:

--- a/.circleci/matching_branch_check
+++ b/.circleci/matching_branch_check
@@ -1,13 +1,13 @@
 # Default to the main branch if we don't find a matching branch on the starter repository.
-# STARTER_REPO_BRANCH="main"
-# BRANCH_NAMES=$(curl -H "Accept: application.vnd.github+json" https://api.github.com/repos/$CIRCLE_USERNAME/bullet_train/branches | jq -r '.[].name')
-#
-# for BRANCH in $BRANCH_NAMES; do
-#   if [ ${BRANCH} == $CIRCLE_BRANCH ]; then
-#     STARTER_REPO_BRANCH=$BRANCH
-#     break
-#   fi
-# done
-#
-# echo "Cloning from ${STARTER_REPO_BRANCH}..."
-# git clone -b $STARTER_REPO_BRANCH https://github.com/$CIRCLE_USERNAME/bullet_train.git tmp/starter
+STARTER_REPO_BRANCH="main"
+BRANCH_NAMES=$(curl -H "Accept: application.vnd.github+json" https://api.github.com/repos/$CIRCLE_USERNAME/bullet_train/branches | jq -r '.[].name')
+
+for BRANCH in $BRANCH_NAMES; do
+  if [ ${BRANCH} == $CIRCLE_BRANCH ]; then
+    STARTER_REPO_BRANCH=$BRANCH
+    break
+  fi
+done
+
+echo "Cloning from ${STARTER_REPO_BRANCH}..."
+git clone -b $STARTER_REPO_BRANCH https://github.com/$CIRCLE_USERNAME/bullet_train.git tmp/starter

--- a/.circleci/matching_branch_check
+++ b/.circleci/matching_branch_check
@@ -1,13 +1,13 @@
 # Default to the main branch if we don't find a matching branch on the starter repository.
-STARTER_REPO_BRANCH="main"
-BRANCH_NAMES=$(curl -H "Accept: application.vnd.github+json" https://api.github.com/repos/$CIRCLE_USERNAME/bullet_train/branches | jq -r '.[].name')
-
-for BRANCH in $BRANCH_NAMES; do
-  if [ ${BRANCH} == $CIRCLE_BRANCH ]; then
-    STARTER_REPO_BRANCH=$BRANCH
-    break
-  fi
-done
-
-echo "Cloning from ${STARTER_REPO_BRANCH}..."
-git clone -b $STARTER_REPO_BRANCH https://github.com/$CIRCLE_USERNAME/bullet_train.git tmp/starter
+# STARTER_REPO_BRANCH="main"
+# BRANCH_NAMES=$(curl -H "Accept: application.vnd.github+json" https://api.github.com/repos/$CIRCLE_USERNAME/bullet_train/branches | jq -r '.[].name')
+#
+# for BRANCH in $BRANCH_NAMES; do
+#   if [ ${BRANCH} == $CIRCLE_BRANCH ]; then
+#     STARTER_REPO_BRANCH=$BRANCH
+#     break
+#   fi
+# done
+#
+# echo "Cloning from ${STARTER_REPO_BRANCH}..."
+# git clone -b $STARTER_REPO_BRANCH https://github.com/$CIRCLE_USERNAME/bullet_train.git tmp/starter

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.2.0"
+ruby "3.2.1"
 
 gem "standard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ DEPENDENCIES
   standard
 
 RUBY VERSION
-   ruby 3.2.0p0
+   ruby 3.2.1p31
 
 BUNDLED WITH
    2.3.8

--- a/bin/checkout-and-link-starter-repo
+++ b/bin/checkout-and-link-starter-repo
@@ -6,7 +6,7 @@ STARTER_REPO_BRANCH="main"
 # Look for a matching branch on the starter repository when running tests on CircleCI.
 CI_BRANCH=$CIRCLE_BRANCH
 if [[ -v CI_BRANCH ]]; then
-  BRANCH_RESPONSE=$(curl --head -H "Accept: application.vnd.github+json" https://api.github.com/repos/bullet-train-co/bullet_train/branches/$CI_BRANCH)
+  BRANCH_RESPONSE=$(curl --head -H "Accept: application.vnd.github+json" https://api.github.com/repos/$CIRCLE_USERNAME/bullet_train/branches/$CI_BRANCH)
 
   if echo $BRANCH_RESPONSE | grep "200"; then
     STARTER_REPO_BRANCH=$CI_BRANCH
@@ -14,7 +14,7 @@ if [[ -v CI_BRANCH ]]; then
 fi
 
 echo "Cloning from ${STARTER_REPO_BRANCH}..."
-git clone -b $STARTER_REPO_BRANCH --depth 1 https://github.com/bullet-train-co/bullet_train.git bt
+git clone -b $STARTER_REPO_BRANCH --depth 1 https://github.com/$CIRCLE_USERNAME/bullet_train.git bt
 
 packages=(
   "bullet_train"

--- a/bin/checkout-and-link-starter-repo
+++ b/bin/checkout-and-link-starter-repo
@@ -41,9 +41,9 @@ for package in "${packages[@]}"
 do
   :
   echo "$PWD"
-  grep -v "gem \"$package\"" Gemfile > Gemfile.tmp
-  mv Gemfile.tmp Gemfile
-  echo "gem \"$package\", path: \"../../../$package\"" >> Gemfile
+  grep -v "gem \"$package\"" ./bt/Gemfile > ./bt/Gemfile.tmp
+  mv ./bt/Gemfile.tmp ./bt/Gemfile
+  echo "gem \"$package\", path: \"../../../$package\"" >> bt/Gemfile
 done
 
 updates="${packages[@]}"

--- a/bin/checkout-and-link-starter-repo
+++ b/bin/checkout-and-link-starter-repo
@@ -14,7 +14,7 @@ if [[ -v CI_BRANCH ]]; then
 fi
 
 echo "Cloning from ${STARTER_REPO_BRANCH}..."
-git clone -b $STARTER_REPO_BRANCH --depth 1 https://github.com/$CIRCLE_USERNAME/bullet_train.git bt
+git clone -b $STARTER_REPO_BRANCH --depth 1 https://github.com/$CIRCLE_USERNAME/bullet_train.git .
 
 packages=(
   "bullet_train"
@@ -40,10 +40,10 @@ packages=(
 for package in "${packages[@]}"
 do
   :
-  grep -v "gem \"$package\"" ./bt/Gemfile > ./bt/Gemfile.tmp
-  mv ./bt/Gemfile.tmp ./bt/Gemfile
-  echo "gem \"$package\", path: \"../../../$package\"" >> bt/Gemfile
+  grep -v "gem \"$package\"" Gemfile > Gemfile.tmp
+  mv Gemfile.tmp Gemfile
+  echo "gem \"$package\", path: \"../../$package\"" >> Gemfile
 done
 
 updates="${packages[@]}"
-( cd bt && bundle lock --update $updates )
+bundle lock --update $updates

--- a/bin/checkout-and-link-starter-repo
+++ b/bin/checkout-and-link-starter-repo
@@ -40,9 +40,10 @@ packages=(
 for package in "${packages[@]}"
 do
   :
-  grep -v "gem \"$package\"" tmp/starter/bt/Gemfile > tmp/starter/bt/Gemfile.tmp
-  mv tmp/stater/bt/Gemfile.tmp tmp/starter/bt/Gemfile
-  echo "gem \"$package\", path: \"../../../$package\"" >> tmp/starter/bt/Gemfile
+  echo "$PWD"
+  grep -v "gem \"$package\"" bt/Gemfile > bt/Gemfile.tmp
+  mv bt/Gemfile.tmp bt/Gemfile
+  echo "gem \"$package\", path: \"../../../$package\"" >> bt/Gemfile
 done
 
 updates="${packages[@]}"

--- a/bin/checkout-and-link-starter-repo
+++ b/bin/checkout-and-link-starter-repo
@@ -41,7 +41,7 @@ for package in "${packages[@]}"
 do
   :
   grep -v "gem \"$package\"" tmp/starter/Gemfile > tmp/starter/Gemfile.tmp
-  mv temp/starter/Gemfile.tmp tmp/starter/Gemfile
+  mv tmp/starter/Gemfile.tmp tmp/starter/Gemfile
   echo "gem \"$package\", path: \"../../$package\"" >> tmp/starter/Gemfile
 done
 

--- a/bin/checkout-and-link-starter-repo
+++ b/bin/checkout-and-link-starter-repo
@@ -14,7 +14,7 @@ if [[ -v CI_BRANCH ]]; then
 fi
 
 echo "Cloning from ${STARTER_REPO_BRANCH}..."
-git clone -b $STARTER_REPO_BRANCH --depth 1 https://github.com/bullet-train-co/bullet_train.git
+git clone -b $STARTER_REPO_BRANCH --depth 1 https://github.com/bullet-train-co/bullet_train.git tmp/starter
 
 packages=(
   "bullet_train"
@@ -40,9 +40,9 @@ packages=(
 for package in "${packages[@]}"
 do
   :
-  grep -v "gem \"$package\"" Gemfile > Gemfile.tmp
-  mv Gemfile.tmp Gemfile
-  echo "gem \"$package\", path: \"../../$package\"" >> Gemfile
+  grep -v "gem \"$package\"" tmp/starter/Gemfile > tmp/starter/Gemfile.tmp
+  mv temp/starter/Gemfile.tmp tmp/starter/Gemfile
+  echo "gem \"$package\", path: \"../../$package\"" >> tmp/starter/Gemfile
 done
 
 updates="${packages[@]}"

--- a/bin/checkout-and-link-starter-repo
+++ b/bin/checkout-and-link-starter-repo
@@ -14,7 +14,7 @@ if [[ -v CI_BRANCH ]]; then
 fi
 
 echo "Cloning from ${STARTER_REPO_BRANCH}..."
-git clone -b $STARTER_REPO_BRANCH --depth 1 https://github.com/bullet-train-co/bullet_train.git bt
+git clone -b $STARTER_REPO_BRANCH --depth 1 https://github.com/$CIRCLE_USERNAME/bullet_train.git bt
 
 packages=(
   "bullet_train"

--- a/bin/checkout-and-link-starter-repo
+++ b/bin/checkout-and-link-starter-repo
@@ -14,7 +14,7 @@ if [[ -v CI_BRANCH ]]; then
 fi
 
 echo "Cloning from ${STARTER_REPO_BRANCH}..."
-git clone -b $STARTER_REPO_BRANCH --depth 1 https://github.com/bullet-train-co/bullet_train.git tmp/starter
+git clone -b $STARTER_REPO_BRANCH --depth 1 https://github.com/bullet-train-co/bullet_train.git tmp
 
 packages=(
   "bullet_train"
@@ -40,9 +40,9 @@ packages=(
 for package in "${packages[@]}"
 do
   :
-  grep -v "gem \"$package\"" tmp/starter/Gemfile > tmp/starter/Gemfile.tmp
-  mv tmp/starter/Gemfile.tmp tmp/starter/Gemfile
-  echo "gem \"$package\", path: \"../../$package\"" >> tmp/starter/Gemfile
+  grep -v "gem \"$package\"" tmp/bullet_train/Gemfile > tmp/bullet_train/Gemfile.tmp
+  mv tmp/bullet_train/Gemfile.tmp tmp/bullet_train/Gemfile
+  echo "gem \"$package\", path: \"../../$package\"" >> tmp/bullet_train/Gemfile
 done
 
 updates="${packages[@]}"

--- a/bin/checkout-and-link-starter-repo
+++ b/bin/checkout-and-link-starter-repo
@@ -14,7 +14,7 @@ if [[ -v CI_BRANCH ]]; then
 fi
 
 echo "Cloning from ${STARTER_REPO_BRANCH}..."
-git clone -b $STARTER_REPO_BRANCH --depth 1 https://github.com/$CIRCLE_USERNAME/bullet_train.git bt
+git clone -b $STARTER_REPO_BRANCH --depth 1 https://github.com/bullet-train-co/bullet_train.git bt
 
 packages=(
   "bullet_train"
@@ -40,7 +40,6 @@ packages=(
 for package in "${packages[@]}"
 do
   :
-  echo "$PWD"
   grep -v "gem \"$package\"" ./bt/Gemfile > ./bt/Gemfile.tmp
   mv ./bt/Gemfile.tmp ./bt/Gemfile
   echo "gem \"$package\", path: \"../../../$package\"" >> bt/Gemfile

--- a/bin/checkout-and-link-starter-repo
+++ b/bin/checkout-and-link-starter-repo
@@ -46,5 +46,6 @@ do
   echo "gem \"$package\", path: \"../../../$package\"" >> bt/Gemfile
 done
 
+cd bt
 updates="${packages[@]}"
 bundle lock --update $updates

--- a/bin/checkout-and-link-starter-repo
+++ b/bin/checkout-and-link-starter-repo
@@ -41,9 +41,9 @@ for package in "${packages[@]}"
 do
   :
   echo "$PWD"
-  grep -v "gem \"$package\"" bt/Gemfile > bt/Gemfile.tmp
-  mv bt/Gemfile.tmp bt/Gemfile
-  echo "gem \"$package\", path: \"../../../$package\"" >> bt/Gemfile
+  grep -v "gem \"$package\"" Gemfile > Gemfile.tmp
+  mv Gemfile.tmp Gemfile
+  echo "gem \"$package\", path: \"../../../$package\"" >> Gemfile
 done
 
 updates="${packages[@]}"

--- a/bin/checkout-and-link-starter-repo
+++ b/bin/checkout-and-link-starter-repo
@@ -14,7 +14,7 @@ if [[ -v CI_BRANCH ]]; then
 fi
 
 echo "Cloning from ${STARTER_REPO_BRANCH}..."
-git clone -b $STARTER_REPO_BRANCH --depth 1 https://github.com/bullet-train-co/bullet_train.git tmp
+git clone -b $STARTER_REPO_BRANCH --depth 1 https://github.com/bullet-train-co/bullet_train.git bt
 
 packages=(
   "bullet_train"
@@ -40,9 +40,9 @@ packages=(
 for package in "${packages[@]}"
 do
   :
-  grep -v "gem \"$package\"" tmp/bullet_train/Gemfile > tmp/bullet_train/Gemfile.tmp
-  mv tmp/bullet_train/Gemfile.tmp tmp/bullet_train/Gemfile
-  echo "gem \"$package\", path: \"../../$package\"" >> tmp/bullet_train/Gemfile
+  grep -v "gem \"$package\"" tmp/starter/bt/Gemfile > tmp/starter/bt/Gemfile.tmp
+  mv tmp/stater/bt/Gemfile.tmp tmp/starter/bt/Gemfile
+  echo "gem \"$package\", path: \"../../../$package\"" >> tmp/starter/bt/Gemfile
 done
 
 updates="${packages[@]}"

--- a/bin/checkout-and-link-starter-repo
+++ b/bin/checkout-and-link-starter-repo
@@ -14,7 +14,7 @@ if [[ -v CI_BRANCH ]]; then
 fi
 
 echo "Cloning from ${STARTER_REPO_BRANCH}..."
-git clone -b $STARTER_REPO_BRANCH --depth 1 https://github.com/bullet-train-co/bullet_train.git .
+git clone -b $STARTER_REPO_BRANCH --depth 1 https://github.com/bullet-train-co/bullet_train.git
 
 packages=(
   "bullet_train"

--- a/bin/checkout-and-link-starter-repo
+++ b/bin/checkout-and-link-starter-repo
@@ -46,6 +46,5 @@ do
   echo "gem \"$package\", path: \"../../../$package\"" >> bt/Gemfile
 done
 
-cd bt
 updates="${packages[@]}"
-bundle lock --update $updates
+( cd bt && bundle lock --update $updates )


### PR DESCRIPTION
Joint PR
- https://github.com/bullet-train-co/bullet_train/pull/690

## Details
There was a CI bug which we fixed by merging https://github.com/bullet-train-co/bullet_train/pull/649/files in the starter repository.

However, even though we have `- checkout` right after `steps:` here in the CI config file, it looks like this doesn't quite work when updating to the new CI image, `cimg/ruby:3.2.1-browsers`.

The problem is that there is a file in `tmp/starter`, our working directory. The file is `LICENSE.chromedriver`, and we can't use `git clone` until the working directory is empty.

## The fix
I just simply deleted the file before cloning. (Check comment [here](https://github.com/CircleCI-Public/browser-tools-orb/issues/62#issuecomment-1377819007))

## Checking branch by username
Since people who submit PRs to the starter repository have their own forks, I set things up so the matching branches are run against the user's repository. You can see here that the [matching PR](https://github.com/bullet-train-co/bullet_train/pull/690) I have for this PR is being cloned after the fix:

![image](https://user-images.githubusercontent.com/10546292/224245268-52deb1fa-fb17-4724-b484-2c4d5212da6d.png)

## Other CI PRs

@kaspth I know you've been working on CI stuff recently so I thought I'd tag you in case we should set things up differently.

My brain's a bit fried right now, so I'll give it some time and look over it again soon.