### PR TITLE
Permit cloudinary photo in User strong parameters

### DIFF
--- a/bullet_train-api/app/controllers/concerns/api/v1/users/controller_base.rb
+++ b/bullet_train-api/app/controllers/concerns/api/v1/users/controller_base.rb
@@ -14,7 +14,8 @@ module Api::V1::Users::ControllerBase
         :first_name,
         :last_name,
         :time_zone,
-        :locale
+        :locale,
+        :profile_photo_id
       ]
 
       selected_fields = if params.is_a?(BulletTrain::Api::StrongParametersReporter)


### PR DESCRIPTION
When updating a user with a cloudinary photo for their profile, the user was being "successfully updated," but we didn't have this strong parameter so the image wasn't actually being saved to the User.

This fix ensures the image is saved and can be seen in the circle in the menu bar in place of the `ui-avatars` avatar.