### PR TITLE
Inject Light theme colors into Showcase

### DIFF
--- a/bullet_train-themes-light/app/views/showcase/engine/_head.html.erb
+++ b/bullet_train-themes-light/app/views/showcase/engine/_head.html.erb
@@ -1,0 +1,7 @@
+<script>
+  const color = "<%= BulletTrain::Themes::Light.color %>"
+  const secondaryColor = "<%= BulletTrain::Themes::Light.secondary_color %>"
+
+  if (color) document.documentElement.classList.add(`theme-${color}`)
+  if (secondaryColor) document.documentElement.classList.add(`theme-secondary-${secondaryColor}`)
+</script>


### PR DESCRIPTION
Let's the configured theme colors be used in Showcase automatically.

What we want before https://github.com/bullet-train-co/bullet_train-core/pull/377

Closes https://github.com/bullet-train-co/showcase/issues/68