### PR TITLE
Run `yarn build` in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,7 @@ jobs:
       - node/install-packages:
           pkg-manager: yarn
       - run: yarn build:css
+      - run: yarn build
 
       - *wait_for_docker
 
@@ -128,6 +129,7 @@ jobs:
       - node/install-packages:
           pkg-manager: yarn
       - run: yarn build:css
+      - run: yarn build
 
       - *wait_for_docker
 


### PR DESCRIPTION
We need to do this so that the `core` js packages get included correctly.