### PR TITLE
Minor refactoring in Transformer

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -92,6 +92,7 @@ class Scaffolding::Transformer
       "scaffolding_completely_concrete_tangible_things",
       "scaffolding-absolutely-abstract-creative-concepts",
       "scaffolding-completely-concrete-tangible-things",
+      "scaffolding.completely_concrete.tangible_things"
     ]
 
     class_name_with_context = [

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -122,10 +122,10 @@ class Scaffolding::Transformer
     ]
 
     (
-      full_class_name + full_class_name.map(&:singularize) +
+      full_class_name + full_class_exceptions + full_class_name.map(&:singularize) +
       class_name_with_context + class_name_with_context.map(&:singularize) +
       class_name + class_name.map(&:singularize) +
-      full_class_exceptions + [":account", "/account"] # Account namespace vs. others.
+      [":account", "/account"] # Account namespace vs. others.
     ).each do |needle|
       string = string.gsub(needle, encode_double_replacement_fix(class_names_transformer.replacement_for(needle)))
     end

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -76,9 +76,7 @@ class Scaffolding::Transformer
   end
 
   def transform_string(string)
-    [
-
-      # full class name plural.
+    full_class_name = [
       "Scaffolding::AbsolutelyAbstract::CreativeConcepts",
       "Scaffolding::CompletelyConcrete::TangibleThings",
       "ScaffoldingAbsolutelyAbstractCreativeConcepts",
@@ -94,24 +92,9 @@ class Scaffolding::Transformer
       "scaffolding_completely_concrete_tangible_things",
       "scaffolding-absolutely-abstract-creative-concepts",
       "scaffolding-completely-concrete-tangible-things",
+    ]
 
-      # full class name singular.
-      "Scaffolding::AbsolutelyAbstract::CreativeConcept",
-      "Scaffolding::CompletelyConcrete::TangibleThing",
-      "ScaffoldingAbsolutelyAbstractCreativeConcept",
-      "ScaffoldingCompletelyConcreteTangibleThing",
-      "Scaffolding Absolutely Abstract Creative Concept",
-      "Scaffolding Completely Concrete Tangible Thing",
-      "Scaffolding/Absolutely Abstract/Creative Concept",
-      "Scaffolding/Completely Concrete/Tangible Thing",
-      "scaffolding/absolutely_abstract/creative_concept",
-      "scaffolding/completely_concrete/tangible_thing",
-      "scaffolding_absolutely_abstract_creative_concept",
-      "scaffolding_completely_concrete_tangible_thing",
-      "scaffolding-absolutely-abstract-creative-concept",
-      "scaffolding-completely-concrete-tangible-thing",
-      "scaffolding.completely_concrete.tangible_things",
-
+    class_name_with_context = [
       # class name in context plural.
       "absolutely_abstract_creative_concepts",
       "completely_concrete_tangible_things",
@@ -119,16 +102,9 @@ class Scaffolding::Transformer
       "completely_concrete/tangible_things",
       "absolutely-abstract-creative-concepts",
       "completely-concrete-tangible-things",
+    ]
 
-      # class name in context singular.
-      "absolutely_abstract_creative_concept",
-      "completely_concrete_tangible_thing",
-      "absolutely_abstract/creative_concept",
-      "completely_concrete/tangible_thing",
-      "absolutely-abstract-creative-concept",
-      "completely-concrete-tangible-thing",
-
-      # just class name singular.
+    class_name = [
       "creative_concepts",
       "tangible_things",
       "creative-concepts",
@@ -139,24 +115,14 @@ class Scaffolding::Transformer
       "Tangible things",
       "creative concepts",
       "tangible things",
+    ]
 
-      # just class name plural.
-      "creative_concept",
-      "tangible_thing",
-      "creative-concept",
-      "tangible-thing",
-      "Creative Concept",
-      "Tangible Thing",
-      "Creative concept",
-      "Tangible thing",
-      "creative concept",
-      "tangible thing",
-
-      # Account namespace vs. others.
-      ":account",
-      "/account/"
-
-    ].each do |needle|
+    (
+      full_class_name + full_class_name.map(&:singularize) +
+      class_name_with_context + class_name_with_context.map(&:singularize) +
+      class_name + class_name_with_context.map(&:singularize) +
+      [":account", "/account"] # Account namespace vs. others.
+    ).each do |needle|
       string = string.gsub(needle, encode_double_replacement_fix(class_names_transformer.replacement_for(needle)))
     end
 

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -87,12 +87,10 @@ class Scaffolding::Transformer
       "Scaffolding/Completely Concrete/Tangible Things",
       "scaffolding/absolutely_abstract/creative_concepts",
       "scaffolding/completely_concrete/tangible_things",
-      "scaffolding/completely_concrete/_tangible_things",
       "scaffolding_absolutely_abstract_creative_concepts",
       "scaffolding_completely_concrete_tangible_things",
       "scaffolding-absolutely-abstract-creative-concepts",
       "scaffolding-completely-concrete-tangible-things",
