### PR TITLE
Showcase page with notices on its preview

### DIFF
--- a/bullet_train-themes-light/app/views/showcase/previews/partials/_notices.html.erb
+++ b/bullet_train-themes-light/app/views/showcase/previews/partials/_notices.html.erb
@@ -1,16 +1,6 @@
-<% flash.now[:notice] = "Success Message" %>
-
 <% showcase.sample "Basic" do %>
+  <% flash.now[:notice] = "Success Notice" %>
+  <% flash.now[:error] = "Error Notice" %>
+
   <%= render "shared/notices" %>
 <% end %>
-
-<% showcase.sample "In a page" do %>
-  <%= render "shared/page", title: "Page Title" do |page| %>
-    <% page.body.render "shared/box" do |box| %>
-      <% box.title "Box Title" %>
-      <% box.description "Description" %>
-      <% box.body "Lorem ipsum dolor sit amet…" %>
-    <% end %>
-  <% end %>
-<% end %>
-

--- a/bullet_train-themes-light/app/views/showcase/previews/partials/_page.html.erb
+++ b/bullet_train-themes-light/app/views/showcase/previews/partials/_page.html.erb
@@ -1,15 +1,13 @@
 <% showcase.description do %>
   <p>Partial to wrap an app page, like a #show view.</p>
 
-  <p>It's composed of three content sections:</p>
+  <p class="py-4">It's composed of three content sections:</p>
 
-  <p>
-    <ol>
-      <li>render "shared/title", with the title and actions provided.</li>
-      <li>render "shared/notices", for any account level notices.</li>
-      <li>Outputs the passed body.</li>
-    </ol>
-  </p>
+  <ol class="list-decimal list-inside">
+    <li>render "shared/title", with the title and actions provided.</li>
+    <li>render "shared/notices", for any account level notices.</li>
+    <li>Outputs the passed body.</li>
+  </ol>
 <% end %>
 
 <% showcase.sample "Basic" do %>
@@ -31,6 +29,12 @@
       <% box.body "Lorem ipsum dolor sit amet…" %>
     <% end %>
   <% end %>
+<% end %>
+
+<% showcase.sample "With notices" do %>
+  <% flash.now[:notice] = "Success Notice" %>
+  <% flash.now[:error] = "Error Notice" %>
+  <%= render "shared/page", title: "Title" %>
 <% end %>
 
 <% showcase.options.context :nice_partials do |o| %>


### PR DESCRIPTION
Our page showcase says we render "shared/notices" but we don't demo that there — instead it's demoed on the notices preview.

Seems like it's clearer on the page preview, so I'm moving it there.

I've also spruced up the description HTML to look a little nicer.