### PR TITLE
Invitations API

### DIFF
--- a/bullet_train-api/app/controllers/concerns/api/controllers/base.rb
+++ b/bullet_train-api/app/controllers/concerns/api/controllers/base.rb
@@ -89,6 +89,10 @@ module Api::Controllers::Base
     current_user&.teams&.first
   end
 
+  def current_membership
+    current_user.memberships.where(team: current_team).first
+  end
+
   def collection_variable
     @collection_variable ||= "@#{self.class.name.split("::").last.gsub("Controller", "").underscore}"
   end

--- a/bullet_train-api/app/controllers/concerns/api/v1/invitations/controller_base.rb
+++ b/bullet_train-api/app/controllers/concerns/api/v1/invitations/controller_base.rb
@@ -49,14 +49,16 @@ module Api::V1::Invitations::ControllerBase
     end
   end
 
-  # # PUT /api/v1/invitations/:id
-  # def update
-  #   if @invitation.update(invitation_params)
-  #     render :show
-  #   else
-  #     render json: @invitation.errors, status: :unprocessable_entity
-  #   end
-  # end
+  # POST /api/v1/invitations/1/resend
+  def resend
+    if @invitation.touch
+      UserMailer.invited(params[:id]).deliver_later
+      @invitation
+      render :show, status: :ok, location: [:api, :v1, @invitation]
+    else
+      render json: @invitation.errors, status: :unprocessable_entity
+    end
+  end
 
   # DELETE /api/v1/invitations/:id
   def destroy

--- a/bullet_train-api/app/controllers/concerns/api/v1/invitations/controller_base.rb
+++ b/bullet_train-api/app/controllers/concerns/api/v1/invitations/controller_base.rb
@@ -53,7 +53,6 @@ module Api::V1::Invitations::ControllerBase
   def resend
     if @invitation.touch
       UserMailer.invited(params[:id]).deliver_later
-      @invitation
       render :show, status: :ok, location: [:api, :v1, @invitation]
     else
       render json: @invitation.errors, status: :unprocessable_entity

--- a/bullet_train-api/app/controllers/concerns/api/v1/invitations/controller_base.rb
+++ b/bullet_train-api/app/controllers/concerns/api/v1/invitations/controller_base.rb
@@ -1,0 +1,65 @@
+module Api::V1::Invitations::ControllerBase
+  extend ActiveSupport::Concern
+
+  module StrongParameters
+    # Only allow a list of trusted parameters through.
+    def invitation_params
+      strong_params = params.require(:invitation).permit(
+        *permitted_fields,
+        :email,
+        # 🚅 super scaffolding will insert new fields above this line.
+        *permitted_arrays,
+        # 🚅 super scaffolding will insert new arrays above this line
+      )
+
+      process_params(strong_params)
+
+      strong_params
+    end
+  end
+
+  included do
+    load_and_authorize_resource :invitation, class: "Invitation", prepend: true,
+      member_actions: (defined?(MEMBER_ACTIONS) ? MEMBER_ACTIONS : []),
+      collection_actions: (defined?(COLLECTION_ACTIONS) ? COLLECTION_ACTIONS : [])
+
+    private
+
+    include StrongParameters
+  end
+
+  # GET /api/v1/teams/:team_id/invitations
+  def index
+  end
+
+  # GET /api/v1/invitations/:id
+  def show
+  end
+
+  # POST /api/v1/teams/:team_id/invitations
+  def create
+    @invitation.membership.team = current_team
+    # this allows notifications to be sent to a user before they've accepted their invitation.
+    @invitation.membership.user_email = @invitation.email
+    @invitation.from_membership = current_membership
+    if @invitation.save
+      render :show, status: :created, location: [:api, :v1, @invitation]
+    else
+      render json: @invitation.errors, status: :unprocessable_entity
+    end
+  end
+
+  # # PUT /api/v1/invitations/:id
+  # def update
+  #   if @invitation.update(invitation_params)
+  #     render :show
+  #   else
+  #     render json: @invitation.errors, status: :unprocessable_entity
+  #   end
+  # end
+
+  # DELETE /api/v1/invitations/:id
+  def destroy
+    @invitation.destroy
+  end
+end

