### PR TITLE
Ensure first Super Scaffolded attribute has link

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -668,6 +668,18 @@ class Scaffolding::Transformer
       type = parts.join(":")
       boolean_buttons = type == "boolean"
 
+      if first_table_cell && ["trix_editor", "ckeditor", "text_area"].include?(type)
+        puts ""
+        puts "The first attribute of your model cannot be any of the following types:".red
+        puts "1. trix_editor"
+        puts "2. ckeditor"
+        puts "3. text_area"
+        puts ""
+        puts "Please ensure you have another attribute type as the first attribute for your model and try again."
+
+        exit
+      end
+
       # extract any options they passed in with the field.
       # will extract options declared with either [] or {}.
       type, attribute_options = type.scan(/^(.*){(.*)}/).first || type


### PR DESCRIPTION
Closes #198.

In the Transformer, we add a link for the first attribute here:

https://github.com/bullet-train-co/bullet_train-core/blob/b79f9d926615b7d34aabbf0259e45012a4e104af/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb#L994-L996

However, we skip this logic if `cli_options[skip-table]` is `true`:
https://github.com/bullet-train-co/bullet_train-core/blob/b79f9d926615b7d34aabbf0259e45012a4e104af/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb#L969

We set `cli_options[skip-table]` to `true` here, so `text_area` and other related attributes don't get scaffolded with a link:

https://github.com/bullet-train-co/bullet_train-core/blob/b79f9d926615b7d34aabbf0259e45012a4e104af/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb#L785-L788

This means we get the index page like the screenshot in #198 and the record can't be accessed via a link.

In this PR, I added this hook to prevent developers from Super Scaffolding if the first attribute is a text-related attribute.