### PR TITLE
Fix: Produce really underscored DOM ids from a title

### DIFF
--- a/bullet_train-themes-light/app/views/themes/light/menu/_subsection.html.erb
+++ b/bullet_train-themes-light/app/views/themes/light/menu/_subsection.html.erb
@@ -10,7 +10,7 @@
   </div>
 <% else %>
   <div>
-    <div class="inline-block relative group" data-controller="desktop-menu" data-action="keydown->desktop-menu#hideSubmenu" id="<%= title.underscore %>">
+    <div class="inline-block relative group" data-controller="desktop-menu" data-action="keydown->desktop-menu#hideSubmenu" id="<%= title.parameterize(separator: '_') %>">
       <%= render 'account/shared/menu/heading' do %>
         <%= title %>
 


### PR DESCRIPTION
Closes #278.

Replaces `.underscore` with `.parameterize(separator: '_')` in producing DOM ids from a title.

Using `parameterize` instead of `gsub` or `tr` not only downcases the string and replaces spaces with underscores, but also handles other special characters by converting them into their ASCII equivalents, which is useful for creating URL-friendly strings.