### PR TITLE
Fixes partial path resolvings for jbuilder partials.

### DIFF
--- a/bullet_train-themes/lib/bullet_train/themes.rb
+++ b/bullet_train-themes/lib/bullet_train/themes.rb
@@ -32,6 +32,22 @@ module BulletTrain
         end
 
         def resolved_partial_path_for(lookup_context, path, locals)
+          # Skip caching procedure if path is a hash (for example), as the hash will occur the error:
+          # TypeError: no implicit conversion of nil into Integer 
+          #
+          # This situation happens by rendering of partials in jbuilder templates like:
+          #
+          #   ```
+          #     json.array! @records do |record|
+          #       json.partial!('show', record: record) # <--
+          #     end
+          #   ```
+          #
+          # It's especially hard if this happens, from an embedded gem/engine, which uses those calls alot, 
+          # and you don't have control over the code.
+          return unless path.is_a?(String)
+          
+          
           # We disable partial path caching in development so new templates are taken into account without restarting the server.
           partial_paths = {}
 


### PR DESCRIPTION
For me it was a hard journey to discover this error, especially reasoned by the condition if Rails.env.development?, which lets the error only occur in production environment. And I was looking for some trouble (TypeError: no implicit conversion of nil into Integer) in the affected jbuilder template, which was totally wrong.

I am sorry, that I can't afford the time to write tests for that and I understand, if that's why the PR won't be merged. But as I investigated several hours in finding this issue, I (at least) wanted to point this error out.

So if you didn't ever plan that this method is called with a path with another class-instance than String, you could easily approve it. Otherwise I hope this PR helps somebody as reference, as we implemented that as a monkey patch for now.

Let me know if I should clarify the situation more that I reached with my comment.