### PR TITLE
Fix scaffolding with sidebar flag

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -1601,8 +1601,18 @@ class Scaffolding::Transformer
 
       if top_level_model?
         icon_name = nil
-        if cli_options["sidebar"].present?
-          icon_name = cli_options["sidebar"]
+        if cli_options["navbar"].present?
+          icon_name = if cli_options["navbar"].match?(/^ti/)
+            "ti #{cli_options["navbar"]}"
+          elsif cli_options["navbar"].match?(/^fa/)
+            "fal #{cli_options["navbar"]}"
+          else
+            puts ""
+            puts "'#{cli_options["navbar"]}' is not a valid icon.".red
+            puts "Please refer to the Themify or Font Awesome documentation and pass the value like so:"
+            puts "--navbar=\"ti-world\""
+            exit
+          end
         else
           puts ""
           # TODO: Update this help text letting developers know they can Super Scaffold

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -1618,7 +1618,7 @@ class Scaffolding::Transformer
           # TODO: Update this help text letting developers know they can Super Scaffold
           # models without a parent after the `--skip-parent` logic is implemented.
           puts "Hey, models that are scoped directly off of a Team are eligible to be added to the navbar."
-          puts "Do you want to add this resource to the sidebar menu? (y/N)"
+          puts "Do you want to add this resource to the navbar menu? (y/N)"
           response = $stdin.gets.chomp
           if response.downcase[0] == "y"
             puts ""


### PR DESCRIPTION
Joint PR
- https://github.com/bullet-train-co/bullet_train/pull/706

In our system tests, we pass the sidebar flag like this:
```
--sidebar="ti.ti-world"
```

This doesn't correctly scaffold the icon though, so I fixed it here.
I wanted to originally write this, but the script didn't play well with spaces:
```
--sidebar="ti ti-world"
```

Now we can just pass it like this:
```
--navbar="ti-world"
```

## navbar
I also just changed this to `navbar` since the developer can choose to have a sidebar or a navbar at the top.
