### PR TITLE
Cache the base path of `bullet_train` when accessing documentation

### DIFF
--- a/bullet_train/app/controllers/concerns/documentation_support.rb
+++ b/bullet_train/app/controllers/concerns/documentation_support.rb
@@ -1,7 +1,7 @@
 module DocumentationSupport
   extend ActiveSupport::Concern
 
-  BULLET_TRAIN_BASE_PATH=`bundle show bullet_train`.chomp
+  BULLET_TRAIN_BASE_PATH = `bundle show bullet_train`.chomp
 
   def docs
     target = params[:page].presence || "index"

--- a/bullet_train/app/controllers/concerns/documentation_support.rb
+++ b/bullet_train/app/controllers/concerns/documentation_support.rb
@@ -8,8 +8,8 @@ module DocumentationSupport
     # all_paths = ([Rails.root.to_s] + `bundle show --paths`.lines.map(&:chomp))
     # @path = all_paths.map { |path| path + "/docs/#{target}.md" }.detect { |path| File.exist?(path) }
 
-    # TODO Trying to just brute force this for now.
-    @path = `bundle show bullet_train`.chomp + "/docs/#{target}.md"
+    @path = Rails.cache.fetch('bullet_train_path') { `bundle show bullet_train`.chomp }
+    @path += "/docs/#{target}.md"
 
     render :docs, layout: "docs"
   end

--- a/bullet_train/app/controllers/concerns/documentation_support.rb
+++ b/bullet_train/app/controllers/concerns/documentation_support.rb
@@ -9,7 +9,7 @@ module DocumentationSupport
     # @path = all_paths.map { |path| path + "/docs/#{target}.md" }.detect { |path| File.exist?(path) }
 
     # TODO Trying to just brute force this for now.
-    @path = Rails.cache.fetch('bullet_train_path') { `bundle show bullet_train`.chomp }
+    @path = Rails.cache.fetch("bullet_train_path") { `bundle show bullet_train`.chomp }
     @path += "/docs/#{target}.md"
 
     render :docs, layout: "docs"

--- a/bullet_train/app/controllers/concerns/documentation_support.rb
+++ b/bullet_train/app/controllers/concerns/documentation_support.rb
@@ -1,6 +1,8 @@
 module DocumentationSupport
   extend ActiveSupport::Concern
 
+  BULLET_TRAIN_BASE_PATH=`bundle show bullet_train`.chomp
+
   def docs
     target = params[:page].presence || "index"
 
@@ -8,9 +10,7 @@ module DocumentationSupport
     # all_paths = ([Rails.root.to_s] + `bundle show --paths`.lines.map(&:chomp))
     # @path = all_paths.map { |path| path + "/docs/#{target}.md" }.detect { |path| File.exist?(path) }
 
-    # TODO Trying to just brute force this for now.
-    @path = Rails.cache.fetch("bullet_train_path", expires_in: 30.minutes) { `bundle show bullet_train`.chomp }
-    @path += "/docs/#{target}.md"
+    @path = "#{BULLET_TRAIN_BASE_PATH}/docs/#{target}.md"
 
     render :docs, layout: "docs"
   end

--- a/bullet_train/app/controllers/concerns/documentation_support.rb
+++ b/bullet_train/app/controllers/concerns/documentation_support.rb
@@ -8,6 +8,7 @@ module DocumentationSupport
     # all_paths = ([Rails.root.to_s] + `bundle show --paths`.lines.map(&:chomp))
     # @path = all_paths.map { |path| path + "/docs/#{target}.md" }.detect { |path| File.exist?(path) }
 
+    # TODO Trying to just brute force this for now.
     @path = Rails.cache.fetch('bullet_train_path') { `bundle show bullet_train`.chomp }
     @path += "/docs/#{target}.md"
 

--- a/bullet_train/app/controllers/concerns/documentation_support.rb
+++ b/bullet_train/app/controllers/concerns/documentation_support.rb
@@ -9,7 +9,7 @@ module DocumentationSupport
     # @path = all_paths.map { |path| path + "/docs/#{target}.md" }.detect { |path| File.exist?(path) }
 
     # TODO Trying to just brute force this for now.
-    @path = Rails.cache.fetch("bullet_train_path") { `bundle show bullet_train`.chomp }
+    @path = Rails.cache.fetch("bullet_train_path", expires_in: 30.minutes) { `bundle show bullet_train`.chomp }
     @path += "/docs/#{target}.md"
 
     render :docs, layout: "docs"


### PR DESCRIPTION
I looked into the TODO in the `DocumentationSupport` module, and although this doesn't fix it, it gives us a speed boost by caching the `bundle show bullet_train` output.

I can't think of another way right now to access the docs from the gem in the context of a Bullet Train app besides linking to each raw file here on GitHub, but I feel like that would be slower anyways. I'm personally okay with `bundle show bullet_train` initially if we keep this cache, but I didn't delete the TODO just in case there's another way we want to approach this problem.