### PR TITLE
Fix Trix Editor styling

### DIFF
--- a/bullet_train-themes-light/app/assets/stylesheets/light/fields/trix_editor.css
+++ b/bullet_train-themes-light/app/assets/stylesheets/light/fields/trix_editor.css
@@ -9,6 +9,22 @@ trix-toolbar {
   }
 }
 
+/* Override Tailwind's preflight styles */
+/* https://github.com/tailwindlabs/tailwindcss/issues/989#issuecomment-506555308 */
+trix-editor ul {
+  list-style-type: disc;
+  padding-left: 2.5rem;
+}
+
+trix-editor ol {
+  list-style-type: decimal;
+  padding-left: 2.5rem;
+}
+
+.trix-button {
+  @apply dark:bg-slate-300 !important;
+}
+
 a[href^="bullettrain://"], span.tribute-reference {
   border-radius: 4px;
   display: inline-block;

--- a/bullet_train-themes-light/app/assets/stylesheets/light/fields/trix_editor.css
+++ b/bullet_train-themes-light/app/assets/stylesheets/light/fields/trix_editor.css
@@ -25,6 +25,11 @@ trix-editor ol {
   @apply dark:bg-slate-300 !important;
 }
 
+/* Prevent red ring on Trix Editor */
+:-moz-focusring {
+  outline-style: none;
+}
+
 a[href^="bullettrain://"], span.tribute-reference {
   border-radius: 4px;
   display: inline-block;


### PR DESCRIPTION
Closes #150.

## Details
Tailwind's [preflight styles](https://tailwindcss.com/docs/preflight) were overriding the Trix Editor styles. Adam Wathan posted a workaround [here](https://github.com/tailwindlabs/tailwindcss/issues/989#issuecomment-506555308) which I used. I also added another style to make the toolbar icons clearer to see.

I wanted to change the `color` CSS property for the icons, but since they're all images we'd have to [change the background image](https://github.com/basecamp/trix/issues/464) for each icon, which I figured wasn't worth the effort.

![image](https://user-images.githubusercontent.com/10546292/226795725-cddc6ece-4354-4ff5-9121-bc8d19c5a848.png)

## Firefox bug
For some reason Firefox displays a red ring around the trix editor when it's focused. The file in [this issue](https://github.com/tailwindlabs/tailwindcss/discussions/6749) has the same styles that were overriding our `ol` and `ul` tags here so I adjusted the `-moz-focusring` style which originally looked like this:
```css
/*
Use the modern Firefox focus style for all focusable elements.
*/

:-moz-focusring {
  outline: auto;
}
```

This took away the red ring, so I added a comment just to make sure whoever reads the file knows why I added it there.