### PR TITLE
Remove unused `Billing::Usage::TeamSupport` include

### DIFF
--- a/bullet_train/app/models/concerns/teams/base.rb
+++ b/bullet_train/app/models/concerns/teams/base.rb
@@ -27,10 +27,6 @@ module Teams::Base
       if defined?(Billing::Stripe::Subscription)
         has_many :billing_stripe_subscriptions, class_name: "Billing::Stripe::Subscription", dependent: :destroy, foreign_key: :team_id
       end
-
-      if defined?(Billing::Usage::TeamSupport)
-        include Billing::Usage::TeamSupport
-      end
     end
 
     # validations

--- a/bullet_train/docs/billing/usage.md
+++ b/bullet_train/docs/billing/usage.md
@@ -59,13 +59,13 @@ class ApplicationRecord
 end
 ```
 
-The second concern is `Billing::HasTrackers` and it allows any model to hold the usage tracking. This is usually done on the `Team` model.
+The second concern is `Billing::Usage::HasTrackers` and it allows any model to hold the usage tracking. This is usually done on the `Team` model.
 
 ```
 # app/models/team.rb
 
 class Team
-  include Billing::HasTrackers
+  include Billing::Usage::HasTrackers
 end
 ```
 


### PR DESCRIPTION
`TeamSupport` was renamed to `HasTrackers` in https://github.com/bullet-train-pro/bullet_train-billing-usage/commit/e4d3aedaae06d10d8700df747c0b2d79cfb2a3d8

Additionally, the guide recommends adding `Billing::HasTrackers` (the guide needs updating to `Billing::Usage::HasTrackers` too) directly.

So we aren't expecting this code to run and we can remove it.