### PR TITLE
Add localizations for file fields

### DIFF
--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/attributes/_file.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/attributes/_file.erb
@@ -6,7 +6,7 @@
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
     <%= link_to url_for(object.send(attribute)), class: 'button download-file' do %>
       <i class="leading-none mr-2 text-base ti ti-download"></i>
-      <span>Download File</span>
+      <span><%= t("global.file_fields.download") %></span>
     <% end %>
   <% end %>
 <% end %>

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_file_field.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_file_field.html.erb
@@ -15,20 +15,20 @@ other_options ||= {}
         <% if form.object.send(method).attached? %>
           <%= link_to url_for(form.object.send(method)), class: 'button download-file mr-3', data: {'fields--file-field-target': 'downloadFileButton'} do %>
             <i class="leading-none mr-2 text-base ti ti-download"></i>
-            <span>Download Current Document</span>
+            <span><%= t("global.file_fields.download_current") %></span>
           <% end %>
         <% end %>
         <% if form.object.send(method).attached? %>
           <div class="button-alternative cursor-pointer mr-3" data-action="click->fields--file-field#removeFile" data-fields--file-field-target="removeFileButton">
             <i class="leading-none mr-2 text-base ti ti-trash"></i>
-            <span>Remove Current Document</span>
+            <span><%= t("global.file_fields.remove") %></span>
           </div>
         <% end %>
       </div>
       <div class="mt-2">
         <div class="button-alternative cursor-pointer" data-action="click->fields--file-field#uploadFile" data-fields--file-field-target="selectFileButton">
           <i class="leading-none mr-2 text-base ti ti-upload dark:text-white"></i>
-          <span class="dark:text-white">Upload New Document</span>
+          <span class="dark:text-white"><%= t("global.file_fields.upload") %></span>
         </div>
         <div class="mt-2 hidden overflow-hidden text-xs rounded bg-slate-100 shadow-inner relative">
           <div data-fields--file-field-target="progressBar" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="absolute top-0 left-0 whitespace-nowrap overflow-hidden animate-pulse bg-primary-500 dark:bg-slate-800 rounded" role="progressbar" style="width: 0%;">&nbsp;</div>

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_options.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_options.html.erb
@@ -50,7 +50,7 @@ end
             }, class: "focus:ring-blue h-4 w-4 text-blue border-slate-300 rounded" %>
           </div>
           <div class="ml-2.5 text-sm pr-4">
-            <%# TODO: should be localized %>
+            <%= t("global.bulk_select.all") %>
             All
           </div>
         </label>

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_options.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_options.html.erb
@@ -51,7 +51,6 @@ end
           </div>
           <div class="ml-2.5 text-sm pr-4">
             <%= t("global.bulk_select.all") %>
-            All
           </div>
         </label>
       <% end %>

--- a/bullet_train/config/locales/en/base.yml
+++ b/bullet_train/config/locales/en/base.yml
@@ -84,7 +84,7 @@ en:
       download: Download File
       download_current: Download Current Document
       remove: Remove Current Document
-      upload: Upload New Document Man
+      upload: Upload New Document
 
   menus:
     main:

--- a/bullet_train/config/locales/en/base.yml
+++ b/bullet_train/config/locales/en/base.yml
@@ -80,6 +80,11 @@ en:
       timestamp_unavailable: Never
       date: '%m/%d/%Y'
       date_and_time: '%m/%d/%Y %l:%M %p'
+    file_fields:
+      download: Download File
+      download_current: Download Current Document
+      remove: Remove Current Document
+      upload: Upload New Document Man
 
   menus:
     main:

--- a/bullet_train/config/locales/en/base.yml
+++ b/bullet_train/config/locales/en/base.yml
@@ -85,6 +85,8 @@ en:
       download_current: Download Current Document
       remove: Remove Current Document
       upload: Upload New Document
+    bulk_select:
+      all: All
 
   menus:
     main:


### PR DESCRIPTION
Closes #204.

The only file field localization that isn't covered here is `Select Another File`:

https://github.com/bullet-train-co/bullet_train-core/blob/b2c0bd2762286a80bb4bd585df21c9ff56bf504d/bullet_train-fields/app/javascript/controllers/fields/file_field_controller.js#L88

We used [i18n-js](https://github.com/fnando/i18n-js) in the past a while back before the Tailwind repository, so if we  want to implement that again I'd be glad to work on it.