### PR TITLE
Prefer `.public_send` over `.send` in partials

### DIFF
--- a/bullet_train-themes-light/app/views/themes/light/attributes/_block.html.erb
+++ b/bullet_train-themes-light/app/views/themes/light/attributes/_block.html.erb
@@ -2,8 +2,8 @@
 <% strategy ||= current_attributes_strategy || :none %>
 <% url ||= nil %>
 
-<% if object.send(attribute).present? %>
+<% if object.public_send(attribute).present? %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
-    <pre><%= object.send(attribute) %></pre>
+    <pre><%= object.public_send(attribute) %></pre>
   <% end %>
 <% end %>

--- a/bullet_train-themes-light/app/views/themes/light/attributes/_progress_bar.html.erb
+++ b/bullet_train-themes-light/app/views/themes/light/attributes/_progress_bar.html.erb
@@ -4,7 +4,7 @@
 <% hide_completed ||= false %>
 
 <% if object.send(total).present? %>
-  <% completion_percent = (object.send(attribute).to_f / object.send(total).to_f) * 100.0 %>
+  <% completion_percent = (object.public_send(attribute).to_f / object.send(total).to_f) * 100.0 %>
 
   <% unless completion_percent == 100 && hide_completed %>
     <%= render 'shared/attributes/attribute', object: object, attribute: "#{attribute}_over_#{total}".to_sym, strategy: strategy, url: url do %>

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/attributes/_code.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/attributes/_code.html.erb
@@ -3,10 +3,10 @@
 <% source ||= nil %>
 <% url ||= nil %>
 <% secret ||= false %>
-<% if object.send(attribute).present? %>
+<% if object.public_send(attribute).present? %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
     <% if secret && source.nil? %>
-      <% attribute = object.send(attribute) %>
+      <% attribute = object.public_send(attribute) %>
       <% attribute_short = attribute[0..4] %>
       <div class="flex flex-row">
         <details class="group peer order-2">

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/attributes/_file.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/attributes/_file.erb
@@ -2,9 +2,9 @@
 <% strategy ||= current_attributes_strategy || :none %>
 <% url ||= nil %>
 
-<% if object.send(attribute).attached? %>
+<% if object.public_send(attribute).attached? %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
-    <%= link_to url_for(object.send(attribute)), class: 'button download-file' do %>
+    <%= link_to url_for(object.public_send(attribute)), class: 'button download-file' do %>
       <i class="leading-none mr-2 text-base ti ti-download"></i>
       <span><%= t("global.file_fields.download") %></span>
     <% end %>

--- a/bullet_train-themes/app/views/themes/base/attributes/_belongs_to.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_belongs_to.html.erb
@@ -3,12 +3,12 @@
 <% disable_link ||= false %>
 <% url ||= nil %>
 
-<% if object.send(attribute).present? %>
+<% if object.public_send(attribute).present? %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
     <% if disable_link %>
-      <%= object.send(attribute).label_string %>
+      <%= object.public_send(attribute).label_string %>
     <% else %>
-      <%= link_to object.send(attribute).label_string, url || [:account, object.send(attribute)] %>
+      <%= link_to object.public_send(attribute).label_string, url || [:account, object.public_send(attribute)] %>
     <% end %>
   <% end %>
 <% end %>

--- a/bullet_train-themes/app/views/themes/base/attributes/_block.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_block.html.erb
@@ -2,8 +2,8 @@
 <% strategy ||= current_attributes_strategy || :none %>
 <% url ||= nil %>
 
-<% if object.send(attribute).present? %>
+<% if object.public_send(attribute).present? %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
-    <pre><%= object.send(attribute) %></pre>
+    <pre><%= object.public_send(attribute) %></pre>
   <% end %>
 <% end %>

--- a/bullet_train-themes/app/views/themes/base/attributes/_boolean.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_boolean.html.erb
@@ -4,6 +4,6 @@
 
 <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
   <% unless object[attribute].nil? %>
-    <%= t("#{object.class.name.underscore.pluralize}.fields.#{attribute}.options.#{object.send(attribute)}") %>
+    <%= t("#{object.class.name.underscore.pluralize}.fields.#{attribute}.options.#{object.public_send(attribute)}") %>
   <% end %>
 <% end %>

--- a/bullet_train-themes/app/views/themes/base/attributes/_code.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_code.html.erb
@@ -3,7 +3,7 @@
 <% source ||= nil %>
 <% url ||= nil %>
 
-<% if object.send(attribute).present? %>
+<% if object.public_send(attribute).present? %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
     <code class="text-pink-600 font-light"><%= object.send(source || attribute) %></code>
   <% end %>

--- a/bullet_train-themes/app/views/themes/base/attributes/_date.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_date.html.erb
@@ -3,9 +3,9 @@
 <% url ||= nil %>
 <% default_message = local_assigns[:default_message] || t('global.formats.timestamp_unavailable') %>
 
-<% if object.send(attribute).present? %>
+<% if object.public_send(attribute).present? %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
-    <%= display_date(object.send(attribute), local_assigns[:date_format]) %>
+    <%= display_date(object.public_send(attribute), local_assigns[:date_format]) %>
   <% end %>
 <% else %>
   <%= default_message %>

--- a/bullet_train-themes/app/views/themes/base/attributes/_date_and_time.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_date_and_time.html.erb
@@ -3,9 +3,9 @@
 <% url ||= nil %>
 <% default_message = local_assigns[:default_message] || t('global.formats.timestamp_unavailable') %>
 
