### PR TITLE
Fix request safety issue in set_locale

### DIFF
--- a/bullet_train-api/test/dummy/config/locales/en.yml
+++ b/bullet_train-api/test/dummy/config/locales/en.yml
@@ -10,9 +10,9 @@
 #
 #     <%= t("hello") %>
 #
-# To use a different locale, set it with `I18n.locale`:
+# To use a different locale, set it with `I18n.with_locale`:
 #
-#     I18n.locale = :es
+#     I18n.with_locale(:es, &block)
 #
 # This would use the information in config/locales/es.yml.
 #

--- a/bullet_train-fields/test/dummy/config/locales/en.yml
+++ b/bullet_train-fields/test/dummy/config/locales/en.yml
@@ -10,9 +10,9 @@
 #
 #     <%= t("hello") %>
 #
-# To use a different locale, set it with `I18n.locale`:
+# To use a different locale, set it with `I18n.with_locale`:
 #
-#     I18n.locale = :es
+#     I18n.with_locale(:es, &block)
 #
 # This would use the information in config/locales/es.yml.
 #

--- a/bullet_train-has_uuid/test/dummy/config/locales/en.yml
+++ b/bullet_train-has_uuid/test/dummy/config/locales/en.yml
@@ -10,9 +10,9 @@
 #
 #     <%= t("hello") %>
 #
-# To use a different locale, set it with `I18n.locale`:
+# To use a different locale, set it with `I18n.with_locale`:
 #
-#     I18n.locale = :es
+#     I18n.with_locale(:es, &block)
 #
 # This would use the information in config/locales/es.yml.
 #

--- a/bullet_train-incoming_webhooks/test/dummy/config/locales/en.yml
+++ b/bullet_train-incoming_webhooks/test/dummy/config/locales/en.yml
@@ -10,9 +10,9 @@
 #
 #     <%= t("hello") %>
 #
-# To use a different locale, set it with `I18n.locale`:
+# To use a different locale, set it with `I18n.with_locale`:
 #
-#     I18n.locale = :es
+#     I18n.with_locale(:es, &block)
 #
 # This would use the information in config/locales/es.yml.
 #

--- a/bullet_train-integrations-stripe/test/dummy/config/locales/en.yml
+++ b/bullet_train-integrations-stripe/test/dummy/config/locales/en.yml
@@ -10,9 +10,9 @@
 #
 #     <%= t("hello") %>
 #
-# To use a different locale, set it with `I18n.locale`:
+# To use a different locale, set it with `I18n.with_locale`:
 #
-#     I18n.locale = :es
+#     I18n.with_locale(:es, &block)
 #
 # This would use the information in config/locales/es.yml.
 #

--- a/bullet_train-integrations/test/dummy/config/locales/en.yml
+++ b/bullet_train-integrations/test/dummy/config/locales/en.yml
@@ -10,9 +10,9 @@
 #
 #     <%= t("hello") %>
 #
-# To use a different locale, set it with `I18n.locale`:
+# To use a different locale, set it with `I18n.with_locale`:
 #
-#     I18n.locale = :es
+#     I18n.with_locale(:es, &block)
 #
 # This would use the information in config/locales/es.yml.
 #

--- a/bullet_train-obfuscates_id/test/dummy/config/locales/en.yml
+++ b/bullet_train-obfuscates_id/test/dummy/config/locales/en.yml
@@ -10,9 +10,9 @@
 #
 #     <%= t("hello") %>
 #
-# To use a different locale, set it with `I18n.locale`:
+# To use a different locale, set it with `I18n.with_locale`:
 #
-#     I18n.locale = :es
+#     I18n.with_locale(:es, &block)
 #
 # This would use the information in config/locales/es.yml.
 #

--- a/bullet_train-outgoing_webhooks/test/dummy/config/locales/en.yml
+++ b/bullet_train-outgoing_webhooks/test/dummy/config/locales/en.yml
@@ -10,9 +10,9 @@
 #
 #     <%= t("hello") %>
 #
-# To use a different locale, set it with `I18n.locale`:
+# To use a different locale, set it with `I18n.with_locale`:
 #
-#     I18n.locale = :es
+#     I18n.with_locale(:es, &block)
 #
 # This would use the information in config/locales/es.yml.
 #

--- a/bullet_train-roles/test/dummy/config/locales/en.yml
+++ b/bullet_train-roles/test/dummy/config/locales/en.yml
@@ -10,9 +10,9 @@
 #
 #     <%= t("hello") %>
 #
-# To use a different locale, set it with `I18n.locale`:
+# To use a different locale, set it with `I18n.with_locale`:
 #
-#     I18n.locale = :es
+#     I18n.with_locale(:es, &block)
 #
 # This would use the information in config/locales/es.yml.
 #

--- a/bullet_train-scope_questions/test/dummy/config/locales/en.yml
+++ b/bullet_train-scope_questions/test/dummy/config/locales/en.yml
@@ -10,9 +10,9 @@
 #
 #     <%= t("hello") %>
 #
-# To use a different locale, set it with `I18n.locale`:
+# To use a different locale, set it with `I18n.with_locale`:
 #
-#     I18n.locale = :es
+#     I18n.with_locale(:es, &block)
 #
 # This would use the information in config/locales/es.yml.
 #

