### PR TITLE
Allow `required` to be passed in to field partials

### DIFF
--- a/bullet_train-themes-light/app/views/themes/light/fields/_field.html.erb
+++ b/bullet_train-themes-light/app/views/themes/light/fields/_field.html.erb
@@ -15,6 +15,11 @@ options ||= {}
 options[:id] ||= form.field_id(method)
 # options[:disabled] ||= !field_editable?(form.object, method) if user_signed_in?
 options[:placeholder] ||= labels.placeholder if labels.placeholder
+
+if !options.key?(:required)
+  options[:required] = presence_validated?(form.object, method)
+end
+
 other_options ||= {}
 other_options[:help] = [other_options[:help], labels.help].compact.join(" ")
 
@@ -31,7 +36,7 @@ end
 
 %>
 
-<div class="<%= 'required' if presence_validated?(form.object, method) %>">
+<div class="<%= 'required' if options[:required] %>">
 
   <% # the label. %>
   <% unless other_options[:hide_label] == true %>

--- a/bullet_train/app/views/devise/registrations/new.html.erb
+++ b/bullet_train/app/views/devise/registrations/new.html.erb
@@ -17,7 +17,7 @@
            <%= render 'shared/fields/password_field', form: f, method: :password, options: {show_strength_indicator: true} %>
          </div>
          <div>
-           <%= render 'shared/fields/password_field', form: f, method: :password_confirmation, other_options: {error: f.object.errors.full_messages_for(:password).first, hide_custom_error: true} %>
+           <%= render 'shared/fields/password_field', form: f, method: :password_confirmation, options:{ required: true }, other_options: {error: f.object.errors.full_messages_for(:password).first, hide_custom_error: true} %>
          </div>
        </div>
 


### PR DESCRIPTION
Fixes https://github.com/bullet-train-co/bullet_train-core/issues/379 (Kind of)

Currently we have kind of weird handling around required fields. This PR is an attempt to resolve that situation.

It's a pretty small change, but has potentially big impacts on applications. I'd love to get a bunch of eyes on this and hear what everyone thinks, so I'm going to tag a bunch of people. (Sorry! Feel free to tag in anyone else that might be interested.) @andrewculver @gazayas @kaspth @pascallaliberte @newstler @adampal @julianrubisch 

## The Problem

Currently we show the red asterisk on required fields **only** if the object represented by the form has a validation for `presence` on that field. For instance on the user registration form we don't show an asterisk for `password_confirmation` because Devise doesn't setup a `validates_presence` validation for that field.

![CleanShot 2023-08-30 at 10 45 51](https://github.com/bullet-train-co/bullet_train-core/assets/58702/fe69d021-10a5-4913-971d-189bf4fe8e57)

But the field really is required. If you fill in a password, but no confirmation and then submit the form, it causes an error.

![CleanShot 2023-08-30 at 10 52 33](https://github.com/bullet-train-co/bullet_train-core/assets/58702/616d16e3-da55-4819-bdeb-194d752bf9db)

If a developer were to eject the devise form they could add `options: { required: true}` to the form:

```diff
  <%= render 'shared/fields/password_field', form: f,
    method: :password_confirmation,
+   options: { required: true },
    other_options: {
        error: f.object.errors.full_messages_for(:password).first,
        hide_custom_error: true
    }
  %>
```

That will have the effect of setting the `required` attribute on the password field that ends up getting rendered. That leads to a confusing experience where the label does not indicate that the field is required, but the browser does complain that it's not filled in. 

![CleanShot 2023-08-30 at 10 42 29](https://github.com/bullet-train-co/bullet_train-core/assets/58702/805c60a3-770c-4511-bf94-469f005ed2c9)

(And if they didn't also add it to the main `password` field they would not see the browser complain about _that_ field being blank.)

## One possible fix

This PR makes it so that if `required` is passed into the `options` hash that the field partial that renders the asterisk will use that value first, and will fallback to the existing validation method if it's not passed in.

That makes it so that the red asterisk will show up, and then the browser "validation" matches the label.

![CleanShot 2023-08-30 at 10 58 39](https://github.com/bullet-train-co/bullet_train-core/assets/58702/6f48175a-8df8-41a6-8a22-a8baa623733f)

This PR _also_ makes it so that we pass that same `required` value in the `options` hash down into the rendered HTML element. 

## Possible problems

The biggest problem I see with this is that it dramatically changes what happens when someone tries to submit a form without filling in a required attribute.

Currently the form would actually be submitted and then we are in control of what the user sees in response.

![CleanShot 2023-08-30 at 11 01 09](https://github.com/bullet-train-co/bullet_train-core/assets/58702/3617b217-08d4-47a4-8490-f6b0a852a08f)

This PR makes it so that most browsers would refuse to even submit the form, and would show their own native messaging around empty required fields.

![CleanShot 2023-08-30 at 11 00 32](https://github.com/bullet-train-co/bullet_train-core/assets/58702/2b97d3e1-cad5-4e7a-83c4-d1778228475c)

## Other options

We could potentially tell people to put `required: true` in `other_options` instead of `options` so that it's not passed down to the rendered html element. ([See the docs for more info about this.](https://bullettrain.co/docs/field-partials#options-vs-other_options))

And then we'd modify this PR to look at `other_options` instead of `options`.

And we could potentially remove `required` from the `options` hash if it's passed there, just to be consistent. But I think that leads to...

## Accessibility concerns

I think that this PR is the "most correct" way of handling this because it ends up getting the `required` attribute into the rendered HTML of all fields that are actually required. That means that browsers and screen readers and other accessibility tools can "see" it. I _think_ that this is the best option from an accessibility standpoint because it relies on the HTML standard, whereas our current solution relies on people being able to _visually see_ the little red asterisk that we add via CSS.

But I realize that this is a big change from a user experience perspective, so I want to hear what everyone else thinks.