### PR TITLE
Refactor time zone selection

### DIFF
--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_date_and_time_field.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_date_and_time_field.html.erb
@@ -61,8 +61,8 @@ other_options ||= {}
           </div>
           <div class="hidden flex flex-row items-center mt-3 text-sm" data-<%= stimulus_controller %>-target="timeZoneSelectWrapper">
             <div class="flex-grow">
-              <%= select_tag :time_zone, 
-                  options_for_select(ActiveSupport::TimeZone.all.map{|tz| [tz.name.to_s, tz.tzinfo.name.to_s]}, [  user_tz || team_tz ]), 
+              <%= select_tag :time_zone,
+                  options_for_select(ActiveSupport::TimeZone.all.map{|tz| [tz.name, tz.tzinfo.name]}, [user_tz || team_tz]),
                   class: 'form-control select2',
                   data: { "#{stimulus_controller}-target": "timeZoneSelect", action: "#{stimulus_controller}#selectTimeZoneChange"}
               %>

--- a/bullet_train/app/helpers/account/dates_helper.rb
+++ b/bullet_train/app/helpers/account/dates_helper.rb
@@ -42,10 +42,6 @@ module Account::DatesHelper
     !"#{I18n.t("time.am", fallback: false, default: "")}#{I18n.t("time.pm", fallback: false, default: "")}".empty?
   end
 
-  def time_zone_name_to_id
-    ActiveSupport::TimeZone.all.map { |tz| {tz.name.to_s => tz.tzinfo.name} }.reduce({}, :merge)
-  end
-
   def current_time_zone
     current_time_zone_name = current_user&.time_zone || current_user&.current_team&.time_zone || "UTC"
     ActiveSupport::TimeZone.find_tzinfo(current_time_zone_name).name


### PR DESCRIPTION
Removes unused `time_zone_name_to_id` and cuts needless `to_s` calls.