### PR TITLE
Prepare Paddle subscriptions pertaining to a team

### DIFF
--- a/bullet_train/app/models/concerns/teams/base.rb
+++ b/bullet_train/app/models/concerns/teams/base.rb
@@ -28,6 +28,11 @@ module Teams::Base
         has_many :billing_stripe_subscriptions, class_name: "Billing::Stripe::Subscription", dependent: :destroy, foreign_key: :team_id
       end
 
+      # TODO We need a way for `bullet_train-billing-paddle` to define these.
+      if defined?(Billing::Paddle::Subscription)
+        has_many :billing_paddle_subscriptions, class_name: "Billing::Paddle::Subscription", dependent: :destroy, foreign_key: :team_id
+      end
+
       if defined?(Billing::Usage::TeamSupport)
         include Billing::Usage::TeamSupport
       end


### PR DESCRIPTION
In preparation of a paddle billing module, add the `billing_paddle_subscriptions` associations.

Though it'd be admittably better if the modules defined this themselves, would allow quick iteration on the paddle adapter.