### PR TITLE
Add `tailwind.mailer.light.config.js` to the gem package

### DIFF
--- a/bullet_train-themes-light/bullet_train-themes-light.gemspec
+++ b/bullet_train-themes-light/bullet_train-themes-light.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   # spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md", "tailwind.light.config.js", ".bt-link"]
+    Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md", "tailwind.light.config.js", "tailwind.mailer.light.config.js", ".bt-link"]
   end
 
   spec.add_development_dependency "standard"


### PR DESCRIPTION
Fixes https://github.com/bullet-train-co/bullet_train-core/issues/26

Since we weren't including this file in the package it was causing problems for people who were running with the released gems.

But the file would be available if you'd linked your core repos into the starter repo.