### PR TITLE
Use the application's default color for the Turbo progress bar

### DIFF
--- a/bullet_train-themes-light/app/assets/stylesheets/light/application.css
+++ b/bullet_train-themes-light/app/assets/stylesheets/light/application.css
@@ -33,3 +33,9 @@ form.button_to {
 
 /* hide the first breadcrumb chevron */
 ol.breadcrumb li:first-child svg { display: none; }
+
+/* Override Turbo's progress bar color with the application's theme. */
+.turbo-progress-bar {
+  height: 5px;
+  @apply bg-primary-500;
+}


### PR DESCRIPTION
The following is when the theme is set to `:emerald`


https://user-images.githubusercontent.com/10546292/229503040-f11c472a-5e1a-41a8-b0b5-fc72add37af9.mov

The archived repository [TurboLinks](https://github.com/turbolinks/turbolinks#advanced-usage) had instructions on how to change this:

```css
.turbolinks-progress-bar {
  height: 5px;
  background-color: green;
}
```

So I had to fish for the proper class in the new turbo-rails repository, which turned out to be `.turbo-progress-bar` ([source](https://github.com/hotwired/turbo-rails/blob/7402db85029092ec49dca4a020a7de51b6fa5e8b/app/assets/javascripts/turbo.js#L1458))