### PR TITLE
[release process] Protect `bin/bump-all` and `bin/release-all`

### DIFF
--- a/bin/bump-all
+++ b/bin/bump-all
@@ -41,6 +41,12 @@ class CoreBumpCLI < Thor
     write_to_github_output_file
   end
 
+  # This allows failure to be reported to the shell correctly.
+  # https://github.com/rails/thor/wiki/Making-An-Executable
+  def self.exit_on_failure?
+    true
+  end
+
   # This allows us to define helper methods that aren't attached to thor commands
   no_commands do
     def github_output_file

--- a/bin/bump-all
+++ b/bin/bump-all
@@ -1,74 +1,133 @@
 #!/usr/bin/env ruby
 
-bump_version = ARGV[0]
+require 'thor'
 
-if !bump_version || !['patch', 'minor', 'major'].include?(bump_version)
-  puts "Invalid or no version bump specified. Should be one of: patch, minor, major"
-  if bump_version
-    puts "Version bump supplied: #{bump_version}"
+class CoreBumpCLI < Thor
+  desc "bump BUMP_LEVEL", "Bump the versions of bullet_train-core gems and npm packages. BUMP_LEVEL should be major, minor, or patch."
+  option :allow_local
+  def bump(bump_level)
+    if !bump_level || !['patch', 'minor', 'major'].include?(bump_level)
+      say_error "Invalid or no version bump specified. Should be one of: patch, minor, major", :red
+      if bump_level
+        say_error "Version bump supplied: #{bump_level}", :red
+      end
+      return
+    end
+    if !github_output_file && !options[:allow_local]
+      banner = <<~BANNER
+        --------------------------------------------------------------------------------------------------------
+        - It looks like you're running this scirpt locally.
+        - This script was designed to run as part of a GitHub workflow.
+        - The workflow will prepare a speically formatted PR that will kick off other workflows when merged.
+        - We don't recommend using this script locally to make updates directly to the core repo.
+        -
+        - You can run the workflow by going here:
+        - https://github.com/bullet-train-co/bullet_train-core/actions/workflows/version-bump.yml
+        -
+        - If you really want to run this locally you should make sure you're not on the `main` branch,
+        - and then you can pass the `--allow-local` flag to skip this notice and run the script.
+        -
+        - For example:
+        - ./bin/bump-all patch --allow-local
+        -------------------------------------------------------------------------------------------------------
+      BANNER
+      say_error banner, :red
+      return
+    end
+
+    bump_top_level(bump_level)
+    bump_ruby_gems(bump_level)
+    bump_npm_packages
+    write_to_github_output_file
   end
-  return
+
+  # This allows us to define helper methods that aren't attached to thor commands
+  no_commands do
+    def github_output_file
+      ENV['GITHUB_OUTPUT']
+    end
+
+    def bump_top_level(bump_level)
+      # First we run `bump` at the top level, this acts as the authorative gem version.
+      # We have a fake version file in `lib`, just to keep `bump` happy.
+
+      puts "bumping core"
+      puts output = `bump #{bump_level} --tag --no-commit`
+      @version = output.chomp.lines.last.chomp
+      puts "Bumped to #{@version}."
+    end
+
+    def bump_ruby_gems(bump_level)
+      # Now we bump each of the sub gems
+      ruby_gems.each do |package|
+        puts "bumping package: #{package}"
+        Dir.chdir "./#{package}"
+        puts output = `bump #{bump_level}`
+        Dir.chdir ".."
+      end
+    end
+
+    def current_version
+      @current_version || `bump current`
+    end
+
+    def bump_npm_packages
+      # And now we munge the package.json files
+      npm_packages.each do |package|
+        puts "bumping npm package: #{package}"
+        Dir.chdir "./#{package}"
+
+        text = File.read("package.json")
+        new_contents = text.gsub(/"version": ".*"/, "\"version\": \"#{@version}\"")
+        File.open("package.json", "w") { |file| file.puts new_contents }
+
+        Dir.chdir ".."
+      end
+    end
+
+    def write_to_github_output_file
+      if github_output_file
+        puts "The new version to pass to the GitHub output file = #{@version}"
+        IO.write(github_output_file, "NEW_VERSION_NUMBER=#{@version}\n", mode: 'a')
+      else
+        say "We don't seem to be running in GitHub actions. Skipping the GitHub output file."
+      end
+    end
+
+    def ruby_gems
+      %w(
+        bullet_train
+        bullet_train-api
+        bullet_train-fields
+        bullet_train-has_uuid
+        bullet_train-incoming_webhooks
+        bullet_train-integrations
+        bullet_train-integrations-stripe
+        bullet_train-obfuscates_id
+        bullet_train-outgoing_webhooks
+        bullet_train-roles
+        bullet_train-scope_questions
+        bullet_train-scope_validator
+        bullet_train-sortable
+        bullet_train-super_load_and_authorize_resource
+        bullet_train-super_scaffolding
+        bullet_train-themes
+        bullet_train-themes-light
+        bullet_train-themes-tailwind_css
+      )
+    end
+
+    def npm_packages
+      %w(
+        bullet_train
+        bullet_train-fields
+        bullet_train-sortable
+      )
+    end
+  end
 end
 
