### PR TITLE
Allow members to view resources from other teams

### DIFF
--- a/bullet_train/app/controllers/concerns/account/controllers/base.rb
+++ b/bullet_train/app/controllers/concerns/account/controllers/base.rb
@@ -64,7 +64,7 @@ module Account::Controllers::Base
   def ensure_onboarding_is_complete
     # This is temporary, but if we've gotten this far and `@team` is loaded, we need to ensure current_team is
     # updated for the checks below. This entire concept of `current_team` is going away soon.
-    current_user.update(current_team: @team) if @team&.persisted?
+    current_user.update(current_team: @team) if @team&.persisted? && current_user.teams.include?(@team)
 
     # since the onboarding controllers are child classes of this class,
     # we actually have to check to make sure we're not currently on that

--- a/bullet_train/app/helpers/account/users_helper.rb
+++ b/bullet_train/app/helpers/account/users_helper.rb
@@ -76,6 +76,6 @@ module Account::UsersHelper
   end
 
   def current_membership
-    current_user.memberships.where(team: current_team).first
+    current_user.memberships.where(team: current_user.current_team).first
   end
 end


### PR DESCRIPTION
Context: https://discord.com/channels/836637622432170028/1096469430101344378/1096469437860814930

## The goal
To allow members to view resources from other teams. For example, say we have a model `Foo`, and we add the following in `ability.rb` (we could probably edit `config/models/roles.rb` instead, but writing this to match the discussion on Discord):

```ruby
can :show, Foo
```

## The error
`current_membership` is called [here](https://github.com/bullet-train-co/bullet_train-core/blob/d1d9be164aa8cfd4a7b06c456f5d0fc2e4529f12/bullet_train-themes-light/app/views/themes/light/menu/_user.html.erb#L5), but it returns `nil` resulting in the following error:

<img width="1061" alt="スクリーンショット 2023-04-18 19 04 49" src="https://user-images.githubusercontent.com/10546292/232744371-cc22c133-9656-4880-a826-22d3a893f1ec.png">

## The fix
On the `ensure_onboarding_is_complete` step, we were updating `current_user.current_team_id` with `@team`, the team resource being loaded on the page. Since this is originally intended for use within teams `current_user` already belongs to, we didn't have anything in place to prevent this id from being updated when the member is visiting a team they <b>don't</b> belong to, so the id was being updating with a team they shouldn't be a part of. With this fix, we'll only update the current team if the member belongs to the team.

## Navigation bar updates
I'm opening this up as a draft because there is an issue with the navigation bar links. Basically, the links point to the team being loaded, not the `current_user`'s `current_team`. So, for example, the team name should be `Another Team` but is `Your Team`, and if we click on `Team Members`...

<img width="476" alt="スクリーンショット 2023-04-18 19 12 16" src="https://user-images.githubusercontent.com/10546292/232746123-de2ce7ac-d80c-4b55-9daf-03ed60ae93ba.png">

We get redirected to the current team (You can see `Another Team` on the right side) with an unauthorized error:

<img width="1427" alt="スクリーンショット 2023-04-18 19 13 11" src="https://user-images.githubusercontent.com/10546292/232746399-ea890282-2aa2-4b48-a8b1-b7cc7b1b2e5f.png">
