### PR TITLE
Release workflow bug fix

### DIFF
--- a/bin/release-all
+++ b/bin/release-all
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-puts output = `bump patch`
+puts output = `bump current`
 version = output.chomp.lines.last.chomp
 
 "Releasing version: #{version}"


### PR DESCRIPTION
We should use `bump current` to get the current version number instead of using `bump patch` which increments it.