### PR TITLE
Upstream support for endpoints having a single event source.

### DIFF
--- a/bullet_train-outgoing_webhooks/app/models/concerns/webhooks/outgoing/event_support.rb
+++ b/bullet_train-outgoing_webhooks/app/models/concerns/webhooks/outgoing/event_support.rb
@@ -8,6 +8,11 @@ module Webhooks::Outgoing::EventSupport
     belongs_to :subject, polymorphic: true
     has_many :deliveries, dependent: :destroy
 
+    # This is an undocumented feature implemented for one project and subject to change. Don't use it.
+    belongs_to :issuer, polymorphic: true, optional: true
+
+    validates :data, presence: true
+
     before_create do
       self.payload = generate_payload
     end
@@ -27,7 +32,17 @@ module Webhooks::Outgoing::EventSupport
     payload.dig("event_type")
   end
 
+  # This is an undocumented feature implemented for one project and subject to change. Don't use it.
+  def self.issuer_enabled?
+    column_names.include?("issuer_id")
+  end
+
   def endpoints
+    # This is an undocumented feature implemented for one project and subject to change. Don't use it.
+    if self.class.issuer_enabled? && issuer
+      return [issuer.webhooks_outgoing_endpoint]
+    end
+
     endpoints = send(BulletTrain::OutgoingWebhooks.parent_association).webhooks_outgoing_endpoints.where(api_version: api_version).listening_for_event_type_id(event_type_id)
 
     case subject_type

--- a/bullet_train-outgoing_webhooks/app/models/concerns/webhooks/outgoing/event_support.rb
+++ b/bullet_train-outgoing_webhooks/app/models/concerns/webhooks/outgoing/event_support.rb
@@ -11,8 +11,6 @@ module Webhooks::Outgoing::EventSupport
     # This is an undocumented feature implemented for one project and subject to change. Don't use it.
     belongs_to :issuer, polymorphic: true, optional: true
 
-    validates :data, presence: true
-
     before_create do
       self.payload = generate_payload
     end

--- a/bullet_train-outgoing_webhooks/app/models/concerns/webhooks/outgoing/event_support.rb
+++ b/bullet_train-outgoing_webhooks/app/models/concerns/webhooks/outgoing/event_support.rb
@@ -31,13 +31,13 @@ module Webhooks::Outgoing::EventSupport
   end
 
   # This is an undocumented feature implemented for one project and subject to change. Don't use it.
-  def self.issuer_enabled?
-    column_names.include?("issuer_id")
+  def issuer_enabled?
+    self.class.column_names.include?("issuer_id")
   end
 
   def endpoints
     # This is an undocumented feature implemented for one project and subject to change. Don't use it.
-    if self.class.issuer_enabled? && issuer
+    if issuer_enabled? && issuer
       return [issuer.webhooks_outgoing_endpoint]
     end
 


### PR DESCRIPTION
This is an undocumented feature and shouldn't be used by anyone.