### PR TITLE
Fix resolver issue for GitHub branches

### DIFF
--- a/bullet_train/lib/bullet_train/resolver.rb
+++ b/bullet_train/lib/bullet_train/resolver.rb
@@ -104,7 +104,10 @@ module BulletTrain
 
       if result[:absolute_path]
         if result[:absolute_path].include?("/bullet_train")
-          regex = /#{"bullet_train-core" if result[:absolute_path].include?("bullet_train-core")}\/bullet_train[a-z|\-._0-9]*.*/
+          # This Regular Expression covers gem versions like bullet_train-1.2.26,
+          # and hashed versions of branches on GitHub like bullet_train-core-b00a02bd513c.
+          gem_version_regex = /[a-z|\-._0-9]*/
+          regex = /#{"bullet_train-core#{gem_version_regex}" if result[:absolute_path].include?("bullet_train-core")}\/bullet_train#{gem_version_regex}.*/
           base_path = result[:absolute_path].scan(regex).pop
 
           # Try to calculate which package the file is from, and what it's path is within that project.


### PR DESCRIPTION
@kaspth

The regular expression was working when resolving files in public releases of gems like so:
```
bullet_train-1.2.26
```

However, when running a matching branch between the starting repository and `bullet_train-core` in CircleCI, this string was showing up in the resolver:
```
bullet_train-core-b00a02bd513c/bullet_train/lib/bullet_train/resolver.rb
```

I went ahead and updated the regular expression so it handles both situations.
