### PR TITLE
Ensure `sort_order` is Super Scaffolded when using `--sortable`

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -1523,6 +1523,12 @@ class Scaffolding::Transformer
       unless cli_options["skip-model"]
         scaffold_add_line_to_file("./app/models/scaffolding/completely_concrete/tangible_thing.rb", "def collection\n  absolutely_abstract_creative_concept.completely_concrete_tangible_things\nend\n\n", METHODS_HOOK, prepend: true)
         scaffold_add_line_to_file("./app/models/scaffolding/completely_concrete/tangible_thing.rb", "include Sortable\n", CONCERNS_HOOK, prepend: true)
+
+        migration = Dir.glob("db/migrate/*").last
+        migration_lines = File.open(migration).readlines
+        parent_line_idx = Scaffolding::FileManipulator.find(migration_lines, "t.references :#{parent.downcase}")
+        new_lines = Scaffolding::BlockManipulator.insert_line("t.integer :sort_order", parent_line_idx, migration_lines, false)
+        Scaffolding::FileManipulator.write(migration, new_lines)
       end
 
       unless cli_options["skip-table"]

--- a/bullet_train/docs/super-scaffolding/sortable.md
+++ b/bullet_train/docs/super-scaffolding/sortable.md
@@ -12,7 +12,7 @@ The `--sortable` option:
 
 1. Wraps the table's body in a `sortable` Stimulus controller, providing drag-and-drop re-ordering;
 2. Adds a `reorder` action to your resource via `include SortableActions`, triggered automatically on re-order;
-3. Adds a migration to add the `sort_order` column to your model to store the ordering;
+3. Adds a `sort_order` attribute to your model to store the ordering;
 4. Adds a `default_scope` which orders by `sort_order` and auto increments `sort_order` on create via `include Sortable` on the model.
 
 ## Disabling Saving on Re-order


### PR DESCRIPTION
We claim the following in the [sortable docs](https://bullettrain.co/docs/super-scaffolding/sortable):

```
The --sortable option:
1. ...
2. ...
3. Adds a migration to add the sort_order column to your model to store the ordering;
```

However, the transformer only had the following code for the `--sortable` flag:
```ruby
if cli_options["sortable"]
  unless cli_options["skip-model"]
    scaffold_add_line_to_file("./app/models/scaffolding/completely_concrete/tangible_thing.rb", "def collection\n  absolutely_abstract_creative_concept.completely_concrete_tangible_things\nend\n\n", METHODS_HOOK, prepend: true)
    scaffold_add_line_to_file("./app/models/scaffolding/completely_concrete/tangible_thing.rb", "include Sortable\n", CONCERNS_HOOK, prepend: true)
  end

  unless cli_options["skip-table"]
    scaffold_replace_line_in_file("./app/views/account/scaffolding/completely_concrete/tangible_things/_index.html.erb", transform_string("<tbody data-controller=\"sortable\" data-sortable-reorder-path-value=\"<%= url_for [:reorder, :account, context, collection] %>\">"), "<tbody>")
  end

  unless cli_options["skip-controller"]
    scaffold_add_line_to_file("./app/controllers/account/scaffolding/completely_concrete/tangible_things_controller.rb", "include SortableActions\n", "Account::ApplicationController", increase_indent: true)
  end
end
```

The code in this pull request ensures that we add `sort_order` to the latest migration (instead of creating a new migration altogether) so the sortable logic will work.