### PR TITLE
Add OpenAI defaults to `bullet_train`

### DIFF
--- a/bullet_train/bullet_train.gemspec
+++ b/bullet_train/bullet_train.gemspec
@@ -93,6 +93,9 @@ Gem::Specification.new do |spec|
   # Extract the body from emails received using action inbox.
   spec.add_dependency "extended_email_reply_parser" # TODO ➡️ `bullet_train-conversations`
 
+  # Open AI
+  spec.add_dependency "ruby-openai"
+
   # Conversations.
   spec.add_runtime_dependency "unicode-emoji"
 

--- a/bullet_train/bullet_train.gemspec
+++ b/bullet_train/bullet_train.gemspec
@@ -93,7 +93,7 @@ Gem::Specification.new do |spec|
   # Extract the body from emails received using action inbox.
   spec.add_dependency "extended_email_reply_parser" # TODO ➡️ `bullet_train-conversations`
 
-  # Open AI
+  # OpenAI
   spec.add_dependency "ruby-openai"
 
   # Conversations.

--- a/bullet_train/docs/application-options.md
+++ b/bullet_train/docs/application-options.md
@@ -15,6 +15,7 @@ The helper methods below can also be directly invoked in your application if you
 | FONTAWESOME_NPM_AUTH_TOKEN | String | `"your_font_awesome_token"` | `font_awesome?` |
 | SILENCE_LOGS | Boolean | `"true"` | `silence_logs?` |
 | TESTING_PROVISION_KEY | String | `"asdf123"` | N/A |
+| OPENAI_ACCESS_TOKEN | String |`your_openai_token`| `openai_enabled?` |
 
 | Option | Description |
 | --- | --- |
@@ -27,3 +28,4 @@ The helper methods below can also be directly invoked in your application if you
 | FONTAWESOME_NPM_AUTH_TOKEN | Enables use of Font Awesome. |
 | SILENCE_LOGS | Silences Super Scaffolding logs. |
 | TESTING_PROVISION_KEY | Creates a test `Platform::Application` by accessing `/testing/provision?key=your_provision_key` |
+| OPENAI_ACCESS_TOKEN | Enables use [OpenAI](https://openai.com/) with the [ruby-openai](https://github.com/alexrudall/ruby-openai) gem. |

--- a/bullet_train/lib/bullet_train.rb
+++ b/bullet_train/lib/bullet_train.rb
@@ -33,6 +33,7 @@ require "commonmarker"
 require "extended_email_reply_parser"
 require "pagy"
 require "devise/pwned_password"
+require "openai"
 
 module BulletTrain
   mattr_accessor :routing_concerns, default: []
@@ -151,4 +152,12 @@ end
 
 def silence_logs?
   ENV["SILENCE_LOGS"].present?
+end
+
+def openai_enabled?
+  ENV["OPENAI_ACCESS_TOKEN"].present?
+end
+
+def openai_organization_exists?
+  ENV["OPENAI_ORGANIZATION_ID"]
 end


### PR DESCRIPTION
Closes #212.

Joint PR
- https://github.com/bullet-train-co/bullet_train/pull/709

Using an organization ID is optional, but I thought I'd add it here just in case.