### PR TITLE
Fix html option settings for objects that have multiple values

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -841,8 +841,8 @@ class Scaffolding::Transformer
           field_options[:color_picker_options] = "t('#{child.pluralize.underscore}.fields.#{name}.options')"
         end
 
-        # When rendering a super_select element we simply use `multiple: true` as an option,
-        # but all other fields require `html_options {multiple: true}` to work.
+        # When rendering a super_select element we need to use `html_options: {multiple: true}`,
+        # but all other fields simply use `multiple: true` to work.
         if is_multiple
           if type == "super_select"
             field_options[:multiple] = "true"

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -841,13 +841,21 @@ class Scaffolding::Transformer
           field_options[:color_picker_options] = "t('#{child.pluralize.underscore}.fields.#{name}.options')"
         end
 
+        # When rendering a super_select element we simply use `multiple: true` as an option,
+        # but all other fields require `html_options {multiple: true}` to work.
+        if is_multiple
+          if type == "super_select"
+            field_options[:multiple] = "true"
+          else
+            field_attributes[:multiple] = "true"
+          end
+        end
+
         valid_values = if is_id
           "valid_#{name_without_id.pluralize}"
         elsif is_ids
           "valid_#{collection_name}"
         end
-
-        field_options[:multiple] = "true" if is_multiple
 
         # https://stackoverflow.com/questions/21582464/is-there-a-ruby-hashto-s-equivalent-for-the-new-hash-syntax
         if field_options.any? || options.any?


### PR DESCRIPTION
I thought we would be ok with #317, but it turns out that merging it broke the tests.

What's happening here is that super select objects uses `html_options: {multiple: true}` whereas other objects use `multiple: true`:

```erb
<!-- From PartialTest's _form.html.erb partial after running the Super Scaffolding test setup script-->

<%= render 'shared/fields/buttons', method: :multiple_buttons_test, multiple: true %>

<%= render 'shared/fields/super_select', method: :multiple_super_select_test, html_options: {multiple: true} %>
```

It's a little difficult to tell what's going on in this portion of the transformer, but I hope this comment helps to clear things up a little bit.