### PR TITLE
Use parent_association setting for outgoing webhook events

### DIFF
--- a/bullet_train-outgoing_webhooks/app/views/api/v1/webhooks/outgoing/events/_event.json.jbuilder
+++ b/bullet_train-outgoing_webhooks/app/views/api/v1/webhooks/outgoing/events/_event.json.jbuilder
@@ -1,6 +1,6 @@
 json.extract! event,
   :id,
-  :team_id,
+  BulletTrain::OutgoingWebhooks.parent_association.to_s.foreign_key.to_sym,
   :uuid,
   :event_type_id,
   :subject_id,


### PR DESCRIPTION
Use parent_association setting for API output rather than hardcoded team in outgoing webhook events