### PR TITLE
Delete unneeded TODO in `themes.rb`

### DIFF
--- a/bullet_train-themes/lib/bullet_train/themes.rb
+++ b/bullet_train-themes/lib/bullet_train/themes.rb
@@ -9,7 +9,6 @@ module BulletTrain
 
     mattr_reader :partial_paths, default: {}
 
-    # TODO Do we want this to be configurable by downstream applications?
     INVOCATION_PATTERNS = [
       # ❌ This path is included for legacy purposes, but you shouldn't reference partials like this in new code.
       /^account\/shared\//,


### PR DESCRIPTION
```ruby
INVOCATION_PATTERNS = [
  # ❌ This path is included for legacy purposes, but you shouldn't reference partials like this in new code.
  /^account\/shared\//,

  # ✅ This is the correct path to generically reference theme component partials with.
  /^shared\//,
]
```

Since this feels more like Bullet Train internal information, I feel like we don't have a need to make this configurable.

We also have this entry in the [docs](https://bullettrain.co/docs/themes) which shows developers that they should be using the same invocation even if they're using a different theme:

![Screenshot from 2023-06-21 18-37-06](https://github.com/bullet-train-co/bullet_train-core/assets/10546292/0be5c22b-a0ad-4cf1-9415-b219b088f224)
