### PR TITLE
Fix: OpenAPI warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,4 +46,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.3.8
+   2.4.12

--- a/bullet_train-api/app/helpers/api/open_api_helper.rb
+++ b/bullet_train-api/app/helpers/api/open_api_helper.rb
@@ -60,7 +60,7 @@ module Api
       }.merge(locals))
 
       schema_json = jbuilder.json(
-        FactoryBot.example(model.name.underscore.to_sym) || model.new,
+        FactoryBot.example(model.model_name.param_key.to_sym) || model.new,
         title: I18n.t("#{model.name.underscore.pluralize}.label"),
         # TODO Improve this. We don't have a generic description for models we can use here.
         description: I18n.t("#{model.name.underscore.pluralize}.label"),

--- a/bullet_train-api/app/helpers/api/open_api_helper.rb
+++ b/bullet_train-api/app/helpers/api/open_api_helper.rb
@@ -60,7 +60,7 @@ module Api
       }.merge(locals))
 
       schema_json = jbuilder.json(
-        model.new,
+        FactoryBot.example(model.name.underscore.to_sym) || model.new,
         title: I18n.t("#{model.name.underscore.pluralize}.label"),
         # TODO Improve this. We don't have a generic description for models we can use here.
         description: I18n.t("#{model.name.underscore.pluralize}.label"),
@@ -92,7 +92,8 @@ module Api
 
         parameters_output = JSON.parse(schema_json)
         parameters_output["required"].select! { |key| strong_parameter_keys.include?(key.to_sym) }
-        parameters_output["properties"].select! { |key, value| strong_parameter_keys.include?(key.to_sym) }
+        parameters_output["properties"].select! { |key| strong_parameter_keys.include?(key.to_sym) }
+        parameters_output["example"]&.select! { |key, value| strong_parameter_keys.include?(key.to_sym) && value.present? }
 
         (
           indent(attributes_output.to_yaml.gsub("---", "#{model.name.gsub("::", "")}Attributes:"), 3) +

--- a/bullet_train-api/app/views/api/v1/open_api/shared/_paths.yaml.erb
+++ b/bullet_train-api/app/views/api/v1/open_api/shared/_paths.yaml.erb
@@ -12,7 +12,7 @@
         in: path
         required: true
         schema:
-          type: string
+          type: integer
       - $ref: "#/components/parameters/after"
     responses:
       "404":
@@ -44,7 +44,7 @@
         in: path
         required: true
         schema:
-          type: string
+          type: integer
     requestBody:
       description: "Information about a new Tangible Thing"
       required: true

--- a/bullet_train-api/bullet_train-api.gemspec
+++ b/bullet_train-api/bullet_train-api.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pagy_cursor"
   spec.add_dependency "rack-cors"
   spec.add_dependency "doorkeeper"
-  spec.add_dependency "jbuilder-schema", ">= 2.0.0"
+  spec.add_dependency "jbuilder-schema", ">= 2.2.0"
   spec.add_dependency "factory_bot"
 
   spec.add_dependency "bullet_train"

--- a/bullet_train-api/lib/bullet_train/api.rb
+++ b/bullet_train-api/lib/bullet_train/api.rb
@@ -14,6 +14,7 @@ require "scaffolding"
 require "scaffolding/block_manipulator"
 require "scaffolding/transformer"
 require "jbuilder/schema"
+require "jbuilder/hacks"
 
 module BulletTrain
   module Api

--- a/bullet_train-api/lib/bullet_train/api.rb
+++ b/bullet_train-api/lib/bullet_train/api.rb
@@ -14,7 +14,7 @@ require "scaffolding"
 require "scaffolding/block_manipulator"
 require "scaffolding/transformer"
 require "jbuilder/schema"
-require "jbuilder/hacks"
+require "jbuilder/values_transformer"
 
 module BulletTrain
   module Api

--- a/bullet_train-api/lib/bullet_train/api/example_bot.rb
+++ b/bullet_train-api/lib/bullet_train/api/example_bot.rb
@@ -104,7 +104,7 @@ module FactoryBot
             parameters_output&.select! { |key| strong_parameter_keys.include?(key.to_sym) }
 
             # Wrapping the example as parameters should be wrapped with the model name:
-            parameters_output = { model.to_s => parameters_output }
+            parameters_output = {model.to_s => parameters_output}
 
             return indent(parameters_output.to_yaml.delete_prefix("---\n"), 6).html_safe
           end

--- a/bullet_train-api/lib/bullet_train/api/example_bot.rb
+++ b/bullet_train-api/lib/bullet_train/api/example_bot.rb
@@ -90,7 +90,7 @@ module FactoryBot
       else
         template, class_name, var_name, values = _set_values("get_example", model)
 
-        unless %w[example examples].include?(method.split("_").last)
+        if method.end_with?("parameters")
           if has_strong_parameters?("::Api::#{version.upcase}::#{class_name.pluralize}Controller".constantize)
             strong_params_module = "::Api::#{version.upcase}::#{class_name.pluralize}Controller::StrongParameters".constantize
             strong_parameter_keys = BulletTrain::Api::StrongParametersReporter.new(class_name.constantize, strong_params_module).report
@@ -102,6 +102,9 @@ module FactoryBot
 
             parameters_output = JSON.parse(output)
             parameters_output&.select! { |key| strong_parameter_keys.include?(key.to_sym) }
+
+            # Wrapping the example as parameters should be wrapped with the model name:
+            parameters_output = { model.to_s => parameters_output }
 
             return indent(parameters_output.to_yaml.delete_prefix("---\n"), 6).html_safe
           end

--- a/bullet_train-api/lib/jbuilder/hacks.rb
+++ b/bullet_train-api/lib/jbuilder/hacks.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "jbuilder"
+
+module Hacks
+  def _set_value(key, value)
+    value = value.body if value.is_a?(ActionText::RichText)
+
+    super(key, value)
+  end
+end
+
+::Jbuilder.prepend Hacks

--- a/bullet_train-api/lib/jbuilder/values_transformer.rb
+++ b/bullet_train-api/lib/jbuilder/values_transformer.rb
@@ -2,7 +2,7 @@
 
 require "jbuilder"
 
-module Hacks
+module ValuesTransformer
   def _set_value(key, value)
     value = value.body if value.is_a?(ActionText::RichText)
 
@@ -10,4 +10,4 @@ module Hacks
   end
 end
 
-::Jbuilder.prepend Hacks
+::Jbuilder.prepend ValuesTransformer


### PR DESCRIPTION
Closes https://github.com/bullet-train-co/bullet_train/issues/734
Requires https://github.com/bullet-train-co/bullet_train/pull/749

- Fixes warnings shown by `yarn exec redocly lint http://127.0.0.1:3000/api/v1/openapi.yaml`
- Includes https://github.com/bullet-train-co/bullet_train-core/pull/236 and https://github.com/bullet-train-co/bullet_train-core/pull/258
- Test `test/controllers/api/open_api_controller_test.rb` in starter repo was rewritten to fail on warnings
- Upgraded `jbuilder-schema` to `>= 2.2.0`
- Added Jbuilder hack module in `bullet_train-api/lib/jbuilder/values_transformer.rb` to modify attributes produced by external classes, by now it replaces `ActionText::RichText` object with it's `body` value. More can be added if needed.
