### PR TITLE
Add super select config target to get options from main app

### DIFF
--- a/bullet_train-fields/app/javascript/controllers/fields/super_select_controller.js
+++ b/bullet_train-fields/app/javascript/controllers/fields/super_select_controller.js
@@ -6,7 +6,7 @@ const select2SelectedPreviewSelector = ".select2-selection--single"
 const select2SearchInputFieldSelector = ".select2-search__field"
 
 export default class extends Controller {
-  static targets = [ "select" ]
+  static targets = [ "select", "superSelectConfig" ]
   static values = {
     acceptsNew: Boolean,
     enableSearch: Boolean,
@@ -46,6 +46,7 @@ export default class extends Controller {
     let options = {
       dropdownParent: $(this.element)
     };
+    const options = {...options, ...this.superSelectConfigTarget.dataset["superSelectConfig"]}
 
     if (!this.enableSearchValue) {
       options.minimumResultsForSearch = -1;

--- a/bullet_train-fields/app/javascript/controllers/fields/super_select_controller.js
+++ b/bullet_train-fields/app/javascript/controllers/fields/super_select_controller.js
@@ -79,7 +79,8 @@ export default class extends Controller {
     options.width = 'style';
 
     // Merge in custom options.
-    options = {...options, ...JSON.parse(this.optionsOverride)}
+    const custom_options = Object.keys(this.optionsOverride).length > 0 ? JSON.parse(this.optionsOverride) : {}
+    options = {...options, ...custom_options}
 
     this.cleanupBeforeInit() // in case improperly torn down
     this.pluginMainEl = this.selectTarget // required because this.selectTarget is unavailable on disconnect()

--- a/bullet_train-fields/app/javascript/controllers/fields/super_select_controller.js
+++ b/bullet_train-fields/app/javascript/controllers/fields/super_select_controller.js
@@ -6,11 +6,12 @@ const select2SelectedPreviewSelector = ".select2-selection--single"
 const select2SearchInputFieldSelector = ".select2-search__field"
 
 export default class extends Controller {
-  static targets = [ "select", "superSelectConfig" ]
+  static targets = [ "select" ]
   static values = {
     acceptsNew: Boolean,
     enableSearch: Boolean,
     searchUrl: String,
+    select2Options: String,
   }
   
   // will be reissued as native dom events name prepended with '$' e.g. '$change', '$select2:closing', etc
@@ -26,6 +27,11 @@ export default class extends Controller {
 
   get isSelect2LoadedOnWindowJquery() {
     return window?.$?.fn?.select2 !== undefined
+  }
+
+  get optionsOverride() {
+    if (!this.hasSelect2OptionsValue) { return {} }
+    return this.select2OptionsValue
   }
 
   connect() {
@@ -46,7 +52,6 @@ export default class extends Controller {
     let options = {
       dropdownParent: $(this.element)
     };
-    const options = {...options, ...this.superSelectConfigTarget.dataset["superSelectConfig"]}
 
     if (!this.enableSearchValue) {
       options.minimumResultsForSearch = -1;
@@ -66,13 +71,15 @@ export default class extends Controller {
           }
           return query
         }
-        // Any additional params go here...
       }
     }
 
     options.templateResult = this.formatState;
     options.templateSelection = this.formatState;
     options.width = 'style';
+
+    // Merge in custom options.
+    options = {...options, ...JSON.parse(this.optionsOverride)}
 
     this.cleanupBeforeInit() // in case improperly torn down
     this.pluginMainEl = this.selectTarget // required because this.selectTarget is unavailable on disconnect()

--- a/bullet_train-themes/app/views/themes/base/fields/_super_select.html.erb
+++ b/bullet_train-themes/app/views/themes/base/fields/_super_select.html.erb
@@ -38,6 +38,7 @@ html_options[:data].merge!("#{stimulus_controller}-target": 'select')
 <%= render 'shared/fields/field', form: form, method: method, options: html_options, other_options: other_options do %>
   <% content_for :field do %>
     <%= content_tag :div, data: wrapper_options[:data] do %>
+      <%= content_tag :div, data: {"#{stimulus_controller}-target": "superSelectConfig", super_select_config: super_select_config} do %><% end %>
       <%= form.select method, choices, options, html_options %>
     <% end %>
   <% end %>

--- a/bullet_train-themes/app/views/themes/base/fields/_super_select.html.erb
+++ b/bullet_train-themes/app/views/themes/base/fields/_super_select.html.erb
@@ -4,6 +4,7 @@ stimulus_controller = 'fields--super-select'
 form ||= current_fields_form
 options ||= {}
 other_options ||= {}
+select2_options ||= nil
 html_options ||= {}
 html_options[:id] ||= form.field_id(method)
 html_options[:class] = "form-control select2 #{html_options[:class]}".strip
@@ -24,6 +25,7 @@ wrapper_options = { data: { controller: stimulus_controller }}
 wrapper_options[:data]["#{stimulus_controller}-enable-search-value"] = true if other_options[:search]
 wrapper_options[:data]["#{stimulus_controller}-accepts-new-value"] = true if other_options[:accepts_new]
 wrapper_options[:data]["#{stimulus_controller}-search-url-value"] = choices_url if choices_url.present?
+wrapper_options[:data]["#{stimulus_controller}-select2-options-value"] = select2_options.to_json if select2_options.present?
 
 unless options[:multiple]
   wrapper_options[:data]["action"] ||= ""
@@ -38,7 +40,6 @@ html_options[:data].merge!("#{stimulus_controller}-target": 'select')
 <%= render 'shared/fields/field', form: form, method: method, options: html_options, other_options: other_options do %>
   <% content_for :field do %>
     <%= content_tag :div, data: wrapper_options[:data] do %>
-      <%= content_tag :div, data: {"#{stimulus_controller}-target": "superSelectConfig", super_select_config: super_select_config} do %><% end %>
       <%= form.select method, choices, options, html_options %>
     <% end %>
   <% end %>

--- a/bullet_train/docs/field-partials/super-select.md
+++ b/bullet_train/docs/field-partials/super-select.md
@@ -129,3 +129,18 @@ export default class extends Controller {
 
 [select2]: https://select2.org
 [select2_events]: https://select2.org/programmatic-control/events
+
+## Options
+Select2 has different options available which you can check [here](https://select2.org/configuration/options-api).
+
+You can pass these options to the super select partial like so:
+```erb
+<%= render 'shared/fields/super_select', method: :project,
+  select2_options: {
+    allowClear: true,
+    placeholder: 'Your Custom Placeholder'
+  }
+%>
+```
+
+*Passing options like this doesn't allow JS callbacks or functions to be used, so you must extend the Stimulus controller and add options to the `optionsOverride` getter if you want to do so.


### PR DESCRIPTION
Closes https://github.com/bullet-train-co/bullet_train/issues/783

Joint PR
- https://github.com/bullet-train-co/bullet_train/pull/799

Since we have no way of editing Super Select options from the starter repository, I added this target to the Super Select stimulus controller so we can customize these elements to our liking without having to eject any files.

Linking up to the JS code in bullet_train-core can be super flaky so I'm trying my best to test everything well. I'll have to double check my work on this one (especially with the spread operator to merge the two objects).

Also just curious if this presents any security issues since we're technically passing in raw JavaScript from the DOM.

Anyways, I worked through a number of ideas in the [original issue](https://github.com/bullet-train-co/bullet_train/issues/783) in case anyone wants to look over those or provide a better solution.
