### PR TITLE
Add temporary fix for `TangibleThing` order

### DIFF
--- a/bullet_train-super_scaffolding/app/models/scaffolding/absolutely_abstract/creative_concept.rb
+++ b/bullet_train-super_scaffolding/app/models/scaffolding/absolutely_abstract/creative_concept.rb
@@ -6,7 +6,7 @@ class Scaffolding::AbsolutelyAbstract::CreativeConcept < ApplicationRecord
 
   # TODO: We shouldn't have to explicitly set the order to :asc here, so we need to find out why these records
   # are being returned in descending order when calling @creative_concept.completely_concrete_tangible_things.
-  has_many :completely_concrete_tangible_things, -> { order(created_at: :asc) }, class_name: "Scaffolding::CompletelyConcrete::TangibleThing", foreign_key: :absolutely_abstract_creative_concept_id, dependent: :destroy
+  has_many :completely_concrete_tangible_things, -> { order(:id) }, class_name: "Scaffolding::CompletelyConcrete::TangibleThing", foreign_key: :absolutely_abstract_creative_concept_id, dependent: :destroy
   has_many :collaborators, class_name: "Scaffolding::AbsolutelyAbstract::CreativeConcepts::Collaborator", dependent: :destroy, foreign_key: :creative_concept_id
   has_many :memberships, through: :collaborators
   # 🚅 add has_many associations above.

--- a/bullet_train-super_scaffolding/app/models/scaffolding/absolutely_abstract/creative_concept.rb
+++ b/bullet_train-super_scaffolding/app/models/scaffolding/absolutely_abstract/creative_concept.rb
@@ -4,7 +4,7 @@ class Scaffolding::AbsolutelyAbstract::CreativeConcept < ApplicationRecord
   belongs_to :team
   # 🚅 add belongs_to associations above.
 
-  # TODO: We shouldn't have to explicitly set the order to :asc here, so we need to find out why these records
+  # TODO: We shouldn't have to explicitly set the order here, so we need to find out why these records
   # are being returned in descending order when calling @creative_concept.completely_concrete_tangible_things.
   has_many :completely_concrete_tangible_things, -> { order(:id) }, class_name: "Scaffolding::CompletelyConcrete::TangibleThing", foreign_key: :absolutely_abstract_creative_concept_id, dependent: :destroy
   has_many :collaborators, class_name: "Scaffolding::AbsolutelyAbstract::CreativeConcepts::Collaborator", dependent: :destroy, foreign_key: :creative_concept_id

--- a/bullet_train-super_scaffolding/app/models/scaffolding/absolutely_abstract/creative_concept.rb
+++ b/bullet_train-super_scaffolding/app/models/scaffolding/absolutely_abstract/creative_concept.rb
@@ -4,7 +4,9 @@ class Scaffolding::AbsolutelyAbstract::CreativeConcept < ApplicationRecord
   belongs_to :team
   # 🚅 add belongs_to associations above.
 
-  has_many :completely_concrete_tangible_things, class_name: "Scaffolding::CompletelyConcrete::TangibleThing", foreign_key: :absolutely_abstract_creative_concept_id, dependent: :destroy
+  # TODO: We shouldn't have to explicitly set the order to :asc here, so we need to find out why these records
+  # are being returned in descending order when calling @creative_concept.completely_concrete_tangible_things.
+  has_many :completely_concrete_tangible_things, -> { order(created_at: :asc) }, class_name: "Scaffolding::CompletelyConcrete::TangibleThing", foreign_key: :absolutely_abstract_creative_concept_id, dependent: :destroy
   has_many :collaborators, class_name: "Scaffolding::AbsolutelyAbstract::CreativeConcepts::Collaborator", dependent: :destroy, foreign_key: :creative_concept_id
   has_many :memberships, through: :collaborators
   # 🚅 add has_many associations above.


### PR DESCRIPTION
#408

I'm not entirely sure why the records are being returned in descending order, and my tests are failing locally but CI seems to be passing. Accessing TangibleThings via their CreativeConcept will return them in descending order:

<details>
  <summary>In the CreativeConcept show action:</summary>

```
From: /Users/gabriel_zayas/work/bt/bullet_train/local/bullet_train-core/bullet_train-super_scaffolding/app/controllers/account/scaffolding/absolutely_abstract/creative_concepts_controller.rb:17 Account::Scaffolding::AbsolutelyAbstract::CreativeConceptsController#show:

    16: def show
 => 17:   binding.pry
    18: end

[1] pry(#<Account::Scaffolding::AbsolutelyAbstract::CreativeConceptsController>)> Scaffolding::CompletelyConcrete::TangibleThing.where(absolutely_abstract_creative_concept_id: @creative_concept.id)
=> [#<Scaffolding::CompletelyConcrete::TangibleThing:0x0000000112b17a98
  id: 320,
  absolutely_abstract_creative_concept_id: 30,
  text_field_value: "Test 21",
  button_value: nil,
  cloudinary_image_value: nil,
  date_field_value: nil,
  email_field_value: nil,
  password_field_value: nil,
  phone_field_value: nil,
  super_select_value: nil,
  text_area_value: nil,
  created_at: Wed, 16 Aug 2023 09:41:44.055014000 UTC +00:00,
  updated_at: Wed, 16 Aug 2023 09:41:44.055014000 UTC +00:00,
  sort_order: nil,
  date_and_time_field_value: nil,
  multiple_button_values: [],
  multiple_super_select_values: [],
  color_picker_value: nil,
  boolean_button_value: nil,
  option_value: nil,
  multiple_option_values: []>,
 #<Scaffolding::CompletelyConcrete::TangibleThing:0x0000000112b17958
  id: 319,
  absolutely_abstract_creative_concept_id: 30,
  text_field_value: "Test 20",
  button_value: nil,
  cloudinary_image_value: nil,
  date_field_value: nil,
  email_field_value: nil,
  password_field_value: nil,
  phone_field_value: nil,
  super_select_value: nil,
  text_area_value: nil,
  created_at: Wed, 16 Aug 2023 09:41:44.050715000 UTC +00:00,
  updated_at: Wed, 16 Aug 2023 09:41:44.050715000 UTC +00:00,
  sort_order: nil,
  date_and_time_field_value: nil,
  multiple_button_values: [],
  multiple_super_select_values: [],
  color_picker_value: nil,
  boolean_button_value: nil,
  option_value: nil,
  multiple_option_values: []>,

  ...
```
</details>

The records are returned in the correct order when calling the following though:
```ruby
Scaffolding::CompletelyConcrete::TangibleThing.all
```

I'm not seeing anything in the scopes or controllers that could be causing this, so this is a temporary fix that will return our records in the correct order for the time being.