### PR TITLE
use secure_compare for invitation keys

### DIFF
--- a/bullet_train/app/helpers/invitation_only_helper.rb
+++ b/bullet_train/app/helpers/invitation_only_helper.rb
@@ -1,6 +1,14 @@
+require 'active_support/security_utils'
+
 module InvitationOnlyHelper
   def invited?
-    session[:invitation_key].present? && invitation_keys.include?(session[:invitation_key])
+    return false unless session[:invitation_key].present?
+
+    result = invitation_keys.find do |key|
+      ActiveSupport::SecurityUtils.secure_compare(key, session[:invitation_key])
+    end
+
+    result.present?
   end
 
   def show_sign_up_options?


### PR DESCRIPTION
closes https://github.com/bullet-train-co/bullet_train-core/issues/288

**Overview**
Updated the comparison for `invitation_keys` to use `secure_compare`

**Testing Done**
Set values in `ENV['INVITATION_KEYS']` locally and navigate to the `/invitation?key=XYZ`. Ensure that for keys that match one of the ones set in the environment variable, we are redirected correctly to create a new user or a new team. For keys that do not match, we are redirected to 404.