-packages=%w(
-  bullet_train
-  bullet_train-api
-  bullet_train-fields
-  bullet_train-has_uuid
-  bullet_train-incoming_webhooks
-  bullet_train-integrations
-  bullet_train-integrations-stripe
-  bullet_train-obfuscates_id
-  bullet_train-outgoing_webhooks
-  bullet_train-roles
-  bullet_train-scope_questions
-  bullet_train-scope_validator
-  bullet_train-sortable
-  bullet_train-super_load_and_authorize_resource
-  bullet_train-super_scaffolding
-  bullet_train-themes
-  bullet_train-themes-light
-  bullet_train-themes-tailwind_css
-)
+# We create our own args array so that we don't have to ask the user to include `bump` on the command line
+args = ["bump"] + ARGV
 
-# First we run `bump` at the top level, this acts as the authorative gem version.
-# We have a fake version file in `lib`, just to keep `bump` happy.
-
-puts "bumping core & CHANGELOG"
-puts output = `bump #{bump_version} --tag`
-version = output.chomp.lines.last.chomp
-puts "Bumped to #{version}."
-
-# Now we bump each of the sub gems
-packages.each do |package|
-  puts "bumping package: #{package}"
-  Dir.chdir "./#{package}"
-  puts output = `bump #{bump_version}`
-  Dir.chdir ".."
-end
-
-puts "the last version = #{version}"
-
-npm_packages=%w(
-  bullet_train
-  bullet_train-fields
-  bullet_train-sortable
-)
-
-# And now we munge the package.json files
-npm_packages.each do |package|
-  puts "bumping npm package: #{package}"
-  Dir.chdir "./#{package}"
-
-  text = File.read("package.json")
-  new_contents = text.gsub(/"version": ".*"/, "\"version\": \"#{version}\"")
-  File.open("package.json", "w") { |file| file.puts new_contents }
-
-  Dir.chdir ".."
-end
-
-# This block allows us to pass the new bump version out to the workflow.
-github_output_file = ENV['GITHUB_OUTPUT']
-if github_output_file
-  IO.write(github_output_file, "NEW_VERSION_NUMBER=#{version}\n", mode: 'a')
-end
+CoreBumpCLI.start(args)

--- a/bin/bump-all
+++ b/bin/bump-all
@@ -67,10 +67,6 @@ class CoreBumpCLI < Thor
       end
     end
 
-    def current_version
-      @current_version || `bump current`
-    end
-
     def bump_npm_packages
       # And now we munge the package.json files
       npm_packages.each do |package|

--- a/bin/release-all
+++ b/bin/release-all
@@ -1,70 +1,133 @@
 #!/usr/bin/env ruby
 
-puts output = `bump current`
-version = output.chomp.lines.last.chomp
+require 'thor'
 
-"Releasing version: #{version}"
+class CoreBumpCLI < Thor
+  desc "release", "Build ruby gems & npm packages and push them to their respective platforms."
+  option :allow_local
+  def release
+    if !github_output_file && !options[:allow_local]
+      banner = <<~BANNER
+        --------------------------------------------------------------------------------------------------------
+        - It looks like you're running this scirpt locally.
+        - This script was designed to run as part of a GitHub workflow.
+        - We don't recommend using this script locally to directly publish gems and packages.
+        -
+        - You can run the workflow by going here:
+        - https://github.com/bullet-train-co/bullet_train-core/actions/workflows/version-bump.yml
+        -
+        - If you really want to run this locally you should make sure you're not on the `main` branch,
+        - and then you can pass the `--allow-local` flag to skip this notice and run the script.
+        -
+        - For example:
+        - ./bin/release-all --allow-local
+        -------------------------------------------------------------------------------------------------------
+      BANNER
+      say_error banner, :red
+      return
+    end
 
-packages=%w(
-  bullet_train
-  bullet_train-api
-  bullet_train-fields
-  bullet_train-has_uuid
-  bullet_train-incoming_webhooks
-  bullet_train-integrations
-  bullet_train-integrations-stripe
-  bullet_train-obfuscates_id
-  bullet_train-outgoing_webhooks
-  bullet_train-roles
-  bullet_train-scope_questions
-  bullet_train-scope_validator
-  bullet_train-sortable
-  bullet_train-super_load_and_authorize_resource
-  bullet_train-super_scaffolding
-  bullet_train-themes
-  bullet_train-themes-light
-  bullet_train-themes-tailwind_css
-)
+    puts output = `bump current`
+    @version = output.chomp.lines.last.chomp
+    "Releasing version: #{@version}"
 
+    release_ruby_gems
+    release_npm_packages
+    write_to_github_output_file
+  end
 
-packages.each do |package|
-  puts "releasing package: #{package}"
-  Dir.chdir "./#{package}"
+  # This allows failure to be reported to the shell correctly.
+  # https://github.com/rails/thor/wiki/Making-An-Executable
+  def self.exit_on_failure?
+    true
+  end
 
