### PR TITLE
Use Tailwind for navigation bar link animation

### DIFF
--- a/bullet_train-themes-light/app/assets/stylesheets/light/application.css
+++ b/bullet_train-themes-light/app/assets/stylesheets/light/application.css
@@ -9,18 +9,6 @@
 @import './fields';
 @import './turn';
 
-/* TODO We should be able to do this in Tailwind CSS. */
-.hover-indent-child {
-  .indent-child {
-    transition: transform 0.2s ease;
-  }
-  &:hover {
-    .indent-child {
-      transform:translateX(8px);
-    }
-  }
-}
-
 form.button_to {
   @apply inline-block;
   input[type=submit] {

--- a/bullet_train-themes-light/app/views/themes/light/menu/_item.html.erb
+++ b/bullet_train-themes-light/app/views/themes/light/menu/_item.html.erb
@@ -1,8 +1,8 @@
 <% method ||= nil %>
 <% active ||= request.path == url %>
 
-<%= send (method ? :button_to : :link_to), url, class: "block group hover:text-white hover:no-underline #{'bg-primary-900 dark:bg-black dark:bg-opacity-10' if active} text-white #{@menu_orientation == :top ? "px-5 py-5" : "px-2 py-2 rounded-md hover-indent-child"} #{"rounded-tl-lg" unless @not_first || BulletTrain::Themes::Light.show_logo_in_account} dark:text-white", data: {"desktop-menu-target": "menuItemLink"}, tabIndex: 0, method: method do %>
-  <div class="inline-block indent-child flex items-center">
+<%= send (method ? :button_to : :link_to), url, class: "block group/item hover:text-white hover:no-underline #{'bg-primary-900 dark:bg-black dark:bg-opacity-10' if active} text-white #{@menu_orientation == :top ? "px-5 py-5" : "px-3 py-2 rounded-md"} #{"rounded-tl-lg" unless @not_first || BulletTrain::Themes::Light.show_logo_in_account} dark:text-white", data: {"desktop-menu-target": "menuItemLink"}, tabIndex: 0, method: method do %>
+  <div class="inline-block <%= "transition group-hover/item:translate-x-3 duration-200" if @menu_orientation == :side %> flex items-center">
     <!-- Heroicon name: home -->
     <% if partial.icon? %>
       <span class="mr-3 h-6 w-6 text-center text-secondary-300 text-xl leading-6 dark:text-slate-400">


### PR DESCRIPTION
Handling the TODO way back from this PR:
- https://github.com/bullet-train-co/bullet-train-tailwind-css/pull/315

This time around presented a challenge because now that we have flyout subsections, the hover groups weren't working properly. I added a name to the nested group for it to work. I found a pretty cool entry in the [Tailwind docs](https://tailwindcss.com/docs/hover-focus-and-other-states#differentiating-nested-groups) that led me to solve the issue:
> When nesting groups, you can style something based on the state of a specific parent group by giving that parent a unique group name using a `group/{name}` class, and including that name in modifiers using classes like `group-hover/{name}`

I also changed `px-2` to `px-3` because when the navigation bar is set to `:top` and when we're on the "Account Details" page, hovering over the "Account Details" link made the text overflow outside of the dark blue box it was in.