-      "scaffolding.completely_concrete.tangible_things"
     ]
 
     class_name_with_context = [
@@ -118,11 +116,16 @@ class Scaffolding::Transformer
       "tangible things",
     ]
 
+    full_class_exceptions = [
+      "scaffolding.completely_concrete.tangible_things",
+      "scaffolding.completely_concrete.tangible_things",
+    ]
+
     (
       full_class_name + full_class_name.map(&:singularize) +
       class_name_with_context + class_name_with_context.map(&:singularize) +
       class_name + class_name_with_context.map(&:singularize) +
-      [":account", "/account"] # Account namespace vs. others.
+      full_class_exceptions + [":account", "/account"] # Account namespace vs. others.
     ).each do |needle|
       string = string.gsub(needle, encode_double_replacement_fix(class_names_transformer.replacement_for(needle)))
     end

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -92,6 +92,7 @@ class Scaffolding::Transformer
       "scaffolding_completely_concrete_tangible_things",
       "scaffolding-absolutely-abstract-creative-concepts",
       "scaffolding-completely-concrete-tangible-things",
+      "scaffolding.completely_concrete.tangible_things"
     ]
 
     class_name_with_context = [
@@ -117,17 +118,10 @@ class Scaffolding::Transformer
     ]
 
     (
-      full_class_name +
-
-      # Address special cases here
-      full_class_name.map(&:singularize).reject {|str| str == "scaffolding/completely_concrete/_tangible_thing"} +
-      ["scaffolding.completely_concrete.tangible_things"] +
-
+      full_class_name + full_class_name.map(&:singularize) +
       class_name_with_context + class_name_with_context.map(&:singularize) +
       class_name + class_name.map(&:singularize) +
-
-      # Account namespace vs. others.
-      [":account", "/account/"]
+      [":account", "/account/"] # Account namespace vs. others.
     ).each do |needle|
       string = string.gsub(needle, encode_double_replacement_fix(class_names_transformer.replacement_for(needle)))
     end

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -124,7 +124,7 @@ class Scaffolding::Transformer
     (
       full_class_name + full_class_name.map(&:singularize) +
       class_name_with_context + class_name_with_context.map(&:singularize) +
-      class_name + class_name_with_context.map(&:singularize) +
+      class_name + class_name.map(&:singularize) +
       full_class_exceptions + [":account", "/account"] # Account namespace vs. others.
     ).each do |needle|
       string = string.gsub(needle, encode_double_replacement_fix(class_names_transformer.replacement_for(needle)))

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -117,7 +117,7 @@ class Scaffolding::Transformer
     ]
 
     full_class_exceptions = [
-      "scaffolding.completely_concrete.tangible_things",
+      "scaffolding/completely_concrete/_tangible_things",
       "scaffolding.completely_concrete.tangible_things",
     ]
 

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -87,6 +87,7 @@ class Scaffolding::Transformer
       "Scaffolding/Completely Concrete/Tangible Things",
       "scaffolding/absolutely_abstract/creative_concepts",
       "scaffolding/completely_concrete/tangible_things",
+      "scaffolding/completely_concrete/_tangible_things",
       "scaffolding_absolutely_abstract_creative_concepts",
       "scaffolding_completely_concrete_tangible_things",
       "scaffolding-absolutely-abstract-creative-concepts",
@@ -94,7 +95,6 @@ class Scaffolding::Transformer
     ]
 
     class_name_with_context = [
-      # class name in context plural.
       "absolutely_abstract_creative_concepts",
       "completely_concrete_tangible_things",
       "absolutely_abstract/creative_concepts",
@@ -116,16 +116,18 @@ class Scaffolding::Transformer
       "tangible things",
     ]
 
-    full_class_exceptions = [
-      "scaffolding/completely_concrete/_tangible_things",
-      "scaffolding.completely_concrete.tangible_things",
-    ]
-
     (
-      full_class_name + full_class_exceptions + full_class_name.map(&:singularize) +
+      full_class_name +
+
+      # Address special cases here
+      full_class_name.map(&:singularize).reject {|str| str == "scaffolding/completely_concrete/_tangible_thing"} +
+      ["scaffolding.completely_concrete.tangible_things"] +
+
       class_name_with_context + class_name_with_context.map(&:singularize) +
       class_name + class_name.map(&:singularize) +
-      [":account", "/account"] # Account namespace vs. others.
+
+      # Account namespace vs. others.
+      [":account", "/account/"]
     ).each do |needle|
       string = string.gsub(needle, encode_double_replacement_fix(class_names_transformer.replacement_for(needle)))
     end


### PR DESCRIPTION
When transforming strings, I felt that it would be easier to keep track of everything if we just singularlized the strings instead of keeping two separate lists.