### PR TITLE
Add invisible_captcha to user registration

### DIFF
--- a/bullet_train/Gemfile.lock
+++ b/bullet_train/Gemfile.lock
@@ -28,6 +28,7 @@ PATH
       hiredis
       http_accept_language
       image_processing
+      invisible_captcha
       microscope
       nice_partials (~> 0.9)
       pagy
@@ -202,6 +203,8 @@ GEM
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
+    invisible_captcha (2.1.0)
+      rails (>= 5.2)
     json (2.6.3)
     language_server-protocol (3.17.0.2)
     loofah (2.20.0)

--- a/bullet_train/app/controllers/concerns/registrations/controller_base.rb
+++ b/bullet_train/app/controllers/concerns/registrations/controller_base.rb
@@ -1,9 +1,9 @@
 module Registrations::ControllerBase
   extend ActiveSupport::Concern
 
-  invisible_captcha only: :create
-
   included do
+    invisible_captcha only: :create
+
     def new
       # We have to set the session here because Safari wouldn't save it on a redirect to this URL.
       if params[:invitation_uuid]

--- a/bullet_train/app/controllers/concerns/registrations/controller_base.rb
+++ b/bullet_train/app/controllers/concerns/registrations/controller_base.rb
@@ -1,6 +1,8 @@
 module Registrations::ControllerBase
   extend ActiveSupport::Concern
 
+  invisible_captcha only: :create
+
   included do
     def new
       # We have to set the session here because Safari wouldn't save it on a redirect to this URL.

--- a/bullet_train/app/views/devise/registrations/new.html.erb
+++ b/bullet_train/app/views/devise/registrations/new.html.erb
@@ -6,6 +6,8 @@
        <%= render 'account/shared/notices' %>
        <%= render 'account/shared/forms/errors', form: f %>
 
+       <%= invisible_captcha %>
+
        <%= render 'shared/fields/email_field', form: f, method: :email, options: {autofocus: true} do %>
          <% content_for :help do %>
            <%= link_to t('devise.links.have_account'), new_user_session_path %>

--- a/bullet_train/bullet_train.gemspec
+++ b/bullet_train/bullet_train.gemspec
@@ -105,4 +105,7 @@ Gem::Specification.new do |spec|
 
   # Password strength.
   spec.add_dependency "devise-pwned_password"
+
+  # Captcha
+  spec.add_dependency "invisible_captcha"
 end

--- a/bullet_train/lib/bullet_train/engine.rb
+++ b/bullet_train/lib/bullet_train/engine.rb
@@ -19,6 +19,12 @@ begin
 rescue LoadError
 end
 
+begin
+  # And the same holds true for invisible_captcha
+  require "invisible_captcha"
+rescue LoadError
+end
+
 module BulletTrain
   class Engine < ::Rails::Engine
   end


### PR DESCRIPTION
In my latest BT installation I noticed some bot signups.

I thought that installing invisible_captcha would be a sensible default for all apps.