### PR TITLE
Remove unneeded lines from docs

### DIFF
--- a/bullet_train/docs/field-partials/file-field.md
+++ b/bullet_train/docs/field-partials/file-field.md
@@ -8,8 +8,6 @@ In addition, Bullet Train has integrated the direct-uploads feature of Active St
 
 ## Example
 
-Add a 'document' file as an attachment to a `Post` model:
-
 Add the following to `app/models/post.rb`:
 
 ```ruby

--- a/bullet_train/docs/field-partials/file-field.md
+++ b/bullet_train/docs/field-partials/file-field.md
@@ -8,6 +8,7 @@ In addition, Bullet Train has integrated the direct-uploads feature of Active St
 
 ## Example
 
+The following steps illustrate how to add a `document` file attachment to a `Post` model.
 Add the following to `app/models/post.rb`:
 
 ```ruby


### PR DESCRIPTION
I'm assuming this refers to generating a migration which file attachments don't require, but I don't think we actually need this because you can scaffold a crud-field document with the other steps written here, and there's no command/code written after this particular sentence, so I decided to delete it.
