### PR TITLE
Documentation: Super Scaffolding Options

### DIFF
--- a/bullet_train/docs/super-scaffolding.md
+++ b/bullet_train/docs/super-scaffolding.md
@@ -250,5 +250,6 @@ HIDE_THINGS: true
 ```
 
 ## Advanced Examples
+ - [Super Scaffolding Options](/docs/super-scaffolding/options.md)
  - [Super Scaffolding with Delegated Types](/docs/super-scaffolding/delegated-types.md)
  - [Super Scaffolding with the `--sortable` option](/docs/super-scaffolding/sortable.md)

--- a/bullet_train/docs/super-scaffolding/options.md
+++ b/bullet_train/docs/super-scaffolding/options.md
@@ -1,14 +1,24 @@
 # Super Scaffolding Options
 
-There are different flags you can pass to the Super Scaffolding command which gives you more flexibility over creating your model. Add the flag of your choice to **the end** of the command for the option to take effect:
+There are different flags you can pass to the Super Scaffolding command which gives you more flexibility over creating your model. Add the flag of your choice to **the end** of the command for the option to take effect.
 ```
-bin/super-scaffold crud Project team:references description:text_field --sortable
+bin/super-scaffold crud Project Team description:text_field --sortable
 ```
 
 Most of these include skipping particular functionalities, so take a look at what's available here and pass the flag that applies to your use-case.
 
 | Option | Description |
 |--------|-------------|
-| `--sidebar="ti-world"` | Pass the Themify icon or FontAwesome icon of your choice to automatically add it to the navbar* |
+| `--sortable` | [Details here](/docs/super-scaffolding/sortable.md) |
+| `--namespace=customers` | [Details here](/docs/namespacing.md) |
+| `--navbar="ti-world"` | Pass the Themify icon or Font Awesome icon of your choice to automatically add it to the navbar* |
+| `--only-index` | Only scaffold the index view for a model"` |
+| `--skip-views` | |
+| `--skip-form` | |
+| `--skip-locales` | |
+| `--skip-api` | |
+| `--skip-model` | |
+| `--skip-controller` | |
+| `--skip-routes` | |
 
 *This option is only available for top-level models, which are models that are direct children of the `Team` model.

--- a/bullet_train/docs/super-scaffolding/options.md
+++ b/bullet_train/docs/super-scaffolding/options.md
@@ -11,7 +11,7 @@ Most of these include skipping particular functionalities, so take a look at wha
 |--------|-------------|
 | `--sortable` | [Details here](/docs/super-scaffolding/sortable.md) |
 | `--namespace=customers` | [Details here](/docs/namespacing.md) |
-| `--navbar="ti-world"` | Pass the Themify icon or Font Awesome icon of your choice to automatically add it to the navbar* |
+| `--sidebar="ti-world"` | Pass the Themify icon or Font Awesome icon of your choice to automatically add it to the navbar* |
 | `--only-index` | Only scaffold the index view for a model"` |
 | `--skip-views` | |
 | `--skip-form` | |

--- a/bullet_train/docs/super-scaffolding/options.md
+++ b/bullet_train/docs/super-scaffolding/options.md
@@ -1,0 +1,14 @@
+# Super Scaffolding Options
+
+There are different flags you can pass to the Super Scaffolding command which gives you more flexibility over creating your model. Add the flag of your choice to **the end** of the command for the option to take effect:
+```
+bin/super-scaffold crud Project team:references description:text_field --sortable
+```
+
+Most of these include skipping particular functionalities, so take a look at what's available here and pass the flag that applies to your use-case.
+
+| Option | Description |
+|--------|-------------|
+| `--sidebar="ti-world"` | Pass the Themify icon or FontAwesome icon of your choice to automatically add it to the navbar* |
+
+*This option is only available for top-level models, which are models that are direct children of the `Team` model.


### PR DESCRIPTION
Closes #151.

As far as the `--skip-*` flags, I'm not sure how many of these we actually want to document.

For example, I'm under the impression that `--skip-table` is only for use internally (check out #199) so I didn't document it here. Maybe some of these can be set within the scope of the Transformer and removed from `cli_options`.

Besides that, I didn't document `--skip-parent` because I don't think we have the logic for it implemented as of now.

## navbar
I also added `--navbar` instead of `--sidebar` if #209 gets merged.