### PR TITLE
Fix for `api/example_bot` to work on non-postgres apps

### DIFF
--- a/bullet_train-api/lib/bullet_train/api/example_bot.rb
+++ b/bullet_train-api/lib/bullet_train/api/example_bot.rb
@@ -58,6 +58,8 @@ module FactoryBot
     end
 
     def reset_tables!
+      # This is only availble for postgres
+      return unless ActiveRecord::Base.connection.respond_to?(:reset_pk_sequence!)
       @tables_to_reset.each do |name|
         ActiveRecord::Base.connection.reset_pk_sequence!(name) if ActiveRecord::Base.connection.table_exists?(name)
       end


### PR DESCRIPTION
reset_pk_sequence is only available for Postgres, not MySQL, so check that the method is available before calling.