### PR TITLE
Link npm packages in CI

### DIFF
--- a/bin/checkout-and-link-starter-repo
+++ b/bin/checkout-and-link-starter-repo
@@ -59,6 +59,10 @@ packages=(
   "bullet_train-sortable"
 )
 
+starting_dir=${pwd}
+
+echo "starting_dir: $starting_dir"
+
 echo "yalc dir ======"
 npx yalc dir
 
@@ -69,12 +73,12 @@ do
   echo "linking package: $package"
   echo "npm package: $npm_package"
 
-  cd ./core/$package
+  cd ../../$package
   yarn install
   yarn build
   npx yalc publish
 
-  cd ../../
+  cd $starting_dir
   npx yalc add @bullet-train/$npm_package
 done
 
@@ -89,12 +93,12 @@ npm_package="fields"
 echo "linking package: $package"
 echo "npm package: $npm_package"
 
-cd ./core/$package
+cd ../../$package
 yarn install
 yarn build
 npx yalc publish
 
-cd ../../
+cd $starting_dir
 npx yalc add @bullet-train/$npm_package
 
 

--- a/bin/checkout-and-link-starter-repo
+++ b/bin/checkout-and-link-starter-repo
@@ -53,3 +53,51 @@ done
 
 updates="${packages[@]}"
 bundle lock --update $updates
+
+packages=(
+  "bullet_train"
+  "bullet_train-sortable"
+)
+
+echo "yalc dir ======"
+npx yalc dir
+
+for package in "${packages[@]}"
+do
+  :
+  npm_package=${package/_/-}
+  echo "linking package: $package"
+  echo "npm package: $npm_package"
+
+  cd ./core/$package
+  yarn install
+  yarn build
+  npx yalc publish
+
+  cd ../../
+  npx yalc add @bullet-train/$npm_package
+done
+
+
+# For some reason the fields package is called bullet-train/field and doesn't match the pattern for other packages.
+# If it did match other packages it would be   bullet-train/bullet-train-fields.
+# Since it's different we have to treat it special. It would be nice to standardize, but that's likely to have
+# impacts beyond just fixing CI, so I'm doing the messy thing for now.
+
+package="bullet_train-fields"
+npm_package="fields"
+echo "linking package: $package"
+echo "npm package: $npm_package"
+
+cd ./core/$package
+yarn install
+yarn build
+npx yalc publish
+
+cd ../../
+npx yalc add @bullet-train/$npm_package
+
+
+cat package.json
+
+

--- a/bin/checkout-and-link-starter-repo
+++ b/bin/checkout-and-link-starter-repo
@@ -103,3 +103,10 @@ npx yalc add @bullet-train/$npm_package
 cat package.json
 
 
+# We do this here becausue the  node/install-packages step complains about
+# needing to modify the lock file.
+
+yarn install
+yarn build
+
+

--- a/bin/checkout-and-link-starter-repo
+++ b/bin/checkout-and-link-starter-repo
@@ -59,10 +59,6 @@ packages=(
   "bullet_train-sortable"
 )
 
-starting_dir=${pwd}
-
-echo "starting_dir: $starting_dir"
-
 echo "yalc dir ======"
 npx yalc dir
 
@@ -78,7 +74,7 @@ do
   yarn build
   npx yalc publish
 
-  cd $starting_dir
+  cd tmp/starter
   npx yalc add @bullet-train/$npm_package
 done
 

--- a/bin/checkout-and-link-starter-repo
+++ b/bin/checkout-and-link-starter-repo
@@ -62,6 +62,8 @@ packages=(
 echo "yalc dir ======"
 npx yalc dir
 
+starting_dir=$PWD
+
 for package in "${packages[@]}"
 do
   :
@@ -74,7 +76,7 @@ do
   yarn build
   npx yalc publish
 
-  cd tmp/starter
+  cd $starting_dir
   npx yalc add @bullet-train/$npm_package
 done
 

--- a/bin/checkout-and-link-starter-repo
+++ b/bin/checkout-and-link-starter-repo
@@ -107,6 +107,5 @@ cat package.json
 # needing to modify the lock file.
 
 yarn install
-yarn build
 
 


### PR DESCRIPTION
This makes it so that we're running tests against the JS provided by `core` instead of against the published versions of the packages on npm.