### PR TITLE
Update to Ruby 3.2.2 to match the starter repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
   browser-tools: circleci/browser-tools@1.4.1
 aliases:
   - &ruby_node_browsers_docker_image
-      - image: cimg/ruby:3.2.1-browsers
+      - image: cimg/ruby:3.2.2-browsers
         environment:
           PGHOST: localhost
           PGUSER: untitled_application

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.2.1"
+ruby "3.2.2"
 
 gem "standard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,7 @@ DEPENDENCIES
   standard
 
 RUBY VERSION
-   ruby 3.2.1p31
+   ruby 3.2.2p53
 
 BUNDLED WITH
    2.3.8

--- a/bullet_train-api/.circleci/config.yml
+++ b/bullet_train-api/.circleci/config.yml
@@ -26,7 +26,7 @@ aliases:
       paths:
         - node_modules
   - &ruby_node_browsers_docker_image
-      - image: cimg/ruby:3.1.2-browsers
+      - image: cimg/ruby:3.2.2-browsers
         environment:
           PGHOST: localhost
           PGUSER: untitled_application

--- a/bullet_train-fields/.circleci/config.yml
+++ b/bullet_train-fields/.circleci/config.yml
@@ -26,7 +26,7 @@ aliases:
       paths:
         - node_modules
   - &ruby_node_browsers_docker_image
-      - image: cimg/ruby:3.1.2-browsers
+      - image: cimg/ruby:3.2.2-browsers
         environment:
           PGHOST: localhost
           PGUSER: untitled_application

--- a/bullet_train-outgoing_webhooks/.circleci/config.yml
+++ b/bullet_train-outgoing_webhooks/.circleci/config.yml
@@ -26,7 +26,7 @@ aliases:
       paths:
         - node_modules
   - &ruby_node_browsers_docker_image
-      - image: cimg/ruby:3.1.2-browsers
+      - image: cimg/ruby:3.2.2-browsers
         environment:
           PGHOST: localhost
           PGUSER: untitled_application

--- a/bullet_train-roles/.circleci/config.yml
+++ b/bullet_train-roles/.circleci/config.yml
@@ -26,7 +26,7 @@ aliases:
       paths:
         - node_modules
   - &ruby_node_browsers_docker_image
-      - image: cimg/ruby:3.1.2-browsers
+      - image: cimg/ruby:3.2.2-browsers
         environment:
           PGHOST: localhost
           PGUSER: untitled_application

--- a/bullet_train-sortable/.circleci/config.yml
+++ b/bullet_train-sortable/.circleci/config.yml
@@ -26,7 +26,7 @@ aliases:
       paths:
         - node_modules
   - &ruby_node_browsers_docker_image
-      - image: cimg/ruby:3.1.2-browsers
+      - image: cimg/ruby:3.2.2-browsers
         environment:
           PGHOST: localhost
           PGUSER: untitled_application

--- a/bullet_train-super_scaffolding/.circleci/config.yml
+++ b/bullet_train-super_scaffolding/.circleci/config.yml
@@ -26,7 +26,7 @@ aliases:
       paths:
         - node_modules
   - &ruby_node_browsers_docker_image
-      - image: cimg/ruby:3.1.2-browsers
+      - image: cimg/ruby:3.2.2-browsers
         environment:
           PGHOST: localhost
           PGUSER: untitled_application

--- a/bullet_train-themes-light/.circleci/config.yml
+++ b/bullet_train-themes-light/.circleci/config.yml
@@ -26,7 +26,7 @@ aliases:
       paths:
         - node_modules
   - &ruby_node_browsers_docker_image
-      - image: cimg/ruby:3.1.2-browsers
+      - image: cimg/ruby:3.2.2-browsers
         environment:
           PGHOST: localhost
           PGUSER: untitled_application

--- a/bullet_train-themes-tailwind_css/.circleci/config.yml
+++ b/bullet_train-themes-tailwind_css/.circleci/config.yml
@@ -26,7 +26,7 @@ aliases:
       paths:
         - node_modules
   - &ruby_node_browsers_docker_image
-      - image: cimg/ruby:3.1.2-browsers
+      - image: cimg/ruby:3.2.2-browsers
         environment:
           PGHOST: localhost
           PGUSER: untitled_application

--- a/bullet_train-themes/.circleci/config.yml
+++ b/bullet_train-themes/.circleci/config.yml
@@ -26,7 +26,7 @@ aliases:
       paths:
         - node_modules
   - &ruby_node_browsers_docker_image
-      - image: cimg/ruby:3.1.2-browsers
+      - image: cimg/ruby:3.2.2-browsers
         environment:
           PGHOST: localhost
           PGUSER: untitled_application

--- a/bullet_train/.circleci/config.yml
+++ b/bullet_train/.circleci/config.yml
@@ -49,7 +49,7 @@ aliases:
       paths:
         - tmp/starter/node_modules
   - &ruby_node_browsers_docker_image
-      - image: cimg/ruby:3.1.2-browsers
+      - image: cimg/ruby:3.2.2-browsers
         environment:
           PGHOST: localhost
           PGUSER: untitled_application


### PR DESCRIPTION
Continuation of https://github.com/bullet-train-co/bullet_train/pull/733
This PR ensures we use Ruby 3.2.2 and that 3.2.2 is used in our CI tests.