### PR TITLE
[release process] Pass the tag name to the release action

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -31,4 +31,5 @@ jobs:
         if: ${{ startsWith(steps.tag-on-pr-merge.outputs.tag, 'v') }}
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: ${{ steps.tag-on-pr-merge.outputs.tag }}
           generate_release_notes: true


### PR DESCRIPTION
This should (finally) make it so that we automatically publish a GitHub relase when we tag a version.