### PR TITLE
Fix: Paths methods generation for OpenAPI

### DIFF
--- a/bullet_train-api/app/helpers/api/open_api_helper.rb
+++ b/bullet_train-api/app/helpers/api/open_api_helper.rb
@@ -40,24 +40,10 @@ module Api
       # There are some placeholders specific to this method that we still need to transform.
       model_symbol = model.name.underscore.tr("/", "_").to_sym
 
-      if (get_example = FactoryBot.get_example(model_symbol, version: @version))
-        output.gsub!("🚅 get_example", get_example)
-      end
-
-      if (post_parameters = FactoryBot.post_parameters(model_symbol, version: @version))
-        output.gsub!("🚅 post_parameters", post_parameters)
-      end
-
-      if (post_examples = FactoryBot.post_examples(model_symbol, version: @version))
-        output.gsub!("🚅 post_examples", post_examples)
-      end
-
-      if (put_parameters = FactoryBot.put_parameters(model_symbol, version: @version))
-        output.gsub!("🚅 put_parameters", put_parameters)
-      end
-
-      if (put_example = FactoryBot.put_example(model_symbol, version: @version))
-        output.gsub!("🚅 put_example", put_example)
+      FactoryBot::ExampleBot::REST_METHODS.each do |method|
+        if (code = FactoryBot.send(method, model_symbol, version: @version))
+          output.gsub!("🚅 #{method}", code)
+        end
       end
 
       indent(output, 1)

--- a/bullet_train-api/app/views/api/v1/open_api/shared/_paths.yaml.erb
+++ b/bullet_train-api/app/views/api/v1/open_api/shared/_paths.yaml.erb
@@ -31,7 +31,7 @@
               items:
                 $ref: "#/components/schemas/ScaffoldingCompletelyConcreteTangibleThingAttributes"
             example:
-              🚅 get_example
+              🚅 get_examples
   <% end %>
   <% unless except.include?(:create) %>
   post:
@@ -68,7 +68,7 @@
             schema:
               $ref: "#/components/schemas/ScaffoldingCompletelyConcreteTangibleThingAttributes"
             example:
-              🚅 post_examples
+              🚅 post_example
   <% end %>
 <% end %>
 <% unless except.include?(:show) && except.include?(:update) && except.include?(:destroy) %>

--- a/bullet_train-api/lib/bullet_train/api/example_bot.rb
+++ b/bullet_train-api/lib/bullet_train/api/example_bot.rb
@@ -39,7 +39,9 @@ module FactoryBot
       objects
     end
 
-    %i[get_examples get_example post_examples post_parameters put_example put_parameters patch_example patch_parameters].each do |method|
+    REST_METHODS = %i[get_examples get_example post_example post_parameters put_example put_parameters patch_example patch_parameters]
+
+    REST_METHODS.each do |method|
       define_method(method) do |model, **options|
         _path_examples(method.to_s, model, **options)
       end


### PR DESCRIPTION
Fixes generation of path methods (`get_examples`, `post_parameters` etc.)
Requires https://github.com/bullet-train-co/bullet_train/pull/738