### PR TITLE
Remove unneeded attribute `original_devise_path`

### DIFF
--- a/bullet_train-themes-light/lib/bullet_train/themes/light.rb
+++ b/bullet_train-themes-light/lib/bullet_train/themes/light.rb
@@ -14,7 +14,6 @@ module BulletTrain
       mattr_accessor :logo_color_shift, default: false
       mattr_accessor :show_logo_in_account, default: false
       mattr_accessor :navigation, default: :top
-      mattr_accessor :original_devise_path # TODO: Obsolete: remove after shipping a new BulletTrain version with usage removed.
 
       class Theme < BulletTrain::Themes::TailwindCss::Theme
         def directory_order


### PR DESCRIPTION
We can remove this since the following have been merged:

- https://github.com/bullet-train-co/bullet_train/pull/575
- https://github.com/bullet-train-co/bullet_train-core/pull/33
