### PR TITLE
Add environment variable check for `billing_enabled?` helper

### DIFF
--- a/bullet_train/lib/bullet_train.rb
+++ b/bullet_train/lib/bullet_train.rb
@@ -82,7 +82,7 @@ def inbound_email_enabled?
 end
 
 def billing_enabled?
-  defined?(BulletTrain::Billing)
+  ENV["STRIPE_SECRET_KEY"].present? && defined?(BulletTrain::Billing)
 end
 
 # TODO This should be in an initializer or something.


### PR DESCRIPTION
Closes #244.

It seems like we want this to be dependent on the presence of the gem itself as opposed to the environment variable, but I included this check just in case since subscriptions won't work if the API key isn't there.

Also, since the `bullet_train-billing` and `bullet_train-billing-stripe` gems are each their own thing, I can look into this deeper if we want to separate the logic and only check for the Stripe API key when using `bullet_train-billing-stripe`.

cc/ @jagthedrummer