### PR TITLE
Exports the OpenAPI spec to a file

### DIFF
--- a/bullet_train-api/lib/tasks/bullet_train/api_tasks.rake
+++ b/bullet_train-api/lib/tasks/bullet_train/api_tasks.rake
@@ -128,5 +128,21 @@ namespace :bullet_train do
         puts "Failed to download the OpenAPI Document. Status code: #{response.status}"
       end
     end
+
+    desc "Export the OpenAPI schema for the application"
+    task export_openapi_schema: :environment do
+      @version = BulletTrain::Api.current_version
+      File.open("openapi-#{Time.now.strftime("%Y%m%d-%H%M%S")}.yaml", "w+") do |f|
+        f.binmode
+        f.write(
+          ApplicationController.renderer.render(
+            template: "api/#{@version}/open_api/index",
+            layout: false,
+            format: :text,
+            assigns: { version: @version }
+          )
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
This renders directly as opposed to via an HTTP req as in push_to_redocly task.

This currently just exports to the cwd.