### PR TITLE
Generate clickable anchor links in `/docs`

### DIFF
--- a/bullet_train-themes-light/app/assets/stylesheets/light/application.css
+++ b/bullet_train-themes-light/app/assets/stylesheets/light/application.css
@@ -8,6 +8,7 @@
 @import './devise';
 @import './fields';
 @import './turn';
+@import './docs';
 
 form.button_to {
   @apply inline-block;

--- a/bullet_train-themes-light/app/assets/stylesheets/light/docs.css
+++ b/bullet_train-themes-light/app/assets/stylesheets/light/docs.css
@@ -1,0 +1,45 @@
+#bt-docs-content h1,
+#bt-docs-content h2,
+#bt-docs-content h3,
+#bt-docs-content h4,
+#bt-docs-content h5,
+#bt-docs-content h6{
+  position: relative;
+  margin-left: -1.2em;
+  padding-left: 1.2em;
+}
+#bt-docs-content h1 a,
+#bt-docs-content h2 a,
+#bt-docs-content h3 a,
+#bt-docs-content h4 a,
+#bt-docs-content h5 a,
+#bt-docs-content h6 a{
+  text-decoration: none;
+  display: none;
+  position: absolute;
+  float:left;
+  margin-left:-1.2em;
+  line-height: 1;
+  width: 1em;
+  height: 100%;
+}
+
+#bt-docs-content h1 a::before,
+#bt-docs-content h2 a::before,
+#bt-docs-content h3 a::before,
+#bt-docs-content h4 a::before,
+#bt-docs-content h5 a::before,
+#bt-docs-content h6 a::before{
+  content: "🔗";
+}
+
+#bt-docs-content h1:hover a,
+#bt-docs-content h2:hover a,
+#bt-docs-content h3:hover a,
+#bt-docs-content h4:hover a,
+#bt-docs-content h5:hover a,
+#bt-docs-content h6:hover a{
+  display: flex;
+  justify-content: center; /* Align horizontal */
+  align-items: center; /* Align vertical */
+}

--- a/bullet_train/app/helpers/account/markdown_helper.rb
+++ b/bullet_train/app/helpers/account/markdown_helper.rb
@@ -2,6 +2,7 @@ module Account::MarkdownHelper
   def markdown(string)
     if defined?(Commonmarker.to_html)
       Commonmarker.to_html(string, options: {
+        extensions: {header_ids: true},
         plugins: {syntax_highlighter: {theme: "InspiredGitHub"}},
         render: {width: 120, unsafe: true}
       }).html_safe

--- a/bullet_train/app/views/layouts/docs.html.erb
+++ b/bullet_train/app/views/layouts/docs.html.erb
@@ -355,7 +355,7 @@
             <div class="py-2 px-1">
               <div class="mx-auto sm:px-6 sm:py-4 px-2">
                 <div class="bg-white rounded-md shadow sm:py-14 sm:px-12 py-10 px-7">
-                  <div class="prose" style="max-width: none;">
+                  <div class="prose" style="max-width: none;" id="bt-docs-content">
                     <%= yield %>
                   </div>
                 </div>


### PR DESCRIPTION
Fixes #191

This relies on the `1.x` branch of the `commonmarker` gem, which is currently in pre-relase stages.

We're waiting for `1.x` to get to a general release before we update our dependencies and force the change on downstream users. The maintainer of that gem has estimated that the general release should happen sometime this fall, maybe around October. Once that release is available and once we've updated our depencency list this change should Just Work.

In the meantime downstream applications can opt-in to using a pre-release candidate of `commonmarker` by adding this to the `Gemfile`:

```ruby
gem 'commonmarker', '~> 1.0.0.pre10'
```

![CleanShot 2023-08-24 at 13 49 17](https://github.com/bullet-train-co/bullet_train-core/assets/58702/26b1109d-6d03-4da0-84a1-d70cdb034e3b)
