### PR TITLE
Webhook signatures

### DIFF
--- a/bullet_train-outgoing_webhooks/app/models/concerns/webhooks/outgoing/endpoint_support.rb
+++ b/bullet_train-outgoing_webhooks/app/models/concerns/webhooks/outgoing/endpoint_support.rb
@@ -8,6 +8,7 @@ module Webhooks::Outgoing::EndpointSupport
 
     has_many :deliveries, class_name: "Webhooks::Outgoing::Delivery", dependent: :destroy, foreign_key: :endpoint_id
     has_many :events, -> { distinct }, through: :deliveries
+    has_many :shared_secrets, class_name: "Webhooks::Outgoing::Endpoints::SharedSecret"
 
     scope :listening_for_event_type_id, ->(event_type_id) { where("event_type_ids @> ? OR event_type_ids = '[]'::jsonb", "\"#{event_type_id}\"") }
 

--- a/bullet_train-outgoing_webhooks/app/models/concerns/webhooks/outgoing/endpoints/shared_secret_support.rb
+++ b/bullet_train-outgoing_webhooks/app/models/concerns/webhooks/outgoing/endpoints/shared_secret_support.rb
@@ -1,0 +1,23 @@
+module Webhooks::Outgoing::Endpoints::SharedSecretSupport
+  extend ActiveSupport::Concern
+
+  CURRENT_VERSION = "v1"
+
+  included do
+    belongs_to :endpoint, class_name: "Webhooks::Outgoing::Endpoint"
+
+    has_many :delivery_attempts, class_name: "Webhooks::Outgoing::DeliveryAttempt", foreign_key: :shared_secret_id
+
+    scope :active_for_timestamp, ->(timestamp) { where("expires_at is null or expires_at < ?", timestamp) }
+    scope :active, -> { active_for_timestamp(Time.now) }
+  end
+
+  def generate_signature(timestamp, payload_string)
+    CURRENT_VERSION + "=" + OpenSSL::HMAC.hexdigest("SHA256", secret, [timestamp.to_s, payload_string].join("."))
+  end
+
+  def signature_valid?(timestamp, payload_string, signature)
+    test_sig = generate_signature(timestamp, payload_string)
+    ActiveSupport::SecurityUtils.secure_compare(test_sig, signature)
+  end
+end

--- a/bullet_train-outgoing_webhooks/app/models/webhooks/outgoing/endpoints.rb
+++ b/bullet_train-outgoing_webhooks/app/models/webhooks/outgoing/endpoints.rb
@@ -1,0 +1,5 @@
+module Webhooks::Outgoing::Endpoints
+  def self.table_name_prefix
+    "webhooks_outgoing_endpoints_"
+  end
+end

--- a/bullet_train-outgoing_webhooks/app/models/webhooks/outgoing/endpoints/shared_secret.rb
+++ b/bullet_train-outgoing_webhooks/app/models/webhooks/outgoing/endpoints/shared_secret.rb
@@ -1,0 +1,3 @@
+class Webhooks::Outgoing::Endpoints::SharedSecret < ApplicationRecord
+  include Webhooks::Outgoing::Endpoints::SharedSecretSupport
+end

--- a/bullet_train-outgoing_webhooks/db/migrate/20230711170834_create_webhooks_outgoing_endpoints_shared_secrets.rb
+++ b/bullet_train-outgoing_webhooks/db/migrate/20230711170834_create_webhooks_outgoing_endpoints_shared_secrets.rb
@@ -1,0 +1,11 @@
+class CreateWebhooksOutgoingEndpointsSharedSecrets < ActiveRecord::Migration[7.0]
+  def change
+    create_table :webhooks_outgoing_endpoints_shared_secrets do |t|
+      t.references :endpoint, null: false, foreign_key: true
+      t.string :secret, null: false
+      t.timestamp :expires_at
+
+      t.timestamps
+    end
+  end
+end

--- a/bullet_train-outgoing_webhooks/test/models/concerns/webhooks/outgoing/endpoints/shared_secret_support_test.rb
+++ b/bullet_train-outgoing_webhooks/test/models/concerns/webhooks/outgoing/endpoints/shared_secret_support_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class Webhooks::Outgoing::Endpoints::SharedSecretSupportTest < ActiveSupport::TestCase
+  class DummyModel
+    def self.belongs_to(*args)
+    end
+
+    def self.has_many(*args)
+    end
+
+    def self.scope(*args)
+    end
+
+    def secret
+      "secret"
+    end
+
+    include Webhooks::Outgoing::Endpoints::SharedSecretSupport
+  end
+
+  test "generate_signature" do
+    now = DateTime.parse("2023-07-11 13:37:00Z")
+    m = DummyModel.new
+
+    assert(m.signature_valid?(now.to_i.to_s, "payload", m.generate_signature(now.to_i.to_s, "payload")))
+  end
+end

--- a/bullet_train-outgoing_webhooks/test/setup/active_record.rb
+++ b/bullet_train-outgoing_webhooks/test/setup/active_record.rb
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define do
     t.string :url, null: false
     t.string :name, null: false
     t.integer :event_type_ids, array: true, default: []
+    t.integer :api_version, null: false, default: 1
     t.timestamps null: false
   end
 


### PR DESCRIPTION
Implement signatures modeled on [Stripe's signature algorithm](https://stripe.com/docs/webhooks/signatures).

* New header `Security-Signature`
* Header value is a comma-separated list of tag-value pairs
* Timestamp is tag `t`
* Signature version 1 is tag `v1`
* Signature algorithm: `HMAC256(shared_secret, timestamp + "." + payload)`

One signature will be added to the header for every active shared secret.

To validate a given signature, calculate a signature according to the algorithm and use a constant-time comparison against the given signature. Check the timestamp and reject signatures that are too old.