### PR TITLE
Transform incoming webhooks foreign key index name when super scaffolding a new OAuth provider

### DIFF
--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/oauth_provider_scaffolder.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/oauth_provider_scaffolder.rb
@@ -144,7 +144,7 @@ module BulletTrain
 
           migration_file_name = `grep "create_table #{oauth_transform_string(":webhooks_incoming_oauth_stripe_account_webhooks", options)}" db/migrate/*`.split(":").first
           legacy_replace_in_file(migration_file_name, "null: false", "null: true")
-          legacy_replace_in_file(migration_file_name, "foreign_key: true", 'foreign_key: true, index: {name: "index_stripe_webhooks_on_oauth_stripe_account_id"}')
+          legacy_replace_in_file(migration_file_name, "foreign_key: true", oauth_transform_string('foreign_key: true, index: {name: "index_stripe_webhooks_on_oauth_stripe_account_id"}'))
 
           puts ""
           puts "🎉"


### PR DESCRIPTION
Closes https://github.com/bullet-train-co/bullet_train-core/issues/248.

Applies the `oauth_transform_string` function to the foreign key definition being added to the incoming webhooks migration of a newly created OAuth provider.