-  puts output = `gem build`
-  gem_file = output.chomp.lines.last.chomp.split.last
-  puts "Built gem file: #{gem_file}"
+  # This allows us to define helper methods that aren't attached to thor commands
+  no_commands do
+    def github_output_file
+      ENV['GITHUB_OUTPUT']
+    end
 
-  puts output = `gem push #{gem_file}`
+    def release_ruby_gems
+      ruby_gems.each do |package|
+        puts "releasing package: #{package}"
+        Dir.chdir "./#{package}"
 
-  File.delete(gem_file)
+        puts output = `gem build`
+        gem_file = output.chomp.lines.last.chomp.split.last
+        puts "Built gem file: #{gem_file}"
 
-  Dir.chdir ".."
+        puts output = `gem push #{gem_file}`
 
+        File.delete(gem_file)
+
+        Dir.chdir ".."
+
+      end
+    end
+
+    def release_npm_packages
+      npm_packages.each do |package|
+        puts "releasing npm package: #{package}"
+        Dir.chdir "./#{package}"
+
+        puts `yarn`
+        puts `yarn build`
+        puts output = `yarn pack`
+        npm_file = output.chomp.lines[1].split("/").last.split("\"").first
+        puts "Built npm file: #{npm_file}"
+
+        puts output = `yarn publish #{npm_file} --new-version #{@version}`
+
+        File.delete(npm_file)
+
+        Dir.chdir ".."
+      end
+    end
+
+    def write_to_github_output_file
+      if github_output_file
+        puts "The new version to pass to the GitHub output file = #{@version}"
+        IO.write(github_output_file, "NEW_VERSION_NUMBER=#{@version}\n", mode: 'a')
+      else
+        say "We don't seem to be running in GitHub actions. Skipping the GitHub output file."
+      end
+    end
+
+    def ruby_gems
+      %w(
+        bullet_train
+        bullet_train-api
+        bullet_train-fields
+        bullet_train-has_uuid
+        bullet_train-incoming_webhooks
+        bullet_train-integrations
+        bullet_train-integrations-stripe
+        bullet_train-obfuscates_id
+        bullet_train-outgoing_webhooks
+        bullet_train-roles
+        bullet_train-scope_questions
+        bullet_train-scope_validator
+        bullet_train-sortable
+        bullet_train-super_load_and_authorize_resource
+        bullet_train-super_scaffolding
+        bullet_train-themes
+        bullet_train-themes-light
+        bullet_train-themes-tailwind_css
+      )
+    end
+
+    def npm_packages
+      %w(
+        bullet_train
+        bullet_train-fields
+        bullet_train-sortable
+      )
+    end
+  end
 end
 
+# We create our own args array so that we don't have to ask the user to include `release` on the command line
+args = ["release"] + ARGV
 
-npm_packages=%w(
-  bullet_train
-  bullet_train-fields
-  bullet_train-sortable
-)
-
-npm_packages.each do |package|
-  puts "releasing npm package: #{package}"
-  Dir.chdir "./#{package}"
-
-  puts `yarn`
-  puts `yarn build`
-  puts output = `yarn pack`
-  npm_file = output.chomp.lines[1].split("/").last.split("\"").first
-  puts "Built npm file: #{npm_file}"
-
-  puts output = `yarn publish #{npm_file} --new-version #{version}`
-
-  File.delete(npm_file)
-
-  Dir.chdir ".."
-end
-
-
+CoreBumpCLI.start(args)


### PR DESCRIPTION
Fixes #448

This makes it so that `bin/bump-all` and `bin/release-all` will display a wanring banner if they are run outside of a GitHub actions workflow and if they do not receive the `--allow-local` flag. After displaying the warning banner the scripts will exit and not do anything.

Passing the `--allow-local` will allow the script to run.

The warning banners look like this:

`bin/bump-all`

```
--------------------------------------------------------------------------------------------------------
- It looks like you're running this scirpt locally.
- This script was designed to run as part of a GitHub workflow.
- The workflow will prepare a speically formatted PR that will kick off other workflows when merged.
- We don't recommend using this script locally to make updates directly to the core repo.
-
- You can run the workflow by going here:
- https://github.com/bullet-train-co/bullet_train-core/actions/workflows/version-bump.yml
-
- If you really want to run this locally you should make sure you're not on the `main` branch,
- and then you can pass the `--allow-local` flag to skip this notice and run the script.
-
- For example:
- ./bin/bump-all patch --allow-local
-------------------------------------------------------------------------------------------------------

```

`bin/release-all`

```
--------------------------------------------------------------------------------------------------------
- It looks like you're running this scirpt locally.
- This script was designed to run as part of a GitHub workflow.
- We don't recommend using this script locally to directly publish gems and packages.
-
- You can run the workflow by going here:
- https://github.com/bullet-train-co/bullet_train-core/actions/workflows/version-bump.yml
-
- If you really want to run this locally you should make sure you're not on the `main` branch,
- and then you can pass the `--allow-local` flag to skip this notice and run the script.
-
- For example:
- ./bin/release-all --allow-local
-------------------------------------------------------------------------------------------------------
```