### PR TITLE
Use proper remote name in `upgrades` documentation

### DIFF
--- a/bullet_train/docs/upgrades.md
+++ b/bullet_train/docs/upgrades.md
@@ -67,4 +67,4 @@ git push origin main
 git branch -d updating-bullet-train
 ```
 
-Alternatively, if you're using GitHub, you can push the `updating-bullet-train` branch up and create a PR from it and let your CI integration do it's thing and then merge in the PR and delete the branch there. (That's what we typically do.)
+Alternatively, if you're using GitHub, you can push the `updating-bullet-train` branch up and create a PR from it and let your CI integration do its thing and then merge in the PR and delete the branch there. (That's what we typically do.)

--- a/bullet_train/docs/upgrades.md
+++ b/bullet_train/docs/upgrades.md
@@ -27,7 +27,7 @@ git clean -d -f
 ### 2. Fetch the latest and greatest from the Bullet Train repository.
 
 ```
-git fetch starter-repo
+git fetch bullet-train
 ````
 
 ### 3. Create a new "upgrade" branch off of your main branch.
@@ -40,7 +40,7 @@ git checkout -b updating-starter-repo
 ### 4. Merge in the newest stuff from Bullet Train and resolve any merge conflicts.
 
 ```
-git merge starter-repo/main
+git merge bullet-train/main
 ```
 
 It's quite possible you'll get some merge conflicts at this point. No big deal! Just go through and resolve them like you would if you were integrating code from another developer on your team. We tend to comment our code heavily, but if you have any questions about the code you're trying to understand, let us know on Discord!
@@ -62,9 +62,9 @@ rails test:system
 
 ```
 git checkout main
-git merge updating-starter-repo
+git merge updating-bullet-train
 git push origin main
-git branch -d updating-starter-repo
+git branch -d updating-bullet-train
 ```
 
-Alternatively, if you're using GitHub, you can push the `updating-starter-repo` branch up and create a PR from it and let your CI integration do it's thing and then merge in the PR and delete the branch there. (That's what we typically do.)
+Alternatively, if you're using GitHub, you can push the `updating-bullet-train` branch up and create a PR from it and let your CI integration do it's thing and then merge in the PR and delete the branch there. (That's what we typically do.)


### PR DESCRIPTION
Closes https://github.com/bullet-train-co/bullet_train/issues/286

We set the name `bullet-train` for the starter repository's remote by default in [bin/configure](https://github.com/bullet-train-co/bullet_train/blob/37c4fe178ad9ca16dacb3e6ed3e0772f386302ca/bin/configure#L123-L132), so I reflected this in the docs.
