### PR TITLE
Refactor `with_attribute_settings`

### DIFF
--- a/bullet_train/app/helpers/attributes_helper.rb
+++ b/bullet_train/app/helpers/attributes_helper.rb
@@ -1,32 +1,17 @@
 module AttributesHelper
   def current_attributes_object
-    @_attributes_helper_objects&.last
+    @_current_attribute_settings&.dig(:object)
   end
 
   def current_attributes_strategy
-    @_attributes_helper_strategies&.last
+    @_current_attributes_settings&.dig(:strategy)
   end
 
-  def with_attribute_settings(options)
-    @_attributes_helper_objects ||= []
-    @_attributes_helper_strategies ||= []
-
-    if options[:object]
-      @_attributes_helper_objects << options[:object]
-    end
-
-    if options[:strategy]
-      @_attributes_helper_strategies << options[:strategy]
-    end
-
+  def with_attribute_settings(object: current_attributes_object, strategy: current_attributes_strategy)
+    old_attribute_settings = @_current_attribute_settings
+    @_current_attribute_settings = {object: object, strategy: strategy}
     yield
-
-    if options[:strategy]
-      @_attributes_helper_strategies.pop
-    end
-
-    if options[:object]
-      @_attributes_helper_objects.pop
-    end
+  ensure
+    @_current_attribute_settings = old_attribute_settings
   end
 end


### PR DESCRIPTION
Seems like we can just use one hash to store the settings in. And then use keyword argument defaults to preserve the old behavior of keeping the previous setting in case no override is passed.

This also uses `rescue` so we revert to the previous values in case an exception is thrown.