### PR TITLE
Fix URL output for ngrok tunnel when super scaffolding an incoming webhook

### DIFF
--- a/bullet_train-incoming_webhooks/lib/bullet_train/incoming_webhooks/scaffolders/incoming_webhooks_scaffolder.rb
+++ b/bullet_train-incoming_webhooks/lib/bullet_train/incoming_webhooks/scaffolders/incoming_webhooks_scaffolder.rb
@@ -30,7 +30,7 @@ module BulletTrain
           puts "     See http://bullettrain.co/docs/tunneling for more information.".yellow
           puts ""
           puts "2. Once you have a tunnel running, you can configure the provider to deliver webhooks to:".yellow
-          puts "     https://your-tunnel.ngrok.io/webhooks/incoming/#{provider_name.tableize}_webhooks".yellow
+          puts "     https://your-tunnel.ngrok.io/webhooks/incoming/#{provider_name.tableize.singularize}_webhooks".yellow
           puts ""
 
           transformer.restart_server

--- a/bullet_train/docs/tunneling.md
+++ b/bullet_train/docs/tunneling.md
@@ -11,7 +11,7 @@ You should specifically sign up for a paid account. Although ngrok offers a free
 Once you have ngrok installed, you can start your tunnel like so, replacing `YOUR-SUBDOMAIN` with whatever subdomain you reserved in your ngrok account:
 
 ```
-ngrok http 3000 --subdomain=YOUR-SUBDOMAIN
+ngrok http --domain=YOUR-SUBDOMAIN 3000
 ```
 
 ## Updating Your Configuration


### PR DESCRIPTION
Fixes #474.
Also mentioned [here](https://github.com/bullet-train-co/bullet_train-core/issues/453#issuecomment-1687445312) which has more details about the fix.