### PR TITLE
Super Scaffold with custom namespaces properly

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -1634,7 +1634,6 @@ class Scaffolding::Transformer
 
           # Define which line we want to place the draw line under in the original routes files.
           insert_line = if routes_file.match?("api")
-            draw_line = "#{draw_line}"
             "namespace :v1 do"
           else
             "draw \"sidekiq\""

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -1596,7 +1596,7 @@ class Scaffolding::Transformer
         routes_manipulator.apply([routes_namespace])
         Scaffolding::FileManipulator.write(routes_path, routes_manipulator.lines)
       rescue => _
-        add_additional_step :red, "We weren't able to automatically add your `#{routes_namespace}` routes for you. In theory this should be very rare, so if you could reach out on Slack, you could probably provide context that will help us fix whatever the problem was. In the meantime, to add the routes manually, we've got a guide at https://blog.bullettrain.co/nested-namespaced-rails-routing-examples/ ."
+        add_additional_step :red, "We weren't able to automatically add your `#{routes_namespace}` routes for you. In theory this should be very rare, so if you could reach out on Discord, you could probably provide context that will help us fix whatever the problem was. In the meantime, to add the routes manually, we've got a guide at https://blog.bullettrain.co/nested-namespaced-rails-routing-examples/."
       end
 
       # If we're using a custom namespace, we have to make sure the newly
@@ -1612,7 +1612,7 @@ class Scaffolding::Transformer
 
           # Define which line we want to place the draw line under in the original routes files.
           insert_line = if routes_file.match?("api")
-            draw_line = "  #{draw_line}" # Add necessary indentation.
+            draw_line = "#{draw_line}"
             "namespace :v1 do"
           else
             "draw \"sidekiq\""


### PR DESCRIPTION
Continuation of #35.

## Example model

```
> rails g model Job team:references title:string
> bin/super-scaffold crud Job Team title:text_field --namespace=client
```

## Details
In #35 we got the routes to work properly, but there's still some more work to do here.

I was able to scaffold the API controller (which I believe we'll need because it has all of our strong parameters), and I namespaced the class names of the controllers.

However, I'm getting this error and I'm not quite sure how to handle it from here:
![Screenshot from 2023-04-11 21-34-51](https://user-images.githubusercontent.com/10546292/231164039-252c47f7-4ae7-4694-92e1-a7273ece20c9.png)

