### PR TITLE
[release process] Add committer to the version bump PRs.

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -45,6 +45,7 @@ jobs:
       id: cpr
       uses: peter-evans/create-pull-request@v5
       with:
+        author: "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
         committer: "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
         commit-message: "Version bump: ${{ inputs.versionBump }} - ${{ steps.bump-all.outputs.NEW_VERSION_NUMBER }}"
         branch: "version-bump/${{ steps.bump-all.outputs.NEW_VERSION_NUMBER }}"

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -45,6 +45,7 @@ jobs:
       id: cpr
       uses: peter-evans/create-pull-request@v5
       with:
+        committer: "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
         commit-message: "Version bump: ${{ inputs.versionBump }} - ${{ steps.bump-all.outputs.NEW_VERSION_NUMBER }}"
         branch: "version-bump/${{ steps.bump-all.outputs.NEW_VERSION_NUMBER }}"
         delete-branch: true


### PR DESCRIPTION
This will make it so that we can tell who initiated a version bump, which seems reasonable since it's a manual action, and not automated.