--- a/bullet_train-sortable/test/dummy/config/locales/en.yml
+++ b/bullet_train-sortable/test/dummy/config/locales/en.yml
@@ -10,9 +10,9 @@
 #
 #     <%= t("hello") %>
 #
-# To use a different locale, set it with `I18n.locale`:
+# To use a different locale, set it with `I18n.with_locale`:
 #
-#     I18n.locale = :es
+#     I18n.with_locale(:es, &block)
 #
 # This would use the information in config/locales/es.yml.
 #

--- a/bullet_train-super_load_and_authorize_resource/test/dummy/config/locales/en.yml
+++ b/bullet_train-super_load_and_authorize_resource/test/dummy/config/locales/en.yml
@@ -10,9 +10,9 @@
 #
 #     <%= t("hello") %>
 #
-# To use a different locale, set it with `I18n.locale`:
+# To use a different locale, set it with `I18n.with_locale`:
 #
-#     I18n.locale = :es
+#     I18n.with_locale(:es, &block)
 #
 # This would use the information in config/locales/es.yml.
 #

--- a/bullet_train-super_scaffolding/test/dummy/config/locales/en.yml
+++ b/bullet_train-super_scaffolding/test/dummy/config/locales/en.yml
@@ -10,9 +10,9 @@
 #
 #     <%= t("hello") %>
 #
-# To use a different locale, set it with `I18n.locale`:
+# To use a different locale, set it with `I18n.with_locale`:
 #
-#     I18n.locale = :es
+#     I18n.with_locale(:es, &block)
 #
 # This would use the information in config/locales/es.yml.
 #

--- a/bullet_train-themes-light/test/dummy/config/locales/en.yml
+++ b/bullet_train-themes-light/test/dummy/config/locales/en.yml
@@ -10,9 +10,9 @@
 #
 #     <%= t("hello") %>
 #
-# To use a different locale, set it with `I18n.locale`:
+# To use a different locale, set it with `I18n.with_locale`:
 #
-#     I18n.locale = :es
+#     I18n.with_locale(:es, &block)
 #
 # This would use the information in config/locales/es.yml.
 #

--- a/bullet_train-themes-tailwind_css/test/dummy/config/locales/en.yml
+++ b/bullet_train-themes-tailwind_css/test/dummy/config/locales/en.yml
@@ -10,9 +10,9 @@
 #
 #     <%= t("hello") %>
 #
-# To use a different locale, set it with `I18n.locale`:
+# To use a different locale, set it with `I18n.with_locale`:
 #
-#     I18n.locale = :es
+#     I18n.with_locale(:es, &block)
 #
 # This would use the information in config/locales/es.yml.
 #

--- a/bullet_train-themes/test/dummy/config/locales/en.yml
+++ b/bullet_train-themes/test/dummy/config/locales/en.yml
@@ -10,9 +10,9 @@
 #
 #     <%= t("hello") %>
 #
-# To use a different locale, set it with `I18n.locale`:
+# To use a different locale, set it with `I18n.with_locale`:
 #
-#     I18n.locale = :es
+#     I18n.with_locale(:es, &block)
 #
 # This would use the information in config/locales/es.yml.
 #

--- a/bullet_train/app/controllers/concerns/controllers/base.rb
+++ b/bullet_train/app/controllers/concerns/controllers/base.rb
@@ -85,15 +85,14 @@ module Controllers::Base
     end
   end
 
-  def set_locale
-    I18n.locale = [
+  def set_locale(&action)
+    locale = [
       current_user&.locale,
       current_user&.current_team&.locale,
       http_accept_language.compatible_language_from(I18n.available_locales),
       I18n.default_locale.to_s
     ].compact.find { |potential_locale| I18n.available_locales.include?(potential_locale.to_sym) }
-    yield
-    I18n.locale = I18n.default_locale
+    I18n.with_locale(locale, &action)
   end
 
   # Whitelist the account namespace and prevent JavaScript

--- a/bullet_train/config/locales/en/base.yml
+++ b/bullet_train/config/locales/en/base.yml
@@ -10,9 +10,9 @@
 #
 #     <%= t("hello") %>
 #
-# To use a different locale, set it with `I18n.locale`:
+# To use a different locale, set it with `I18n.with_locale`:
 #
-#     I18n.locale = :es
+#     I18n.with_locale(:es, &block)
 #
 # This would use the information in config/locales/es.yml.
 #

--- a/bullet_train/test/dummy/config/locales/en.yml
+++ b/bullet_train/test/dummy/config/locales/en.yml
@@ -10,9 +10,9 @@
 #
 #     <%= t("hello") %>
 #
-# To use a different locale, set it with `I18n.locale`:
+# To use a different locale, set it with `I18n.with_locale`:
 #
-#     I18n.locale = :es
+#     I18n.with_locale(:es, &block)
 #
 # This would use the information in config/locales/es.yml.
 #


### PR DESCRIPTION
See https://guides.rubyonrails.org/i18n.html#managing-the-locale-across-requests

Setting the locale using I18n.locale = 'es' during the request/response lifecycle can leak to other request/responses in the same thread.

Using I18n.with_locale instead limit the locale change to the underlying block and does not leak the value of I18n.locale to other requests. It is also the recommended way to handle locale change as per the rails doc.