### PR TITLE
Bump CableReady to v5.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,7 @@ GEM
 PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
+  arm64-darwin-22
   ruby
   x86_64-linux
 

--- a/bullet_train/Gemfile.lock
+++ b/bullet_train/Gemfile.lock
@@ -17,7 +17,7 @@ PATH
       bullet_train-scope_validator
       bullet_train-super_load_and_authorize_resource
       bullet_train-themes
-      cable_ready (= 5.0.0.pre9)
+      cable_ready (~> 5.0.0)
       cancancan
       commonmarker
       devise
@@ -135,11 +135,9 @@ GEM
       rails (>= 6.0.0)
     bullet_train-themes (1.2.24)
       rails (>= 6.0.0)
-    cable_ready (5.0.0.pre9)
-      actioncable (>= 5.2)
+    cable_ready (5.0.0)
       actionpack (>= 5.2)
       actionview (>= 5.2)
-      activerecord (>= 5.2)
       activesupport (>= 5.2)
       railties (>= 5.2)
       thread-local (>= 1.1.0)
@@ -151,7 +149,7 @@ GEM
       rest-client (>= 2.0.0)
     coderay (1.1.3)
     commonmarker (0.23.9)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
     connection_pool (2.4.0)
     crass (1.0.6)
     css_parser (1.14.0)
@@ -170,7 +168,7 @@ GEM
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     email_reply_parser (0.5.10)
-    erubi (1.10.0)
+    erubi (1.12.0)
     extended_email_reply_parser (0.5.1)
       activesupport
       charlock_holmes
@@ -197,7 +195,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.6.3)
     language_server-protocol (3.17.0.2)
-    loofah (2.18.0)
+    loofah (2.20.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.8.1)
@@ -214,8 +212,8 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2023.0218.1)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.0)
-    minitest (5.16.2)
+    mini_portile2 (2.8.1)
+    minitest (5.18.0)
     multipart-post (2.3.0)
     net-imap (0.3.4)
       date
@@ -230,7 +228,7 @@ GEM
     nice_partials (0.9.3)
       actionview (>= 4.2.6)
     nio4r (2.5.9)
-    nokogiri (1.13.8)
+    nokogiri (1.14.3)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     orm_adapter (0.5.0)
@@ -256,9 +254,9 @@ GEM
       pry (~> 0.13)
     public_suffix (5.0.1)
     pwned (2.0.2)
-    racc (1.6.0)
-    rack (2.2.4)
-    rack-test (2.0.2)
+    racc (1.6.2)
+    rack (2.2.6.4)
+    rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.3.1)
       actioncable (= 7.0.3.1)
@@ -277,8 +275,8 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.3)
-      loofah (~> 2.3)
+    rails-html-sanitizer (1.5.0)
+      loofah (~> 2.19, >= 2.19.1)
     railties (7.0.3.1)
       actionpack (= 7.0.3.1)
       activesupport (= 7.0.3.1)
@@ -344,7 +342,7 @@ GEM
     thor (1.2.1)
     thread-local (1.1.0)
     timeout (0.3.2)
-    tzinfo (2.0.5)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
       unf_ext

--- a/bullet_train/bullet_train.gemspec
+++ b/bullet_train/bullet_train.gemspec
@@ -69,7 +69,7 @@ Gem::Specification.new do |spec|
 
   # Reactive view magic.
   # The `updates_for` feature replaces Bullet Train's earlier "Cable Collections" feature.
-  spec.add_dependency "cable_ready", "5.0.0.pre9"
+  spec.add_dependency "cable_ready", "~> 5.0.0"
   spec.add_dependency "hiredis"
 
   # Add named slots to regular Rails partials.


### PR DESCRIPTION
Now that CableReady v5 has finally landed, it's time to integrate it.

This branch is intended for use with an older version of nice_partials (hence branched off at BT v1.2.11), but will be rebased once those issues are resolved. cc @andrewculver 