### PR TITLE
Ensure logged out user is redirected to sign in on `teams#new`

### DIFF
--- a/bullet_train/app/controllers/concerns/account/teams/controller_base.rb
+++ b/bullet_train/app/controllers/concerns/account/teams/controller_base.rb
@@ -9,7 +9,7 @@ module Account::Teams::ControllerBase
 
     prepend_before_action do
       if params["action"] == "new"
-        current_user.current_team = nil
+        current_user&.current_team = nil
       end
     end
 


### PR DESCRIPTION
Closes https://github.com/bullet-train-co/bullet_train/issues/692.

## Details
We have this `prepend_before_action` block in the teams controller base:
```ruby
prepend_before_action do
  if params["action"] == "new"
    current_user.current_team = nil
  end
end
```

However, since this is happening early on in the request process, we were getting the error in the original issue because authorization hadn't actually been checked yet, and `current_user` was `nil`.

After adding the fix, when trying to access `account/teams/new` the app correctly redirects us and shows the following notification.

![Screenshot from 2023-03-20 20-27-12](https://user-images.githubusercontent.com/10546292/226326499-2c2ca879-c5ea-4dcf-8e33-08ef2affcef1.png)