-<% if object.send(attribute).present? %>
+<% if object.public_send(attribute).present? %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
-    <%= display_date_and_time(object.send(attribute), local_assigns[:date_format], local_assigns[:time_format]) %>
+    <%= display_date_and_time(object.public_send(attribute), local_assigns[:date_format], local_assigns[:time_format]) %>
   <% end %>
 <% else %>
   <%= default_message %>

--- a/bullet_train-themes/app/views/themes/base/attributes/_days_ago.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_days_ago.html.erb
@@ -3,8 +3,8 @@
 <% url ||= nil %>
 
 <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
-  <% if object.send(attribute) %>
-    <%= time_ago_in_words(object.send(attribute)) %> ago
+  <% if object.public_send(attribute) %>
+    <%= time_ago_in_words(object.public_send(attribute)) %> ago
   <% else %>
     Never
   <% end %>

--- a/bullet_train-themes/app/views/themes/base/attributes/_email.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_email.html.erb
@@ -2,8 +2,8 @@
 <% strategy ||= current_attributes_strategy || :none %>
 <% url ||= nil %>
 
-<% if object.send(attribute).present? %>
+<% if object.public_send(attribute).present? %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
-    <%= link_to object.send(attribute), "mailto:#{object.send(attribute)}" %>
+    <%= link_to object.public_send(attribute), "mailto:#{object.public_send(attribute)}" %>
   <% end %>
 <% end %>

--- a/bullet_train-themes/app/views/themes/base/attributes/_has_many.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_has_many.html.erb
@@ -4,9 +4,9 @@
 <% disable_links ||= false %>
 <% link_options ||= {} %>
 
-<% if object.send(attribute).any? %>
+<% if object.public_send(attribute).any? %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy do %>
-    <%= object.send(attribute).map do |child_object| %>
+    <%= object.public_send(attribute).map do |child_object| %>
       <% capture do %>
         <% if disable_links %>
           <%= child_object.label_string %>

--- a/bullet_train-themes/app/views/themes/base/attributes/_html.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_html.html.erb
@@ -2,9 +2,9 @@
 <% strategy ||= current_attributes_strategy || :none %>
 <% url ||= nil %>
 
-<% if object.send(attribute).present? %>
+<% if object.public_send(attribute).present? %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
     <% # `.to_s` is for action text. %>
-    <%= html_sanitize(object.send(attribute).to_s).html_safe %>
+    <%= html_sanitize(object.public_send(attribute).to_s).html_safe %>
   <% end %>
 <% end %>

--- a/bullet_train-themes/app/views/themes/base/attributes/_image.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_image.html.erb
@@ -4,4 +4,4 @@
 <% options ||= {} %>
 <% options[:height] ||= 200 %>
 
-<%= cloudinary_image_tag object.send(attribute), options %>
+<%= cloudinary_image_tag object.public_send(attribute), options %>

--- a/bullet_train-themes/app/views/themes/base/attributes/_number.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_number.html.erb
@@ -3,8 +3,8 @@
 <% url ||= nil %>
 <% options ||= {} %>
 
-<% if object.send(attribute).present? %>
+<% if object.public_send(attribute).present? %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy do %>
-    <%= object.send(attribute) %>
+    <%= object.public_send(attribute) %>
   <% end %>
 <% end %>

--- a/bullet_train-themes/app/views/themes/base/attributes/_option.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_option.html.erb
@@ -2,8 +2,8 @@
 <% strategy ||= current_attributes_strategy || :none %>
 <% url ||= nil %>
 
-<% if object.send(attribute).present? %>
+<% if object.public_send(attribute).present? %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
-    <%= t("#{object.class.name.underscore.pluralize}.fields.#{attribute}.options.#{object.send(attribute)}") %>
+    <%= t("#{object.class.name.underscore.pluralize}.fields.#{attribute}.options.#{object.public_send(attribute)}") %>
   <% end %>
 <% end %>

--- a/bullet_train-themes/app/views/themes/base/attributes/_options.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_options.html.erb
@@ -2,10 +2,10 @@
 <% strategy ||= current_attributes_strategy || :none %>
 <% url ||= nil %>
 
-<% if object.send(attribute).any? %>
+<% if object.public_send(attribute).any? %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
     <%# TODO: Multiple option partials return arrays with blank characters in them. Is this expected? %>
-    <%= object.send(attribute).reject(&:blank?).map do |value| %>
+    <%= object.public_send(attribute).reject(&:blank?).map do |value| %>
       <% t("#{object.class.name.underscore.pluralize}.fields.#{attribute}.options.#{value}") %>
     <% end.map(&:strip).to_sentence %>
   <% end %>

--- a/bullet_train-themes/app/views/themes/base/attributes/_phone_number.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_phone_number.html.erb
@@ -2,8 +2,8 @@
 <% strategy ||= current_attributes_strategy || :none %>
 <% url ||= nil %>
 
-<% if object.send(attribute).present? %>
+<% if object.public_send(attribute).present? %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
-    <%= display_phone_number(object.send(attribute)) %>
+    <%= display_phone_number(object.public_send(attribute)) %>
   <% end %>
 <% end %>

--- a/bullet_train-themes/app/views/themes/base/attributes/_text.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_text.html.erb
@@ -3,8 +3,8 @@
 <% url ||= nil %>
 <% options ||= {} %>
 
-<% if object.send(attribute).present? %>
+<% if object.public_send(attribute).present? %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
-    <%= options[:password] ? "●" * object.send(attribute).length : object.send(attribute) %>
+    <%= options[:password] ? "●" * object.public_send(attribute).length : object.public_send(attribute) %>
   <% end %>
 <% end %>


### PR DESCRIPTION
Closes #115 

Instead of `object.send(attribute).present?` it would probably be better to use `object.respond_to?(attribute)`. For other cases `public_send` should work fine.