### PR TITLE
Rescue readonly-related error in `ExampleBot` module

### DIFF
--- a/bullet_train-api/lib/bullet_train/api/example_bot.rb
+++ b/bullet_train-api/lib/bullet_train/api/example_bot.rb
@@ -72,7 +72,7 @@ module FactoryBot
           clone.send("#{name}=", associations)
           @tables_to_reset << name
         elsif %i[belongs_to has_one].include?(reflection.macro)
-          clone.send("#{name}=", instance.send(name).clone)
+          clone.send("#{name}=", instance.send(name).clone) rescue ActiveRecord::HasOneThroughNestedAssociationsAreReadonly
           @tables_to_reset << name.pluralize
         end
       end

--- a/bullet_train-api/lib/bullet_train/api/example_bot.rb
+++ b/bullet_train-api/lib/bullet_train/api/example_bot.rb
@@ -72,7 +72,11 @@ module FactoryBot
           clone.send("#{name}=", associations)
           @tables_to_reset << name
         elsif %i[belongs_to has_one].include?(reflection.macro)
-          clone.send("#{name}=", instance.send(name).clone) rescue ActiveRecord::HasOneThroughNestedAssociationsAreReadonly
+          begin
+            clone.send("#{name}=", instance.send(name).clone)
+          rescue
+            ActiveRecord::HasOneThroughNestedAssociationsAreReadonly
+          end
           @tables_to_reset << name.pluralize
         end
       end


### PR DESCRIPTION
Closes #358.

I tried to come up with some other solutions to fix this one because I didn't want to simply rescue the error, but I think the error is specific enough and the original code is clear enough to figure out what's going on here.

To be 100% honest I'm not entirely sure how much of an effect this will have on the Open API docs themselves, but I'm hoping to get the error rescue reviewed first, and I think I'll try to generate and compare some API docs in the meantime.