### PR TITLE
Make the pricing page use the correct theme

### DIFF
--- a/bullet_train-themes-light/app/views/themes/light/layouts/_pricing.html.erb
+++ b/bullet_train-themes-light/app/views/themes/light/layouts/_pricing.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html class="theme-<%= BulletTrain::Themes::Light.color %> <%= "theme-secondary-#{BulletTrain::Themes::Light.secondary_color}" if BulletTrain::Themes::Light.secondary_color %>">
   <head>
     <%= render 'shared/layouts/head' %>
   </head>


### PR DESCRIPTION
This makes the pricing layout use the same theme that the rest of the app uses.

Fixes: https://github.com/bullet-train-pro/bullet_train-billing/issues/8