### PR TITLE
Add back linking the application assets in Showcase

### DIFF
--- a/bullet_train-themes-light/app/views/showcase/engine/_head.html.erb
+++ b/bullet_train-themes-light/app/views/showcase/engine/_head.html.erb
@@ -1,3 +1,6 @@
+<%= stylesheet_link_tag "application" %>
+<%= javascript_include_tag "application" %>
+
 <script>
   const color = "<%= BulletTrain::Themes::Light.color %>"
   const secondaryColor = "<%= BulletTrain::Themes::Light.secondary_color %>"


### PR DESCRIPTION
https://github.com/bullet-train-co/bullet_train-core/pull/378 accidentally removed the application JavaScript and CSS from being bundled in Showcase.

This adds them back.