### PR TITLE
Remove environment variable check for `/testing/provision` route

### DIFF
--- a/bullet_train-api/config/routes.rb
+++ b/bullet_train-api/config/routes.rb
@@ -17,9 +17,7 @@ Rails.application.routes.draw do
     end
   end
 
-  if ENV["TESTING_PROVISION_KEY"].present?
-    get "/testing/provision", to: "account/platform/applications#provision"
-  end
+  get "/testing/provision", to: "account/platform/applications#provision"
 
   namespace :api do
     match "*version/openapi.yaml" => "open_api#index", :via => :get


### PR DESCRIPTION
Since we already have this if statement in the controller itself, we should be able to simply declare this route and only have the environment variable check once:

```ruby
# app/controllers/account/platform/applications_controller.rb
def provision
  if ENV["TESTING_PROVISION_KEY"].present? && params[:key] == ENV["TESTING_PROVISION_KEY"]
    ...
  end
end
```

The tests in https://github.com/bullet-train-co/bullet_train/pull/533 will also pass for both situations when `ENV["TESTING_PROVISION_KEY"]` is present and when it is not.