### PR TITLE
Remove empty navigation_test.rb files

### DIFF
--- a/bullet_train-api/test/integration/navigation_test.rb
+++ b/bullet_train-api/test/integration/navigation_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class NavigationTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/bullet_train-fields/test/integration/navigation_test.rb
+++ b/bullet_train-fields/test/integration/navigation_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class NavigationTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/bullet_train-has_uuid/test/integration/navigation_test.rb
+++ b/bullet_train-has_uuid/test/integration/navigation_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class NavigationTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/bullet_train-incoming_webhooks/test/integration/navigation_test.rb
+++ b/bullet_train-incoming_webhooks/test/integration/navigation_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class NavigationTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/bullet_train-integrations-stripe/test/integration/navigation_test.rb
+++ b/bullet_train-integrations-stripe/test/integration/navigation_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class NavigationTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/bullet_train-integrations/test/integration/navigation_test.rb
+++ b/bullet_train-integrations/test/integration/navigation_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class NavigationTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/bullet_train-obfuscates_id/test/integration/navigation_test.rb
+++ b/bullet_train-obfuscates_id/test/integration/navigation_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class NavigationTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/bullet_train-outgoing_webhooks/test/integration/navigation_test.rb
+++ b/bullet_train-outgoing_webhooks/test/integration/navigation_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class NavigationTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/bullet_train-scope_questions/test/integration/navigation_test.rb
+++ b/bullet_train-scope_questions/test/integration/navigation_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class NavigationTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/bullet_train-sortable/test/integration/navigation_test.rb
+++ b/bullet_train-sortable/test/integration/navigation_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class NavigationTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/bullet_train-super_load_and_authorize_resource/test/integration/navigation_test.rb
+++ b/bullet_train-super_load_and_authorize_resource/test/integration/navigation_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class NavigationTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/bullet_train-super_scaffolding/test/integration/navigation_test.rb
+++ b/bullet_train-super_scaffolding/test/integration/navigation_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class NavigationTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/bullet_train-themes-light/test/integration/navigation_test.rb
+++ b/bullet_train-themes-light/test/integration/navigation_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class NavigationTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/bullet_train-themes-tailwind_css/test/integration/navigation_test.rb
+++ b/bullet_train-themes-tailwind_css/test/integration/navigation_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class NavigationTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/bullet_train-themes/test/integration/navigation_test.rb
+++ b/bullet_train-themes/test/integration/navigation_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class NavigationTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/bullet_train/test/integration/navigation_test.rb
+++ b/bullet_train/test/integration/navigation_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class NavigationTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end


### PR DESCRIPTION
Just clutters up the test directory since we're not using them.