### PR TITLE
Add gap-y and gap-x to showcase partial

### DIFF
--- a/bullet_train-themes-light/app/views/showcase/previews/tailwind/utilities/_spacing.html.erb
+++ b/bullet_train-themes-light/app/views/showcase/previews/tailwind/utilities/_spacing.html.erb
@@ -18,4 +18,20 @@
   </div>
 <% end %>
 
-<% # TODO Add `gap-y` and `gap-x`. %>
+<% showcase.sample "Vertical Gaps" do %>
+  <div class="grid gap-y">
+    <div class="button block">Item</div>
+    <div class="button block">Item</div>
+    <div class="button block">Item</div>
+    <div class="button block">Item</div>
+  </div>
+<% end %>
+
+<% showcase.sample "Horizontal Gaps" do %>
+  <div class="flex gap-x">
+    <div class="flex-1 button">Item</div>
+    <div class="flex-1 button">Item</div>
+    <div class="flex-1 button">Item</div>
+    <div class="flex-1 button">Item</div>
+  </div>
+<% end %>


### PR DESCRIPTION
Addresses the TODO in `bullet_train-themes-light/app/views/showcase/previews/tailwind/utilities/_spacing.html.erb`

## Details
The result isn't that different from the styles for `space-x` and `space-y` which were already there. However, I had trouble getting some of the spacing to work with `flex`.

From the [Tailwind docs](bullet_train-themes-light/app/views/showcase/previews/tailwind/utilities/_spacing.html.erb):
> Use gap-{size} to change the gap between both rows and columns in grid and flexbox layouts.

I went ahead and updated `Vertical Gaps` with `grid` for this reason.

![Screenshot from 2023-04-25 20-41-32](https://user-images.githubusercontent.com/10546292/234266563-c54d2ae2-c13d-44ed-bb8b-45fe453df448.png)
