### PR TITLE
[release process] Auto publish releases

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,17 @@
+name: Publish relesae after tagging
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,4 +1,4 @@
-name: Publish relesae after tagging
+name: Publish release after tagging
 
 on:
   push:


### PR DESCRIPTION
This adds a workflow that will add a GitHub release after a version tag has been pushed to the repo.

The version tag is automatically pushed when we merge a PR that's been generated by the "Create Version Bump PR For Ruby Gems & NPM Packages" workflow.