### PR TITLE
Pass symbol instead of string to `Factorybot.get_example`

### DIFF
--- a/bullet_train-api/app/helpers/api/open_api_helper.rb
+++ b/bullet_train-api/app/helpers/api/open_api_helper.rb
@@ -38,7 +38,7 @@ module Api
       output += render(custom_actions_file_path) if lookup_context.exists?(custom_actions_file_path, [], true)
 
       # There are some placeholders specific to this method that we still need to transform.
-      model_symbol = model.name.underscore.tr("/", "_")
+      model_symbol = model.name.underscore.tr("/", "_").to_sym
 
       if (get_example = FactoryBot.get_example(model_symbol, version: @version))
         output.gsub!("🚅 get_example", get_example)

--- a/bullet_train-api/lib/bullet_train/api/example_bot.rb
+++ b/bullet_train-api/lib/bullet_train/api/example_bot.rb
@@ -48,11 +48,6 @@ module FactoryBot
     private
 
     def factory(model)
-      # TODO Why do we sometimes get a real object here and sometimes just a model name as a symbol?
-      unless model.is_a?(String)
-        model = model.name.underscore.tr("/", "_").to_sym
-      end
-
       factories = FactoryBot.factories.instance_variable_get(:@items).keys
       factories.include?("#{model}_example") ? "#{model}_example".to_sym : model
     end


### PR DESCRIPTION
Since we weren't passing the model as a symbol to `FactoryBot.get_example` in the OpenApi helper, we were getting strings and not symbols.

For example, the webhooks outgoing endpoint model had the following backtrace:
```
 "/Users/gabriel_zayas/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/activerecord-7.0.4.3/lib/active_record/transactions.rb:209:in `transaction'",
 "/Users/gabriel_zayas/work/bt/bullet_train/local/bullet_train-core/bullet_train-api/lib/bullet_train/api/example_bot.rb:12:in `example'",
 "/Users/gabriel_zayas/work/bt/bullet_train/local/bullet_train-core/bullet_train-api/lib/bullet_train/api/example_bot.rb:122:in `_set_values'",
 "/Users/gabriel_zayas/work/bt/bullet_train/local/bullet_train-core/bullet_train-api/lib/bullet_train/api/example_bot.rb:90:in `_path_examples'",
 "/Users/gabriel_zayas/work/bt/bullet_train/local/bullet_train-core/bullet_train-api/lib/bullet_train/api/example_bot.rb:44:in `block (2 levels) in <module:ExampleBot>'",
 "/Users/gabriel_zayas/work/bt/bullet_train/local/bullet_train-core/bullet_train-api/app/helpers/api/open_api_helper.rb:40:in `automatic_paths_for'",
 "/Users/gabriel_zayas/work/bt/bullet_train/app/views/api/v1/open_api/index.yaml.erb:52:in `_app_views_api_v__open_api_index_yaml_erb__3775856957415815323_110920'",
```

Whereas Team had this backtrace:
```
 "/Users/gabriel_zayas/work/bt/bullet_train/local/bullet_train-core/bullet_train-api/lib/bullet_train/api/example_bot.rb:28:in `example_list'",
 "/Users/gabriel_zayas/work/bt/bullet_train/local/bullet_train-core/bullet_train-api/lib/bullet_train/api/example_bot.rb:120:in `_set_values'",
 "/Users/gabriel_zayas/work/bt/bullet_train/local/bullet_train-core/bullet_train-api/lib/bullet_train/api/example_bot.rb:92:in `_path_examples'",
 "/Users/gabriel_zayas/work/bt/bullet_train/local/bullet_train-core/bullet_train-api/lib/bullet_train/api/example_bot.rb:44:in `block (2 levels) in <module:ExampleBot>'",
 "/Users/gabriel_zayas/work/bt/bullet_train/local/bullet_train-core/bullet_train-api/app/views/api/v1/open_api/teams/_paths.yaml.erb:26:in `_local_bullet_train_core_bullet_train_api_app_views_api_v__open_api_teams__paths_yaml_erb__3030827026581219588_118560'",
```

Since team was coming from `bullet_train-api/app/views/api/v1/open_api/teams/_paths.yaml.erb:26` it came through as a symbol no problem because we pass the model there as a symbol explicitly:
```ruby
<%= FactoryBot.get_examples(:team, version: @version) %>
```

## Actual object
The TODO talks about getting an actual object, but I didn't run into model object issues, just the String issue mentioned above.