### PR TITLE
Fix incompatibility with future Nice Partials

### DIFF
--- a/bullet_train-super_scaffolding/config/locales/en/scaffolding/completely_concrete/tangible_things.en.yml
+++ b/bullet_train-super_scaffolding/config/locales/en/scaffolding/completely_concrete/tangible_things.en.yml
@@ -18,6 +18,8 @@ en:
       confirmations:
         # TODO customize for your use-case.
         destroy: Are you sure you want to remove %{tangible_thing_name}? This will also remove any child resources and can't be undone.
+    tangible_thing:
+      buttons: *buttons
     fields: &fields
       id:
         heading: Tangible Thing ID


### PR DESCRIPTION
In Nice Partials, we're trying to clean up the I18n t-prefix solution, so there's fewer edge cases.

In this case that a render call like https://github.com/bullet-train-co/bullet_train-core/blob/0a694deb79af275e47ab9197d21d582cb8a8e6eb/bullet_train-super_scaffolding/app/views/account/scaffolding/completely_concrete/tangible_things/_index.html.erb#L39 will somehow use the outer tangible_things/_index partial as a t-prefix rather than the `render` call with no block clearing that.

So if we add what the future t-prefix is going to be, we'll have compatibility with both versions.