--- a/bullet_train-api/app/views/api/v1/invitations/index.json.jbuilder
+++ b/bullet_train-api/app/views/api/v1/invitations/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @invitations, partial: "api/v1/invitations/invitation", as: :invitation

--- a/bullet_train-api/app/views/api/v1/invitations/show.json.jbuilder
+++ b/bullet_train-api/app/views/api/v1/invitations/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "api/v1/invitations/invitation", invitation: @invitation

--- a/bullet_train-api/config/routes.rb
+++ b/bullet_train-api/config/routes.rb
@@ -27,7 +27,11 @@ Rails.application.routes.draw do
         shallow do
           resources :users
           resources :teams do
-            resources :invitations
+            resources :invitations do
+              member do
+                post :resend
+              end
+            end
             resources :memberships
             namespace :platform do
               resources :applications do

--- a/bullet_train/app/controllers/concerns/account/invitations/controller_base.rb
+++ b/bullet_train/app/controllers/concerns/account/invitations/controller_base.rb
@@ -76,7 +76,7 @@ module Account::Invitations::ControllerBase
   # POST /invitations/1/resend
   def resend
     @invitation = Invitation.find_by(uuid: params[:id])
-    if @invitation
+    if @invitation.touch
       UserMailer.invited(params[:id]).deliver_later
       redirect_to account_team_invitations_path(@invitation.membership.team), notice: I18n.t("invitations.notifications.resent")
     else

--- a/bullet_train/app/controllers/concerns/account/invitations/controller_base.rb
+++ b/bullet_train/app/controllers/concerns/account/invitations/controller_base.rb
@@ -76,7 +76,7 @@ module Account::Invitations::ControllerBase
   # POST /invitations/1/resend
   def resend
     @invitation = Invitation.find_by(uuid: params[:id])
-    if @invitation.touch
+    if @invitation&.touch
       UserMailer.invited(params[:id]).deliver_later
       redirect_to account_team_invitations_path(@invitation.membership.team), notice: I18n.t("invitations.notifications.resent")
     else

--- a/bullet_train/app/models/concerns/invitations/base.rb
+++ b/bullet_train/app/models/concerns/invitations/base.rb
@@ -5,7 +5,6 @@ module Invitations::Base
     belongs_to :team
     belongs_to :from_membership, class_name: "Membership"
     has_one :membership, dependent: :nullify
-    has_many :roles, through: :membership
 
     accepts_nested_attributes_for :membership
 
@@ -15,6 +14,10 @@ module Invitations::Base
     after_create :send_invitation_email
 
     attribute :uuid, default: -> { SecureRandom.hex }
+
+    def roles
+      membership.roles
+    end
   end
 
   def set_added_by_membership

--- a/bullet_train/config/locales/en/invitations.en.yml
+++ b/bullet_train/config/locales/en/invitations.en.yml
@@ -13,10 +13,26 @@ en:
       confirmations:
         destroy: Are you sure you want cancel the invitation to %{invitation_name}? The invitation they've received will no longer work. This can't be undone.
     fields: &fields
+      id:
+        _: &id Invitation ID
+        label: *id
+        heading: *id
       email:
-        name: &email Email Address
+        _: &email Email Address
         label: *email
         heading: *email
+      uuid:
+        name: &uuid Invitation UUID
+        label: *uuid
+        heading: *uuid
+      from_membership_id:
+        name: &from_membership_id Who sent ID
+        label: *from_membership_id
+        heading: *from_membership_id
+      team_id:
+        name: &team_id Team ID
+        label: *team_id
+        heading: *team_id
       roles: &role_ids
         name: &roles Special Privileges
         label: *roles
@@ -26,6 +42,9 @@ en:
       created_at:
         name: &created_at Sent
         heading: *created_at
+      updated_at:
+        name: &updated_at Updated
+        heading: *updated_at
     index:
       section: "Invitations for %{team_name}"
       header: Team Member Invitations


### PR DESCRIPTION
Implements memberships API and adds OpenAPI specs for invitations.
Requires https://github.com/bullet-train-co/bullet_train/pull/737

Replaced `has_many :roles, through: :membership` in `bullet_train/app/models/concerns/invitations/base.rb` with a method as `roles` is not a table.