### PR TITLE
Update the mock lmiter to match the call signature of the real limiter

### DIFF
--- a/bullet_train/app/models/billing/mock_limiter.rb
+++ b/bullet_train/app/models/billing/mock_limiter.rb
@@ -10,7 +10,7 @@ class Billing::MockLimiter
     true
   end
 
-  def exhausted?(model)
+  def exhausted?(model, enforcement = "hard")
     false
   end
 end


### PR DESCRIPTION
This was causing failures in some of the billing repos. This PR just makes the call signatures match.

https://github.com/bullet-train-pro/bullet_train-billing-usage/blob/82f5f77242125dc1da05b57fef2efa6b7e4db9d3/app/models/concerns/billing/limiter/base.rb#L26-L30