### PR TITLE
Update migration search regexp to permit `create_table` options

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -1429,7 +1429,7 @@ class Scaffolding::Transformer
 
     unless cli_options["skip-model"]
       # find the database migration that defines this relationship.
-      migration_file_name = `grep "create_table :#{class_names_transformer.table_name} do |t|" db/migrate/*`.split(":").first
+      migration_file_name = `grep "create_table :#{class_names_transformer.table_name}.*do |t|$" db/migrate/*`.split(":").first
       unless migration_file_name.present?
         raise "No migration file seems to exist for creating the table `#{class_names_transformer.table_name}`.\n" \
           "Please run the following command first and try Super Scaffolding again:\n" \


### PR DESCRIPTION
Fixes https://github.com/bullet-train-co/bullet_train/issues/724

Since `create_table` can take keyword arguments such as `options:` or `force:`, the regexp here should be able to pick up on those.

We could honestly get away with the following:
```ruby
`grep "create_table :#{class_names_transormer.table_name}" db/migrate/*`.split(":").first
```

I went ahead with the more specific regexp though.