### PR TITLE
Add validation for `event_type_ids` for outgoing webhooks

### DIFF
--- a/bullet_train-outgoing_webhooks/app/models/concerns/webhooks/outgoing/endpoint_support.rb
+++ b/bullet_train-outgoing_webhooks/app/models/concerns/webhooks/outgoing/endpoint_support.rb
@@ -16,7 +16,7 @@ module Webhooks::Outgoing::EndpointSupport
     before_validation { url&.strip! }
 
     validates :url, presence: true, allowed_uri: BulletTrain::OutgoingWebhooks.advanced_hostname_security
-    validates :event_type_ids, inclusion: {in: -> (endpoint) { endpoint.valid_event_types.map(&:id) }}
+    validates :event_type_ids, inclusion: {in: ->(endpoint) { endpoint.valid_event_types.map(&:id) }}
 
     after_initialize do
       self.event_type_ids ||= []


### PR DESCRIPTION
Fixes #407.

I was able to confirm the fix provided in the issue works by ejecting the webhooks controller and customizing the valid event types.

What I did in the screenshots here:
1. Ejected the webhooks controller and edited `valid_event_types` to only allow `membership` event types
2. Check `@endpoint.valid?` yields `true` in the create action
3. Temporarily add ALL event types to the record
4. Ensure the record is invalid when ALL the event types have been added.

The record is also valid when the event types field is left blank.

![Screenshot from 2023-08-17 21-46-40](https://github.com/bullet-train-co/bullet_train-core/assets/10546292/1b2671a8-f66c-42de-8bea-c7b66e5b8b85)

![Screenshot from 2023-08-17 21-46-06](https://github.com/bullet-train-co/bullet_train-core/assets/10546292/e448e8e5-9bd0-474e-b504-79cfb09d6dad)