### PR TITLE
Fix regular expression in resolver for use with both local and published gems

### DIFF
--- a/bullet_train/lib/bullet_train/resolver.rb
+++ b/bullet_train/lib/bullet_train/resolver.rb
@@ -104,7 +104,7 @@ module BulletTrain
 
       if result[:absolute_path]
         if result[:absolute_path].include?("/bullet_train")
-          regex = /#{"bullet_train-core" if result[:absolute_path].include?("bullet_train-core")}\/bullet_train[.\-_a-z|0-9]*.*/
+          regex = /#{"bullet_train-core" if result[:absolute_path].include?("bullet_train-core")}\/bullet_train[\-|\.|_|a-z|0-9]*.*/
           base_path = result[:absolute_path].scan(regex).pop
 
           # Try to calculate which package the file is from, and what it's path is within that project.
@@ -152,7 +152,7 @@ module BulletTrain
           @needle = partial_parts.join("/")
         elsif @needle.match?(/bullet_train/)
           # If it's a full path, we need to make sure we're getting it from the right package.
-          _, partial_view_package, partial_path_without_package = @needle.partition(/bullet_train-core\/bullet_train[a-z|\-_0-9.]*/)
+          _, partial_view_package, partial_path_without_package = @needle.partition(/(bullet_train-core\/)?bullet_train[a-z|\-|\.|_|0-9]*/)
 
           # Pop off `bullet_train-core` and the gem's version so we can call `bundle show` correctly.
           partial_view_package.gsub!(/bullet_train-core\//, "")

--- a/bullet_train/lib/bullet_train/resolver.rb
+++ b/bullet_train/lib/bullet_train/resolver.rb
@@ -104,7 +104,7 @@ module BulletTrain
 
       if result[:absolute_path]
         if result[:absolute_path].include?("/bullet_train")
-          regex = /#{"bullet_train-core" if result[:absolute_path].include?("bullet_train-core")}\/bullet_train[\-|\.|_|a-z|0-9]*.*/
+          regex = /#{"bullet_train-core" if result[:absolute_path].include?("bullet_train-core")}\/bullet_train[-|._a-z0-9]*.*/
           base_path = result[:absolute_path].scan(regex).pop
 
           # Try to calculate which package the file is from, and what it's path is within that project.
@@ -152,7 +152,7 @@ module BulletTrain
           @needle = partial_parts.join("/")
         elsif @needle.match?(/bullet_train/)
           # If it's a full path, we need to make sure we're getting it from the right package.
-          _, partial_view_package, partial_path_without_package = @needle.partition(/(bullet_train-core\/)?bullet_train[a-z|\-|\.|_|0-9]*/)
+          _, partial_view_package, partial_path_without_package = @needle.partition(/(bullet_train-core\/)?bullet_train[a-z|\-._0-9]*/)
 
           # Pop off `bullet_train-core` and the gem's version so we can call `bundle show` correctly.
           partial_view_package.gsub!(/bullet_train-core\//, "")

--- a/bullet_train/lib/bullet_train/resolver.rb
+++ b/bullet_train/lib/bullet_train/resolver.rb
@@ -165,7 +165,7 @@ module BulletTrain
           puts "`#{@needle}`".red
           puts ""
           puts "Check the string one more time to see if the package name is there."
-          puts "i.e.: bullet_train-base/app/views/layouts/devise.html.erb".blue
+          puts "i.e.: bullet_train-1.2.24/app/views/layouts/devise.html.erb".blue
           puts ""
           puts "If you're not sure what the package name is, run `bin/resolve --interactive`, follow the prompt, and pass the annotated path."
           puts "i.e.: <!-- BEGIN /your/local/path/bullet_train-base/app/views/layouts/devise.html.erb -->".blue

--- a/bullet_train/lib/bullet_train/resolver.rb
+++ b/bullet_train/lib/bullet_train/resolver.rb
@@ -104,7 +104,7 @@ module BulletTrain
 
       if result[:absolute_path]
         if result[:absolute_path].include?("/bullet_train")
-          regex = /#{"bullet_train-core" if result[:absolute_path].include?("bullet_train-core")}\/bullet_train[a-z|\-._0-9]*/
+          regex = /#{"bullet_train-core" if result[:absolute_path].include?("bullet_train-core")}\/bullet_train[a-z|\-._0-9]*.*/
           base_path = result[:absolute_path].scan(regex).pop
 
           # Try to calculate which package the file is from, and what it's path is within that project.

--- a/bullet_train/lib/bullet_train/resolver.rb
+++ b/bullet_train/lib/bullet_train/resolver.rb
@@ -104,7 +104,7 @@ module BulletTrain
 
       if result[:absolute_path]
         if result[:absolute_path].include?("/bullet_train")
-          regex = /#{"bullet_train-core" if result[:absolute_path].include?("bullet_train-core")}\/bullet_train[-|._a-z0-9]*.*/
+          regex = /#{"bullet_train-core" if result[:absolute_path].include?("bullet_train-core")}\/bullet_train[a-z|\-._0-9]*/
           base_path = result[:absolute_path].scan(regex).pop
 
           # Try to calculate which package the file is from, and what it's path is within that project.


### PR DESCRIPTION
Context: https://discord.com/channels/836637622432170028/836637623048601633/1097941970808217621

The resolver was working for `local/bullet_train-core` when running the script like this:
```
local/bullet_train-core/bullet_train-themes-light/app/views/themes/light/menu/_user.html.erb
```

However, since published gems don't exist under a `bullet_train-core` directory, we were getting a strange output:

<details>
  <summary>bin/resolve outputs all gems</summary>

```
> bin/resolve bullet_train-themes-light/app/views/themes/light/menu/_user.html.erb

Absolute path:
  Gems included by the bundle:
  * actioncable (7.0.4.3)
  * actionmailbox (7.0.4.3)
  * actionmailer (7.0.4.3)
  * actionpack (7.0.4.3)
  * actiontext (7.0.4.3)
  * actionview (7.0.4.3)
  * active_hash (3.1.1)
  * activejob (7.0.4.3)
  * activemodel (7.0.4.3)
  * activerecord (7.0.4.3)
  * activestorage (7.0.4.3)
  * activesupport (7.0.4.3)
  * addressable (2.8.2)
  * ast (2.4.2)
  * awesome_print (1.9.2)
  * aws-eventstream (1.2.0)
  * aws-partitions (1.739.0)
  * aws-sdk-core (3.171.0)
  * aws-sdk-kms (1.63.0)
  * aws-sdk-s3 (1.120.0)
  * aws-sigv4 (1.5.2)
  * aws_cf_signer (0.1.3)
  * bcrypt (3.1.18)
  * bindex (0.8.1)
  * binding_of_caller (1.0.0)
  * bootsnap (1.16.0)
  * builder (3.2.4)
  * bullet_train (1.2.24)
  * bullet_train-api (1.2.24)
  * bullet_train-fields (1.2.24)
  * bullet_train-has_uuid (1.2.24)
  * bullet_train-incoming_webhooks (1.2.24)
  * bullet_train-integrations (1.2.24)
  * bullet_train-integrations-stripe (1.2.24)
  * bullet_train-obfuscates_id (1.2.24)
  * bullet_train-outgoing_webhooks (1.2.24)
  * bullet_train-roles (1.2.24)
  * bullet_train-routes (1.0.0)
  * bullet_train-scope_questions (1.2.24)
  * bullet_train-scope_validator (1.2.24)
  * bullet_train-sortable (1.2.24)
  * bullet_train-super_load_and_authorize_resource (1.2.24)
  * bullet_train-super_scaffolding (1.2.24)
  * bullet_train-themes (1.2.24)
  * bullet_train-themes-light (1.2.24)
  * bullet_train-themes-tailwind_css (1.2.24)
  * bundler (2.4.8)
  * cable_ready (5.0.0.pre9)
  * cancancan (3.5.0)
  * capybara (3.39.0 96a8baa)
  * capybara-email (3.0.2)
  * charlock_holmes (0.7.7)
  * chronic (0.10.2)
  * chunky_png (1.4.0)
  * cloudinary (1.25.0)
  * code_analyzer (0.5.5)
  * coderay (1.1.3)
  * colorize (0.8.1)
  * commonmarker (0.23.9)
  * concurrent-ruby (1.2.2)
  * connection_pool (2.4.0)
  * crass (1.0.6)
  * css_parser (1.14.0)
  * cssbundling-rails (1.1.2)
  * date (3.3.3)
  * debug (1.7.2)
  * debug_inspector (1.1.0)
  * devise (4.9.1)
  * devise-pwned_password (0.1.9)
  * devise-two-factor (5.0.0)
  * docile (1.4.0)
  * domain_name (0.5.20190701)
  * doorkeeper (5.6.6)
  * email_reply_parser (0.5.10)
  * erubi (1.12.0)
  * erubis (2.7.0)
  * extended_email_reply_parser (0.5.1)
  * factory_bot (6.2.1)
  * factory_bot_rails (6.2.0)
  * faraday (2.7.4)
  * faraday-net_http (3.0.2)
  * fastimage (2.2.6)
  * figaro (1.2.0)
  * foreman (0.87.2)
  * globalid (1.1.0)
  * hashids (1.0.6)
  * hashie (5.0.0)
  * hiredis (0.6.3)
  * honeybadger (5.2.1)
  * htmlentities (4.3.4)
  * http-accept (1.7.0)
  * http-cookie (1.0.5)
  * http_accept_language (2.1.1)
  * httparty (0.21.0)
  * i18n (1.12.0)
  * indefinite_article (0.2.5)
  * io-console (0.6.0)
  * irb (1.6.3)
  * jbuilder (2.11.5)
  * jbuilder-schema (2.1.0)
  * jmespath (1.6.2)
  * jsbundling-rails (1.1.1)
  * json (2.6.3)
  * jwt (2.7.0)
  * knapsack_pro (3.9.0)
  * language_server-protocol (3.17.0.3)
  * launchy (2.5.2)
  * letter_opener (1.8.1)
  * loofah (2.20.0)
  * magic_test (0.0.9)
  * mail (2.8.1)
  * marcel (1.0.2)
  * matrix (0.4.2)
  * method_source (1.0.0)
  * microscope (1.1.1)
  * mime-types (3.4.1)
  * mime-types-data (3.2023.0218.1)
  * mini_mime (1.1.2)
  * minitest (5.18.0)
  * minitest-retry (0.2.2)
  * msgpack (1.7.0)
  * multi_xml (0.6.0)
  * net-imap (0.3.4)
  * net-pop (0.1.2)
  * net-protocol (0.2.1)
  * net-smtp (0.3.3)
  * netrc (0.11.0)
  * nice_partials (0.9.3)
  * nio4r (2.5.9)
  * nokogiri (1.14.3)
  * oauth2 (2.0.9)
  * omniauth (1.9.2)
  * omniauth-oauth2 (1.7.3)
  * omniauth-rails_csrf_protection (0.1.2)
  * omniauth-stripe-connect (2.10.1)
  * orm_adapter (0.5.0)
  * pagy (5.10.1)
  * pagy_cursor (0.5.0)
  * parallel (1.22.1)
  * parser (3.2.2.0)
  * pg (1.4.6)
  * phonelib (0.8.1)
  * possessive (1.0.1)
  * postmark (1.23.0)
  * postmark-rails (0.22.1)
  * premailer (1.21.0)
  * premailer-rails (1.12.0)
  * pry (0.14.2)
  * pry-stack_explorer (0.6.1)
  * public_suffix (5.0.1)
  * puma (6.2.1)
  * pwned (2.0.2)
  * racc (1.6.2)
  * rack (2.2.6.4)
  * rack-cors (2.0.1)
  * rack-mini-profiler (3.0.0)
  * rack-test (2.1.0)
  * rails (7.0.4.3)
  * rails-dom-testing (2.0.3)
  * rails-html-sanitizer (1.5.0)
  * rails_autoscale_agent (0.12.0)
  * rails_best_practices (1.23.2)
  * railties (7.0.4.3)
  * rainbow (3.1.1)
  * rake (13.0.6)
  * redis (5.0.6)
  * redis-client (0.14.1)
  * regexp_parser (2.7.0)
  * reline (0.3.3)
  * require_all (3.0.0)
  * responders (3.1.0)
  * rest-client (2.1.0)
  * rexml (3.2.5)
  * rotp (6.2.2)
  * rqrcode (2.1.2)
  * rqrcode_core (1.2.0)
  * rubocop (1.48.1)
  * rubocop-ast (1.28.0)
  * rubocop-performance (1.16.0)
  * ruby-openai (3.7.0)
  * ruby-progressbar (1.13.0)
  * ruby2_keywords (0.0.5)
  * rubyzip (2.3.2)
  * selenium-webdriver (4.8.6)
  * sentry-rails (5.8.0)
  * sentry-ruby (5.8.0)
  * sentry-sidekiq (5.8.0)
  * sexp_processor (4.16.1)
  * showcase-rails (0.4.2)
  * sidekiq (7.0.7)
  * simplecov (0.22.0)
  * simplecov-html (0.12.3)
  * simplecov_json_formatter (0.1.4)
  * simpleidn (0.2.1)
  * snaky_hash (2.0.1)
  * sprockets (4.2.0)
  * sprockets-rails (3.4.2)
  * standard (1.26.0)
  * stimulus-rails (1.2.1)
  * stripe (8.5.0)
  * thor (1.2.1)
  * thread-local (1.1.0)
  * timeout (0.3.2)
  * turbo-rails (1.4.0)
  * tzinfo (2.0.6)
  * unf (0.1.4)
  * unf_ext (0.0.8.2)
  * unicode-display_width (2.4.2)
  * unicode-emoji (3.3.2)
  * unicode-version (1.3.0)
  * valid_email (0.1.4)
  * version_gem (1.1.2)
  * warden (1.2.9)
  * web-console (4.2.0)
  * webdrivers (5.2.0)
  * websocket (1.2.9)
  * websocket-driver (0.7.5)
  * websocket-extensions (0.1.5)
  * xpath (3.2.0)
  * xxhash (0.5.0)
  * zeitwerk (2.6.7)

Note: If this file was previously ejected from a package, we can no longer see which package it came from. However, it should say at the top of the file where it was ejected from.

> 
```

## The fix
I added a `?` on `bullet_train-core` so it will work for both published gems and `local/bullet_train-core` gems. Since we don't have tests I'm checking things manually, but if anyone wants to try out the branch and give feedback that would be helpful too.