### PR TITLE
Contain commonmarker upgrade to just Bullet Train for now

### DIFF
--- a/bullet_train/Gemfile
+++ b/bullet_train/Gemfile
@@ -11,5 +11,7 @@ gem "sprockets-rails"
 # TODO Have to specify this dependency here until our changes are in the original package.
 gem "active_hash", github: "bullet-train-co/active_hash"
 
+gem "commonmarker", ">= 1.0.0.pre10"
+
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"

--- a/bullet_train/app/helpers/account/markdown_helper.rb
+++ b/bullet_train/app/helpers/account/markdown_helper.rb
@@ -1,8 +1,12 @@
 module Account::MarkdownHelper
   def markdown(string)
-    Commonmarker.to_html(string, options: {
-      plugins: {syntax_highlighter: {theme: "InspiredGitHub"}},
-      render: {width: 120, unsafe: true}
-    }).html_safe
+    if defined?(Commonmarker.to_html)
+      Commonmarker.to_html(string, options: {
+        plugins: {syntax_highlighter: {theme: "InspiredGitHub"}},
+        render: {width: 120, unsafe: true}
+      }).html_safe
+    else
+      CommonMarker.render_html(string, :UNSAFE, [:table]).html_safe
+    end
   end
 end

--- a/bullet_train/bullet_train.gemspec
+++ b/bullet_train/bullet_train.gemspec
@@ -85,7 +85,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "valid_email"
 
   # Allow users to supply content with markdown formatting. Powers our markdown() view helper.
-  spec.add_dependency "commonmarker", ">= 1.0.0.pre10"
+  spec.add_dependency "commonmarker"
 
   # Extract the body from emails received using action inbox.
   spec.add_dependency "extended_email_reply_parser" # TODO ➡️ `bullet_train-conversations`


### PR DESCRIPTION
As discussed in #384 within https://github.com/bullet-train-co/bullet_train-core/pull/384#issuecomment-1668523752

Bullet Train apps can still do `bundle update --pre commonmarker` to get the new version going but we don't force it on them now.