### PR TITLE
Add showcase example for breadcrumb with model `url_for`

### DIFF
--- a/bullet_train-themes-light/app/views/showcase/previews/partials/_breadcrumb.html.erb
+++ b/bullet_train-themes-light/app/views/showcase/previews/partials/_breadcrumb.html.erb
@@ -5,10 +5,9 @@
   </ul>
 <% end %>
 
-<%# TODO: Find a suitable url_for GET route here that every BulletTrain app would have. %>
-<%# showcase.sample "With model url_for" do %>
-<%#= render "shared/breadcrumb", url: [:account, Scaffolding::CompletelyConcrete::TangibleThing.new(id: 1)], label: "Concept" %>
-<%# end %>
+<% showcase.sample "With model url_for" do %>
+  <%= render 'account/shared/breadcrumb', label: t('memberships.label'), url: [:account, current_team, :memberships] %>
+<% end %>
 
 <% showcase.options do |o| %>
   <% o.required :label, "The breadcrumb text, either shown in the link or the plain label" %>


### PR DESCRIPTION
Addresses the TODO in `bullet_train-themes-light/app/views/showcase/previews/partials/_breadcrumb.html.erb`.

I found that this is an easy URL that we can use in all Bullet Train applications.

https://github.com/bullet-train-co/bullet_train-core/blob/350023aa4c3116f4df89c85f6dd2d7dbf8261bbf/bullet_train/app/views/account/invitations/_breadcrumbs.html.erb#L4

I wrote `current_team` here, but we can change that if necessary.
