### PR TITLE
`bin/hack --link github`

### DIFF
--- a/bullet_train/lib/tasks/bullet_train_tasks.rake
+++ b/bullet_train/lib/tasks/bullet_train_tasks.rake
@@ -229,7 +229,7 @@ namespace :bullet_train do
   def set_core_gems(flag, link_flag_value, framework_packages)
     packages = framework_packages.keys
     gemfile_lines = File.readlines("./Gemfile")
-    version_regexp = /[\d|\.]/
+    version_regexp = /[\d|.]/
 
     packages.each do |package|
       original_path = "gem \"#{package}\""

--- a/bullet_train/lib/tasks/bullet_train_tasks.rake
+++ b/bullet_train/lib/tasks/bullet_train_tasks.rake
@@ -122,7 +122,7 @@ namespace :bullet_train do
             link_flag_value = process[:values].pop
             set_core_gems(process[:flag], link_flag_value, framework_packages)
 
-            # Bundler will throw an error if we try to `bundle install` right after adding the gems to the Gemfile.
+            # Bundler will throw an error if we try to `bundle install` right after adding the GitHub link to the Gemfile.
             if link_flag_value == "github"
               puts ""
               puts "Now you can run `bundle install` to check out the public repositories on GitHub."

--- a/bullet_train/lib/tasks/bullet_train_tasks.rake
+++ b/bullet_train/lib/tasks/bullet_train_tasks.rake
@@ -112,15 +112,23 @@ namespace :bullet_train do
             puts ""
             puts "bin/hack: " + "Clone bullet_train-core and link up gems (will only link up gems if already cloned).".blue
             puts "bin/hack --link: " + "Link all of your Bullet Train gems to `local/bullet_train-core`.".blue
+            puts "bin/hack --link github: " + "Link all of your Bullet Train gems to the public repositories on GitHub".blue
             puts "bin/hack --link (version-number): " + "Link all of your Bullet Train gems to the version number passed.".blue
             puts "bin/hack --reset: " + "Resets all of your gems to their original definition.".blue
             puts "bin/hack --watch-js: " + "Watches for any changes in JavaScript files gems that have an npm package.".blue
             puts "bin/hack --clean-js: " + "Resets all of your npm packages from `local/bullet_train-core` to their original definition.".blue
             exit
           when "--link", "--reset"
-            version = process[:values].pop
-            set_core_gems(process[:flag], version, framework_packages)
-            stream "bundle install"
+            link_flag_value = process[:values].pop
+            set_core_gems(process[:flag], link_flag_value, framework_packages)
+
+            # Bundler will throw an error if we try to `bundle install` right after adding the gems to the Gemfile.
+            if link_flag_value == "github"
+              puts ""
+              puts "Now you can run `bundle install` to check out the public repositories on GitHub."
+            else
+              stream "bundle install"
+            end
           when "--watch-js", "--clean-js"
             package_name = process[:values].pop
             framework_package = framework_packages.select { |k, v| k.to_s == package_name }
@@ -218,9 +226,10 @@ namespace :bullet_train do
   end
 
   # Pass "--link" or "--reset" as a flag to set the gems.
-  def set_core_gems(flag, version, framework_packages)
+  def set_core_gems(flag, link_flag_value, framework_packages)
     packages = framework_packages.keys
     gemfile_lines = File.readlines("./Gemfile")
+    version_regexp = /[\d|\.]/
 
     packages.each do |package|
       original_path = "gem \"#{package}\""
@@ -241,7 +250,14 @@ namespace :bullet_train do
               puts "We can't do anything with this. Sorry! We'll proceed, but you have to link this package yourself.".red
             elsif `cat Gemfile | grep "gem \\\"#{package}\\\""`.chomp.present?
               puts "#{package} is directly present in the `Gemfile`, so we'll update that line.".green
-              line = version.present? ? "#{line.chomp}, \"#{version}\"\n" : line.gsub(original_path, local_path)
+
+              line = if link_flag_value == "github"
+                "#{line.chomp}, github: 'bullet-train-co/bullet_train-core'\n"
+              elsif link_flag_value&.match?(version_regexp)
+                "#{line.chomp}, \"#{link_flag_value}\"\n"
+              else
+                line.gsub(original_path, local_path)
+              end
             end
           elsif flag == "--reset"
             if line.match?(/bullet_train/)
