### PR TITLE
[release process] One more fix

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -47,5 +47,3 @@ jobs:
     if: ${{ startsWith(needs.tag.outputs.tag, 'v') }}
     uses: ./.github/workflows/push.yml
     secrets: inherit
-    with:
-      tag_name: ${{ needs.tag.outputs.tag }}


### PR DESCRIPTION
We don't need to pass a value to a workflow that doesn't need it.