### PR TITLE
Remove unnecessary comment

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -175,9 +175,6 @@ class Scaffolding::Transformer
 
   def resolve_template_path(file)
     # Figure out the actual location of the file.
-    # Originally all the potential source files were in the repository alongside the application.
-    # Now the files could be provided by an included Ruby gem, so we allow those Ruby gems to register their base
-    # path and then we check them in order to see which template we should use.
     BulletTrain::SuperScaffolding.template_paths.map do |base_path|
       base_path = Pathname.new(base_path)
       resolved_path = base_path.join(file).to_s


### PR DESCRIPTION
I think this comment was helpful when initially moved everything to `bullet_train-core`, but not that we've been here for a while I feel like we don't need this comment anymore.