### PR TITLE
Add additional message to `bin/super-scaffold crud` command print out.

### DIFF
--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb
@@ -27,6 +27,8 @@ module BulletTrain
             puts ""
             puts "Give it a shot! Let us know if you have any trouble with it! ✌️"
             puts ""
+            puts "Testing the Bullet Train contribution process."
+            puts ""
             exit
           end
 


### PR DESCRIPTION
This PR is for the Improving Bullet Train Packages part of the [onboarding tasks](https://gist.github.com/zackgilbert/608242d2fd82464f6b6eef724de9cd7b).

It showcases the completed task:
- [x] In that branch, modify the Super Scaffolding code so when you run bin/super-scaffold crud in your Bullet Train application, an additional message prints out with the help message saying “Testing the Bullet Train contribution process.”

And in itself, completes:
- [x] Push this branch up to your forked repository and open a PR against the original Super Scaffolding repository.


Just including my notes/commands for reference. The play-by-play wouldn't be a standard feature for actual PRs:
```
bin/hack
# enter (not selecting a specific branch)
cd local/bullet_train-core
git remote rm origin
git remote add origin git@github.com:zackgilbert/bullet_train-core.git
# confirm origin updated correctly:
git remote -v
git checkout -b testing/contributions
bundle update
# Searched for "E.g. a Team has many Sites with some attributes" to find it located:
# /Users/zackgilbert/Developer/bullet-train/super_project/local/bullet_train-core/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb
```