### PR TITLE
We should run the super_scaffolding_partial_test as well

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,9 @@ jobs:
       - run:
           name: 'Run Super Scaffolding Test'
           command: "bundle exec rails test test/system/super_scaffolding_test.rb"
+      - run:
+          name: 'Run Super Scaffolding Partial Test'
+          command: 'bundle exec rails test test/system/super_scaffolding_partial_test.rb'
 
 workflows:
   version: 2


### PR DESCRIPTION
Previously we could introduce changes in `core` that would break tests in the starter repo, but that wouldn't show up as failures in `core`.

This was due to the fact that we were running more tests in the starter repo than we were runnig here.

This PR makes it so that we run the extra tests so that we can spot test failures here.

Fixes #391 