### PR TITLE
Make Table-of-Contents a closer match to the Sidebar

### DIFF
--- a/bullet_train/docs/index.md
+++ b/bullet_train/docs/index.md
@@ -5,13 +5,13 @@
 ## Introduction
  - [What is Bullet Train?](https://bullettrain.co) <i class="ti ti-new-window ml-2"></i>
  - [Getting Started](/docs/getting-started.md)
- - [Upgrading](/docs/upgrades.md)
+ - [Upgrades](/docs/upgrades.md)
 
 ## General Topics
  - [Domain Modeling](/docs/modeling.md)
  - [Dealing with Indirection](/docs/indirection.md)
  - [Overriding the Framework](/docs/overriding.md)
- - [Setting up a Tunnel](/docs/tunneling.md)
+ - [Tunneling](/docs/tunneling.md)
  - [JavaScript](/docs/javascript.md)
  - [Internationalization](/docs/i18n.md)
 
@@ -20,20 +20,21 @@
  - [Action Models](/docs/action-models.md)
  - [Database Seeds](/docs/seeds.md)
  - [Test Suite](/docs/testing.md)
- - [Point-and-Click Test Writing](https://github.com/bullet-train-co/magic_test) <i class="ti ti-new-window ml-2"></i>
+ - [Magic Test: Point-and-Click Test Writing](https://github.com/bullet-train-co/magic_test) <i class="ti ti-new-window ml-2"></i>
  - [Application Options](/docs/application-options.md)
 
 ## Accounts & Teams
  - [Authentication](/docs/authentication.md)
  - [Teams](/docs/teams.md)
- - [Roles and Permissions](/docs/permissions.md)
+ - [Roles & Permissions](/docs/permissions.md)
  - [Onboarding](/docs/onboarding.md)
  - [Namespacing](/docs/namespacing.md)
 
-## UI
+## User Interface
  - [Field Partials](/docs/field-partials.md)
  - [Theme Engine](/docs/themes.md)
- - [Partial Improvements](https://github.com/bullet-train-co/nice_partials) <i class="ti ti-new-window ml-2"></i>
+ - [Nice Partials](https://github.com/bullet-train-co/nice_partials) <i class="ti ti-new-window ml-2"></i>
+ - [Showcase](https://github.com/bullet-train-co/showcase) <i class="ti ti-new-window ml-2"></i>
 
 ## Billing
  - [Stripe](/docs/billing/stripe.md)
@@ -45,11 +46,11 @@
  - [OAuth Providers](/docs/oauth.md)
  - [Outgoing Webhooks](/docs/webhooks/outgoing.md)
  - [Incoming Webhooks](/docs/webhooks/incoming.md)
- 
+
 ## Add-Ons
  - [Font Awesome Pro](/docs/font-awesome-pro.md)
 
-## Production
+## Deployment
  - [Heroku](/docs/heroku.md)
  - [Desktop Applications](/docs/desktop.md)
 


### PR DESCRIPTION
- Renames "Production" to "Deployment" matching the sidebar.
- Add a Showcase link like https://github.com/bullet-train-co/bullet_train-core/pull/375 did for the sidebar. — Rename UI to User Interface.
- Rename other links to be a direct mirror of their sidebar version, except in cases like Dealing with Indirection where the TOC version explains more.
- Explicitly name "Magic Test" in TOC, so it's easier to connote with the sidebar version.