### PR TITLE
Features/gem tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
     executor: ruby/default
     steps:
       - checkout:
-        path: ~/project-gems
+          path: ~/project-gems
       - browser-tools/install-browser-tools:
           firefox-version: "112.0"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,16 +28,27 @@ jobs:
     executor: ruby/default
     steps:
       - checkout
+        path: ~/project-gems
       - browser-tools/install-browser-tools:
           firefox-version: "112.0"
 
+      # TODO: This is a workaround to get `git clone` working, but it shouldn't be here.
+      # https://github.com/CircleCI-Public/browser-tools-orb/issues/62
+      - run:
+          command: rm LICENSE.chromedriver
+
+      - run: ../../bin/checkout-and-link-starter-repo
+
       - ruby/install-deps:
           clean-bundle: true
-      - run: "yarn install"
+      - node/install-packages:
+          pkg-manager: yarn
+      - run: yarn build:css
+      - run: yarn build
       - *wait_for_docker
       - run:
           name: Run unit tests
-          command: bundle exec rails test
+          command: ../../bin/test-core-gems
 
   'Local Standard Ruby':
     docker:
@@ -149,7 +160,7 @@ workflows:
   version: 2
   build:
     jobs:
-      # - 'Local Minitest'
       - 'Local Standard Ruby'
+      - 'Local Minitest'
       - 'Starter Repo Minitest'
       - 'Starter Repo Minitest for Super Scaffolding'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       - image: circleci/redis
     executor: ruby/default
     steps:
-      - checkout
+      - checkout:
         path: ~/project-gems
       - browser-tools/install-browser-tools:
           firefox-version: "112.0"

--- a/bin/test-core-gems
+++ b/bin/test-core-gems
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+packages=(
+  "bullet_train"
+  "bullet_train-api"
+  "bullet_train-fields"
+  "bullet_train-has_uuid"
+  "bullet_train-incoming_webhooks"
+  "bullet_train-integrations"
+  "bullet_train-integrations-stripe"
+  "bullet_train-obfuscates_id"
+  "bullet_train-outgoing_webhooks"
+  "bullet_train-roles"
+  "bullet_train-scope_questions"
+  "bullet_train-scope_validator"
+  "bullet_train-sortable"
+  "bullet_train-super_load_and_authorize_resource"
+  "bullet_train-super_scaffolding"
+  "bullet_train-themes"
+  "bullet_train-themes-light"
+  "bullet_train-themes-tailwind_css"
+)
+
+for package in "${packages[@]}"
+do
+  :
+  # bundle exec rails test ../../${package}
+  bundle exec rails test ../../bullet_train
+done


### PR DESCRIPTION
This is an attempt to run all of the tests for the gems in this repository.

Running `CI=true bundle exec rails test local/bullet_train-core/bullet_train` will work, but if we run `CI=true bundle exec rails test` from within `bullet_train-core/bullet_train`, it will fail because it doesn't have the context of the full application.

I figured we could test these gems from the context of a starter repository application because we already have the `Starter Repo Minitest` in place.

We would have to do a lot of editing to the tests to make them pass, but as of now this is the only solution I can come up with to automate our core gem tests on CI.