### PR TITLE
Adjust condition for making navbar link rounded

### DIFF
--- a/bullet_train-themes-light/app/views/themes/light/menu/_item.html.erb
+++ b/bullet_train-themes-light/app/views/themes/light/menu/_item.html.erb
@@ -1,7 +1,7 @@
 <% method ||= nil %>
 <% active ||= request.path == url %>
 
-<%= send (method ? :button_to : :link_to), url, class: "block group hover:text-white hover:no-underline #{'bg-primary-900 dark:bg-black dark:bg-opacity-10' if active} text-white #{@menu_orientation == :top ? "px-5 py-5" : "px-2 py-2 rounded-md hover-indent-child"} #{"rounded-tl-lg" unless @not_first} dark:text-white", data: {"desktop-menu-target": "menuItemLink"}, tabIndex: 0, method: method do %>
+<%= send (method ? :button_to : :link_to), url, class: "block group hover:text-white hover:no-underline #{'bg-primary-900 dark:bg-black dark:bg-opacity-10' if active} text-white #{@menu_orientation == :top ? "px-5 py-5" : "px-2 py-2 rounded-md hover-indent-child"} #{"rounded-tl-lg" unless @not_first || BulletTrain::Themes::Light.show_logo_in_account} dark:text-white", data: {"desktop-menu-target": "menuItemLink"}, tabIndex: 0, method: method do %>
   <div class="inline-block indent-child flex items-center">
     <!-- Heroicon name: home -->
     <% if partial.icon? %>


### PR DESCRIPTION
This is a very minor detail, but the first link in the item menu was getting rounded even when the logo was present:

![Screenshot from 2023-03-23 17-21-25](https://user-images.githubusercontent.com/10546292/227144037-c2894c3f-4ad2-4646-aab5-c6c223fa2f92.png)
