### PR TITLE
Render table rows as collections

### DIFF
--- a/bullet_train-super_scaffolding/app/views/account/scaffolding/absolutely_abstract/creative_concepts/_index.html.erb
+++ b/bullet_train-super_scaffolding/app/views/account/scaffolding/absolutely_abstract/creative_concepts/_index.html.erb
@@ -27,9 +27,7 @@
             </tr>
           </thead>
           <tbody>
-            <% creative_concepts.each do |creative_concept| %>
-              <%= render 'account/scaffolding/absolutely_abstract/creative_concepts/creative_concept', creative_concept: creative_concept %>
-            <% end %>
+            <%= render partial: 'account/scaffolding/absolutely_abstract/creative_concepts/creative_concept', collection: creative_concepts %>
           </tbody>
         </table>
       <% end %>

--- a/bullet_train-super_scaffolding/app/views/account/scaffolding/completely_concrete/tangible_things/_index.html.erb
+++ b/bullet_train-super_scaffolding/app/views/account/scaffolding/completely_concrete/tangible_things/_index.html.erb
@@ -35,9 +35,7 @@
               </tr>
             </thead>
             <tbody>
-              <% tangible_things.each do |tangible_thing| %>
-                <%= render 'account/scaffolding/completely_concrete/tangible_things/tangible_thing', tangible_thing: tangible_thing %>
-              <% end %>
+              <%= render partial: 'account/scaffolding/completely_concrete/tangible_things/tangible_thing', collection: tangible_things %>
             </tbody>
           </table>
         <% end %>


### PR DESCRIPTION
Changes the way table rows in super scaffolded index views are rendered from a loop to a native `render partial: ... collection: ...` call.

This has multiple advantages:

1. It is highly optimized for Russian doll caching by adding `cached: true` (which will use multi-fetch if the cache store supports it)
2. It provides a `counter` local variable inside the rendered partial