@@ -258,8 +274,10 @@ namespace :bullet_train do
       if flag == "--link"
         unless match_found
           puts "Could not find #{package}. Adding to the end of the Gemfile.".blue
-          new_lines << if version
-            "#{original_path.chomp}, \"#{version}\"\n"
+          new_lines << if link_flag_value == "github"
+            "#{original_path.chomp}, github: 'bullet-train-co/bullet_train-core'\n"
+          elsif link_flag_value&.match?(version_regexp)
+            "#{original_path.chomp}, \"#{link_flag_value}\"\n"
           else
             "#{local_path}\n"
           end

--- a/bullet_train/lib/tasks/bullet_train_tasks.rake
+++ b/bullet_train/lib/tasks/bullet_train_tasks.rake
@@ -252,7 +252,7 @@ namespace :bullet_train do
               puts "#{package} is directly present in the `Gemfile`, so we'll update that line.".green
 
               line = if link_flag_value == "github"
-                "#{line.chomp}, github: 'bullet-train-co/bullet_train-core'\n"
+                "#{line.chomp}, git: 'http://github.com/bullet-train-co/bullet_train-core.git'\n"
               elsif link_flag_value&.match?(version_regexp)
                 "#{line.chomp}, \"#{link_flag_value}\"\n"
               else
@@ -275,7 +275,7 @@ namespace :bullet_train do
         unless match_found
           puts "Could not find #{package}. Adding to the end of the Gemfile.".blue
           new_lines << if link_flag_value == "github"
-            "#{original_path.chomp}, github: 'bullet-train-co/bullet_train-core'\n"
+            "#{original_path.chomp}, git: 'http://github.com/bullet-train-co/bullet_train-core.git'\n"
           elsif link_flag_value&.match?(version_regexp)
             "#{original_path.chomp}, \"#{link_flag_value}\"\n"
           else


### PR DESCRIPTION
```
bin/hack --link github
```

## Result
```ruby
gem "bullet_train", git: 'http://github.com/bullet-train-co/bullet_train-core.git'
gem "bullet_train-super_scaffolding", git: 'http://github.com/bullet-train-co/bullet_train-core.git'
gem "bullet_train-api", git: 'http://github.com/bullet-train-co/bullet_train-core.git'
gem "bullet_train-outgoing_webhooks", git: 'http://github.com/bullet-train-co/bullet_train-core.git'
gem "bullet_train-incoming_webhooks", git: 'http://github.com/bullet-train-co/bullet_train-core.git'
gem "bullet_train-themes", git: 'http://github.com/bullet-train-co/bullet_train-core.git'
gem "bullet_train-themes-light", git: 'http://github.com/bullet-train-co/bullet_train-core.git'
gem "bullet_train-integrations", git: 'http://github.com/bullet-train-co/bullet_train-core.git'
gem "bullet_train-integrations-stripe", git: 'http://github.com/bullet-train-co/bullet_train-core.git'

# Optional support packages.
gem "bullet_train-sortable", git: 'http://github.com/bullet-train-co/bullet_train-core.git'
gem "bullet_train-scope_questions", git: 'http://github.com/bullet-train-co/bullet_train-core.git'
gem "bullet_train-obfuscates_id", git: 'http://github.com/bullet-train-co/bullet_train-core.git'
...
```

## Can't run `bundle install` inside script
I was getting the following error when the script was trying to run `bundle install`:

```
.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/bundler-2.4.8/lib/bundler/source/git/git_proxy.rb:329:in `allowed_with_path': The git source https://github.com/bullet-train-co/bullet_train-core.git is not yet checked out. Please run `bundle install` before trying to start your application (Bundler::GitError)
```

Because of this, you'll have to run `bundle install` separately right after `bin/hack --link github` in the [main GitHub workflow](https://github.com/bullet-train-co/bullet_train/blob/main/.github/workflows/main.yml).