### PR TITLE
Fix Stimulus targeting in emoji picker

### DIFF
--- a/bullet_train-themes/app/views/themes/base/fields/_emoji_field.html.erb
+++ b/bullet_train-themes/app/views/themes/base/fields/_emoji_field.html.erb
@@ -10,8 +10,8 @@ value = form.object.send(method)
 <%= render 'shared/fields/field', form: form, method: method, options: options, other_options: other_options do %>
   <% content_for :field do %>
     <div data-controller="<%= stimulus_controller %>">
-      <%= tag.button data: {action: "#{stimulus_controller}#toggle", target: "#{stimulus_controller}.button"}, class: "button-alternative" do %>
-        <span data-target="<%= stimulus_controller %>.display">
+      <%= tag.button data: {action: "#{stimulus_controller}#toggle", "#{stimulus_controller}_target": "button"}, class: "button-alternative" do %>
+        <span data-<%= stimulus_controller %>-target="display">
           <% if value.present? %>
             <%= value %>
           <% else %>


### PR DESCRIPTION
As noted in https://github.com/bullet-train-co/bullet_train-core/pull/188#issuecomment-1675992829

Fixes the deprecation warning of using the old `data-target` syntax:

> [Warning] Please replace data-target="fields--emoji-picker.display" with data-fields--emoji-picker-target="display". The data-target attribute is deprecated and will be removed in a future version of Stimulus. –
> <span data-target="fields--emoji-picker.display">😘</span>

For some reason it didn't fire on the `data-target="<>.button"`, but that is fixed too.

We were already using the new syntax for the `input` target, so there shouldn't be any concerns over switching to this.