### PR TITLE
Pass parameters properly to new access token nice partial translation

### DIFF
--- a/bullet_train-api/app/views/account/platform/access_tokens/new.html.erb
+++ b/bullet_train-api/app/views/account/platform/access_tokens/new.html.erb
@@ -1,7 +1,7 @@
 <%= render 'account/shared/page' do |page| %>
   <% page.title t('.section') %>
   <% page.body.render 'account/shared/box', divider: true do |box| %>
-    <% box.t :description, title: t('.header') %>
+    <% box.t :description, title: '.header' %>
     <% box.body.render 'form', access_token: @access_token %>
   <% end %>
 <% end %>


### PR DESCRIPTION
Closes #296.

Nice Partials states the following for using the `t` method:

https://github.com/bullet-train-co/nice_partials/blob/63f28a70eca0808a2474ca2a9cc8549acc799fca/lib/nice_partials/partial.rb#L23-L38

You can see that an invocation like `partial.t :description, title: "some.custom.key"` needs just the key, not the translated value, so I fixed that here.