### PR TITLE
Change path search order of resolver

### DIFF
--- a/bullet_train/lib/bullet_train/resolver.rb
+++ b/bullet_train/lib/bullet_train/resolver.rb
@@ -89,7 +89,7 @@ module BulletTrain
         package_name: nil,
       }
 
-      result[:absolute_path] = file_path || class_path || partial_path || locale_path
+      result[:absolute_path] = file_path || class_path || locale_path || partial_path
 
       # If we get the partial resolver template itself, that means we couldn't find the file.
       if result[:absolute_path].match?("app/views/bullet_train/partial_resolver.html.erb")

--- a/bullet_train/lib/bullet_train/resolver.rb
+++ b/bullet_train/lib/bullet_train/resolver.rb
@@ -92,10 +92,10 @@ module BulletTrain
       result[:absolute_path] = file_path || class_path || locale_path || partial_path
 
       # If we get the partial resolver template itself, that means we couldn't find the file.
-      if result[:absolute_path].match?("app/views/bullet_train/partial_resolver.html.erb")
-        puts "We could not find the partial you're looking for: #{@needle}".red
+      if result[:absolute_path].match?("app/views/bullet_train/partial_resolver.html.erb") || result[:absolute_path].nil?
+        puts "We could not resolve the value you're looking for: #{@needle}".red
         puts ""
-        puts "Please try passing the partial string using either of the following two ways:"
+        puts "If you're looking for a partial, please try passing the partial string in either of the following two ways:"
         puts "1. Without underscore and extention: ".blue + "bin/resolve shared/attributes/code"
         puts "2. Literal path with package name: ".blue + "bin/resolve bullet_train-themes/app/views/themes/base/attributes/_code.html.erb"
         puts ""


### PR DESCRIPTION
Context: https://discord.com/channels/836637622432170028/836637623048601633/1109145560117686363

When a partial isn't found, we get the partial resolver itself (`partial_resolver.html.erb`), which raises the error shown in the Discord chat.

The problem is that this happens with the `partial_path` method, and since that value was being set to `result[:absolute_path]`, the resolver didn't bother to run `|| locale_path`.

## An issue with `locale_path` itself
After making the fix things were working fine for the following locales:
1. `en.account.onboarding.user_details.edit.header`
2. `en.devise.headers.sign_in`

The resolver was also working for model names like `Teams::Base`. However, `locale_path` was returning `nil` for `en.users.self.password.help` (a locale that can be found on the sign in page). This seems to be an issue with `locale_path` itself, so I think I'll have to look into that a little bit more.

I also wrote a more generalized message for when the value isn't found.