### PR TITLE
Remove `showcase-rails` as dependency in bullet_train

### DIFF
--- a/bullet_train/Gemfile.lock
+++ b/bullet_train/Gemfile.lock
@@ -34,7 +34,6 @@ PATH
       premailer-rails
       rails (>= 6.0.0)
       ruby-openai
-      showcase-rails
       sidekiq
       unicode-emoji
       valid_email
@@ -318,8 +317,6 @@ GEM
       faraday-multipart (>= 1)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
-    showcase-rails (0.4.2)
-      rails (>= 6.1.0)
     sidekiq (7.1.0)
       concurrent-ruby (< 2)
       connection_pool (>= 2.3.0)

--- a/bullet_train/bullet_train.gemspec
+++ b/bullet_train/bullet_train.gemspec
@@ -75,9 +75,6 @@ Gem::Specification.new do |spec|
   # Add named slots to regular Rails partials.
   spec.add_dependency "nice_partials", "~> 0.9"
 
-  # Allow users to document and showcase their partials, components, view helpers, etc.
-  spec.add_dependency "showcase-rails"
-
   # Inline all CSS for emails.
   spec.add_dependency "premailer-rails"
 


### PR DESCRIPTION
Joint PR
- https://github.com/bullet-train-co/bullet_train/pull/801

Showcase gives us some issues when trying to set up things in API mode, so I plan on moving it to the development group in the Gemfile in the starter repository.