### PR TITLE
Fix color contrast issues for flash error/red alert

### DIFF
--- a/bullet_train-themes-light/app/views/themes/light/_alert.html.erb
+++ b/bullet_train-themes-light/app/views/themes/light/_alert.html.erb
@@ -7,8 +7,8 @@ when :yellow
   div_classes = "bg-amber-100 border-amber-200"
   header_classes = "text-amber-800"
 when :red
-  div_classes = "bg-red-100 border-red-200"
-  header_classes = "text-red-900"
+  div_classes = "bg-red-100 dark:bg-red-900 border-red-200 dark:border-red-700"
+  header_classes = "text-red-900 dark:text-red-100"
 end
 %>
 

--- a/bullet_train-themes-light/app/views/themes/light/_alert.html.erb
+++ b/bullet_train-themes-light/app/views/themes/light/_alert.html.erb
@@ -7,8 +7,8 @@ when :yellow
   div_classes = "bg-amber-100 border-amber-200"
   header_classes = "text-amber-800"
 when :red
-  div_classes = "bg-red-300 border-red-400"
-  header_classes = "text-red-700"
+  div_classes = "bg-red-100 border-red-200"
+  header_classes = "text-red-900"
 end
 %>
 


### PR DESCRIPTION
I'm just starting out with Bullet Train. I noticed that alert message was not very readable due to color contrast between text and background was too low:

<details><summary>Before this change</summary>

https://webaim.org/resources/contrastchecker/?fcolor=B91C1C&bcolor=FCA5A5

![bullet-train-before](https://github.com/bullet-train-co/bullet_train-core/assets/67437/0edbffeb-7348-4ad0-960f-b9ba02cb0816)

</details>

<details><summary>After this change</summary>

https://webaim.org/resources/contrastchecker/?fcolor=7F1D1D&bcolor=FEE2E2

![bullet-train-after](https://github.com/bullet-train-co/bullet_train-core/assets/67437/37bd09a4-932e-45af-ad9c-3026d743d04d)

</details>

<details><summary>For comparison, here's Bootstrap's alert</summary>

https://getbootstrap.com/docs/5.3/components/alerts/

https://webaim.org/resources/contrastchecker/?fcolor=58151C&bcolor=F8D7DA

![bootstrap](https://github.com/bullet-train-co/bullet_train-core/assets/67437/21080501-c859-4963-a13d-41057a005fc4)

</details>

<details><summary>Tailwind CSS alert</summary>

https://tailwindui.com/components/application-ui/feedback/alerts#component-bfa7bc8484740ff2b3dfabe5fd318b25

https://webaim.org/resources/contrastchecker/?fcolor=B91C1C&bcolor=FEF2F2

![tailwind](https://github.com/bullet-train-co/bullet_train-core/assets/67437/03a890da-1e0d-4c89-b853-43a6439e6239)

</details>

There are probably more places where color contrast is not good enough, but this is a start.