### PR TITLE
Insert load hooks for collaborator gems

### DIFF
--- a/bullet_train/app/controllers/concerns/account/controllers/base.rb
+++ b/bullet_train/app/controllers/concerns/account/controllers/base.rb
@@ -123,4 +123,6 @@ module Account::Controllers::Base
   def set_last_seen_at
     current_user.update_attribute(:last_seen_at, Time.current)
   end
+
+  ActiveSupport.run_load_hooks :bullet_train_account_controllers_base, self
 end

--- a/bullet_train/app/models/concerns/memberships/base.rb
+++ b/bullet_train/app/models/concerns/memberships/base.rb
@@ -140,4 +140,6 @@ module Memberships::Base
   def should_receive_notifications?
     invitation.present? || user.present?
   end
+
+  ActiveSupport.run_load_hooks :bullet_train_memberships_base, self
 end

--- a/bullet_train/app/models/concerns/records/base.rb
+++ b/bullet_train/app/models/concerns/records/base.rb
@@ -91,4 +91,6 @@ module Records::Base
       end.attributes!
     end
   end
+
+  ActiveSupport.run_load_hooks :bullet_train_records_base, self
 end

--- a/bullet_train/app/models/concerns/teams/base.rb
+++ b/bullet_train/app/models/concerns/teams/base.rb
@@ -83,4 +83,6 @@ module Teams::Base
       billing_subscriptions.active.empty?
     end
   end
+
+  ActiveSupport.run_load_hooks :bullet_train_teams_base, self
 end

--- a/bullet_train/lib/bullet_train/resolver.rb
+++ b/bullet_train/lib/bullet_train/resolver.rb
@@ -104,7 +104,10 @@ module BulletTrain
 
       if result[:absolute_path]
         if result[:absolute_path].include?("/bullet_train")
-          regex = /#{"bullet_train-core" if result[:absolute_path].include?("bullet_train-core")}\/bullet_train[a-z|\-._0-9]*.*/
+          # This Regular Expression covers gem versions like bullet_train-1.2.26,
+          # and hashed versions of branches on GitHub like bullet_train-core-b00a02bd513c.
+          gem_version_regex = /[a-z|\-._0-9]*/
+          regex = /#{"bullet_train-core#{gem_version_regex}" if result[:absolute_path].include?("bullet_train-core")}\/bullet_train#{gem_version_regex}.*/
           base_path = result[:absolute_path].scan(regex).pop
 
           # Try to calculate which package the file is from, and what it's path is within that project.


### PR DESCRIPTION
This means collaborator gems, particularly the bullet_train-billing(-*) ones, can hook in and help define extra functionality. Here's how that would look:

```ruby
module BulletTrain::Billing::Teams::Base
  extend ActiveSupport::Concern

  included do
    has_many :billing_subscriptions, class_name: "Billing::Subscription", dependent: :destroy, foreign_key: :team_id
  end
end

ActiveSupport.on_load(:bullet_train_teams_base) { include BulletTrain::Billing::Teams::Base }
```

Collaborator gems must use concerns otherwise features won't be included into the class that includes `::Teams::Base`. That's because regular Ruby modules don't support this kind of deep nesting but concerns have specifically added that.

Note: this is also how Rails works internally and expects you to hook into its libraries, like Active Record.

### How to ship this

- [x] Merge this PR.
- [ ] Merge https://github.com/bullet-train-pro/bullet_train-billing/pull/19
- [ ] Merge https://github.com/bullet-train-pro/bullet_train-billing-stripe/pull/10
- [x] Merge bullet_train-billing-usage PR (not needed after all!).
- [ ] Open a new PR to `bullet_train-core` that removes all the billing related extensions in `Teams::Base`, then merge.
- [ ] Release new gem versions.