### PR TITLE
Fix red text for password strength indicator

### DIFF
--- a/bullet_train-themes/app/views/themes/base/fields/_password_field.html.erb
+++ b/bullet_train-themes/app/views/themes/base/fields/_password_field.html.erb
@@ -14,6 +14,7 @@ other_options ||= {}
 <div data-controller="<%= stimulus_controller %>">
   <%= render 'shared/fields/field', form: form, method: method, helper: :password_field, options: options, other_options: other_options %>
   <% if options[:show_strength_indicator] %>
+    <% # TODO This is the wrong place to define this kind of style, but I couldn't make this work in the `:help` content buffer. %>
     <div data-<%= stimulus_controller %>-target="strengthIndicator" class="hidden mt-1.5 text-xs text-red-500"></div>
   <% end %>
 </div>

--- a/bullet_train-themes/app/views/themes/base/fields/_password_field.html.erb
+++ b/bullet_train-themes/app/views/themes/base/fields/_password_field.html.erb
@@ -14,7 +14,6 @@ other_options ||= {}
 <div data-controller="<%= stimulus_controller %>">
   <%= render 'shared/fields/field', form: form, method: method, helper: :password_field, options: options, other_options: other_options %>
   <% if options[:show_strength_indicator] %>
-    <% # TODO This is the wrong place to define this kind of style, but I couldn't make this work in the `:help` content buffer. %>
-    <div data-<%= stimulus_controller %>-target="strengthIndicator" class="hidden mt-1.5 text-xs text-red-600"></div>
+    <div data-<%= stimulus_controller %>-target="strengthIndicator" class="hidden mt-1.5 text-xs text-red-500"></div>
   <% end %>
 </div>


### PR DESCRIPTION
I was looking into this TODO:

```
<% # TODO This is the wrong place to define this kind of style, but I couldn't make this work in the `:help` content buffer. %>
```

I found out that the text wasn't actually showing up as red, so I fixed that here.

I'd like to work on the TODO itself, just not entirely sure right now if we need to move the entire `div` itself or just the style, and I'm still not entirely sure how `content_for :help` is being rendered here if that's what we're using so I'll have to figure that out too.