### PR TITLE
Use `attribute` method in `Invitation` base

### DIFF
--- a/bullet_train/app/models/concerns/invitations/base.rb
+++ b/bullet_train/app/models/concerns/invitations/base.rb
@@ -11,9 +11,10 @@ module Invitations::Base
 
     validates :email, presence: true
 
-    before_create :generate_uuid
     after_create :set_added_by_membership
     after_create :send_invitation_email
+
+    attribute :uuid, default: -> { SecureRandom.hex }
   end
 
   def set_added_by_membership
@@ -22,10 +23,6 @@ module Invitations::Base
 
   def send_invitation_email
     UserMailer.invited(uuid).deliver_later
-  end
-
-  def generate_uuid
-    self.uuid = SecureRandom.hex
   end
 
   def accept_for(user)


### PR DESCRIPTION
Closes #192.

## Details
I searched around for different attributes to change over, but there was a lot of logic that wasn't compatible with this method.

## `attribute` and undefined variables/methods
### Variables
For instance, I tried to write the following in `bullet_train-outgoing_webhooks/app/models/concerns/webhooks/outgoing/delivery_attempt_support.rb`:

```ruby
attribute :attempt_number, default: -> { delivery.attempt_count + 1 }

# I wanted to replace this code:
before_create do
  self.attempt_number = delivery.attempt_count + 1
end
```

However, at this point in the initialization process `delivery` was undefined, so I got an error.

### Methods

I also tried just simply using a method defined in the same file. For example, I wrote the following in `bullet_train-outgoing_webhooks/app/models/concerns/webhooks/outgoing/event_support.rb`:

```ruby
attribute :payload, default: -> { generate_payload }

# I wanted to replace this `before_create` callback we already have:
before_create do
  self.payload = generate_payload
end
```

Here, `generate_payload` was also undefined.

## Works with Ruby/Rails internals
I had no problem setting default values with methods like `SecureRandom.hex`, and the example from the article in #192 uses `Time.zone`, so I think we're limited to values like this when trying to set the default value for `attribute`.

## Primarily for type-casting
Reading over the docs, it looks like `attribute` is useful for overriding the attribute's type if necessary, or if you want to give it a custom data type (see "Creating Custom Types" in the [docs](https://github.com/rails/rails/blob/7c70791470fc517deb7c640bead9f1b47efb5539/activerecord/lib/active_record/attributes.rb#L212)).

## Other attributes I tried changing

```ruby
# In bullet_train-outgoing_webhooks/app/models/webhooks/outgoing/event_type.rb
attribute :data, default: -> { process_data }

def process_data
  YAML.load_file("config/models/webhooks/outgoing/event_types.yml").map do |topic, events|
    events.map { |event| (event == "crud") ? ["created", "updated", "deleted"] : event }.flatten.map { |event| {id: "#{topic}.#{event}"} }
  end.flatten
end
```

This also gave me an undefined error for `process_data`.

## Action Models
I didn't see anything in the base Action Models files, but I'll try generating some files over there and see if we can use `attributes`. I'll submit a new pull request over there if I find anything.