### PR TITLE
Get CircleCI running again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   ruby: circleci/ruby@2.0.0
   node: circleci/node@5.1.0
-  browser-tools: circleci/browser-tools@1.4.1
+  browser-tools: circleci/browser-tools@1.4.3
 aliases:
   - &ruby_node_browsers_docker_image
       - image: cimg/ruby:3.2.2-browsers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
     executor: ruby/default
     steps:
       - checkout
+      - run: sudo apt-get update # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
       - browser-tools/install-browser-tools:
           firefox-version: "112.0"
           chrome-version: 116.0.5845.96 # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
@@ -62,6 +63,7 @@ jobs:
     steps:
       - checkout:
           path: ~/project
+      - run: sudo apt-get update # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
       - browser-tools/install-browser-tools:
           firefox-version: "112.0"
           chrome-version: 116.0.5845.96 # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
@@ -116,6 +118,7 @@ jobs:
     steps:
       - checkout:
           path: ~/project
+      - run: sudo apt-get update # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
       - browser-tools/install-browser-tools:
           firefox-version: "112.0"
           chrome-version: 116.0.5845.96 # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
       - browser-tools/install-browser-tools:
           firefox-version: "112.0"
           chrome-version: "116.0.5845.96" # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
+          replace-existing-chrome: true
 
       - ruby/install-deps:
           clean-bundle: true
@@ -67,6 +68,7 @@ jobs:
       - browser-tools/install-browser-tools:
           firefox-version: "112.0"
           chrome-version: "116.0.5845.96" # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
+          replace-existing-chrome: true
 
       # TODO: This is a workaround to get `git clone` working, but it shouldn't be here.
       # https://github.com/CircleCI-Public/browser-tools-orb/issues/62
@@ -122,6 +124,7 @@ jobs:
       - browser-tools/install-browser-tools:
           firefox-version: "112.0"
           chrome-version: "116.0.5845.96" # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
+          replace-existing-chrome: true
 
       # TODO: This is a workaround to get `git clone` working, but it shouldn't be here.
       # https://github.com/CircleCI-Public/browser-tools-orb/issues/62

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,11 +68,6 @@ jobs:
           chrome-version: "116.0.5845.96" # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
           replace-existing-chrome: true # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
 
-      # TODO: This is a workaround to get `git clone` working, but it shouldn't be here.
-      # https://github.com/CircleCI-Public/browser-tools-orb/issues/62
-      #- run:
-          #command: rm LICENSE.chromedriver
-
       - run: ../../bin/checkout-and-link-starter-repo
 
       - ruby/install-deps:
@@ -122,11 +117,6 @@ jobs:
           firefox-version: "112.0"
           chrome-version: "116.0.5845.96" # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
           replace-existing-chrome: true # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
-
-      # TODO: This is a workaround to get `git clone` working, but it shouldn't be here.
-      # https://github.com/CircleCI-Public/browser-tools-orb/issues/62
-      #- run:
-          #command: rm LICENSE.chromedriver
 
       - run: ../../bin/checkout-and-link-starter-repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,11 +28,10 @@ jobs:
     executor: ruby/default
     steps:
       - checkout
-      #- run: sudo apt-get update # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
       - browser-tools/install-browser-tools:
           firefox-version: "112.0"
           chrome-version: "116.0.5845.96" # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
-          replace-existing-chrome: true
+          replace-existing-chrome: true # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
 
       - ruby/install-deps:
           clean-bundle: true
@@ -64,11 +63,10 @@ jobs:
     steps:
       - checkout:
           path: ~/project
-      #- run: sudo apt-get update # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
       - browser-tools/install-browser-tools:
           firefox-version: "112.0"
           chrome-version: "116.0.5845.96" # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
-          replace-existing-chrome: true
+          replace-existing-chrome: true # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
 
       # TODO: This is a workaround to get `git clone` working, but it shouldn't be here.
       # https://github.com/CircleCI-Public/browser-tools-orb/issues/62
@@ -120,11 +118,10 @@ jobs:
     steps:
       - checkout:
           path: ~/project
-      #- run: sudo apt-get update # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
       - browser-tools/install-browser-tools:
           firefox-version: "112.0"
           chrome-version: "116.0.5845.96" # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
-          replace-existing-chrome: true
+          replace-existing-chrome: true # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
 
       # TODO: This is a workaround to get `git clone` working, but it shouldn't be here.
       # https://github.com/CircleCI-Public/browser-tools-orb/issues/62

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   ruby: circleci/ruby@2.0.0
   node: circleci/node@5.1.0
-  browser-tools: circleci/browser-tools@1.4.3
+  browser-tools: circleci/browser-tools@1.4.4
 aliases:
   - &ruby_node_browsers_docker_image
       - image: cimg/ruby:3.2.2-browsers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - run: sudo apt-get update # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
       - browser-tools/install-browser-tools:
           firefox-version: "112.0"
-          chrome-version: 116.0.5845.96 # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
+          chrome-version: "116.0.5845.96" # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
 
       - ruby/install-deps:
           clean-bundle: true
@@ -66,7 +66,7 @@ jobs:
       - run: sudo apt-get update # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
       - browser-tools/install-browser-tools:
           firefox-version: "112.0"
-          chrome-version: 116.0.5845.96 # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
+          chrome-version: "116.0.5845.96" # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
 
       # TODO: This is a workaround to get `git clone` working, but it shouldn't be here.
       # https://github.com/CircleCI-Public/browser-tools-orb/issues/62
@@ -121,7 +121,7 @@ jobs:
       - run: sudo apt-get update # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
       - browser-tools/install-browser-tools:
           firefox-version: "112.0"
-          chrome-version: 116.0.5845.96 # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
+          chrome-version: "116.0.5845.96" # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
 
       # TODO: This is a workaround to get `git clone` working, but it shouldn't be here.
       # https://github.com/CircleCI-Public/browser-tools-orb/issues/62

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
     executor: ruby/default
     steps:
       - checkout
-      - run: sudo apt-get update # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
+      #- run: sudo apt-get update # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
       - browser-tools/install-browser-tools:
           firefox-version: "112.0"
           chrome-version: "116.0.5845.96" # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
@@ -64,7 +64,7 @@ jobs:
     steps:
       - checkout:
           path: ~/project
-      - run: sudo apt-get update # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
+      #- run: sudo apt-get update # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
       - browser-tools/install-browser-tools:
           firefox-version: "112.0"
           chrome-version: "116.0.5845.96" # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
@@ -120,7 +120,7 @@ jobs:
     steps:
       - checkout:
           path: ~/project
-      - run: sudo apt-get update # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
+      #- run: sudo apt-get update # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
       - browser-tools/install-browser-tools:
           firefox-version: "112.0"
           chrome-version: "116.0.5845.96" # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ jobs:
       - checkout
       - browser-tools/install-browser-tools:
           firefox-version: "112.0"
+          chrome-version: 116.0.5845.96 # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
 
       - ruby/install-deps:
           clean-bundle: true
@@ -63,6 +64,7 @@ jobs:
           path: ~/project
       - browser-tools/install-browser-tools:
           firefox-version: "112.0"
+          chrome-version: 116.0.5845.96 # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
 
       # TODO: This is a workaround to get `git clone` working, but it shouldn't be here.
       # https://github.com/CircleCI-Public/browser-tools-orb/issues/62
@@ -116,6 +118,7 @@ jobs:
           path: ~/project
       - browser-tools/install-browser-tools:
           firefox-version: "112.0"
+          chrome-version: 116.0.5845.96 # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
 
       # TODO: This is a workaround to get `git clone` working, but it shouldn't be here.
       # https://github.com/CircleCI-Public/browser-tools-orb/issues/62

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,8 +72,8 @@ jobs:
 
       # TODO: This is a workaround to get `git clone` working, but it shouldn't be here.
       # https://github.com/CircleCI-Public/browser-tools-orb/issues/62
-      - run:
-          command: rm LICENSE.chromedriver
+      #- run:
+          #command: rm LICENSE.chromedriver
 
       - run: ../../bin/checkout-and-link-starter-repo
 
@@ -128,8 +128,8 @@ jobs:
 
       # TODO: This is a workaround to get `git clone` working, but it shouldn't be here.
       # https://github.com/CircleCI-Public/browser-tools-orb/issues/62
-      - run:
-          command: rm LICENSE.chromedriver
+      #- run:
+          #command: rm LICENSE.chromedriver
 
       - run: ../../bin/checkout-and-link-starter-repo
 


### PR DESCRIPTION
Circle wasn't even getting to running the tests because it was failing with this error:

```
Installed version of Google Chrome is 116.0.5845.140 
116.0.5845.140 will be installed
curl: (22) The requested URL returned error: 404 

Exited with code exit status 22
```

This was due to Google releasing a new version of Chrome without releasing a corresponding version of chromedriver.

Some other issues for reference:
https://github.com/CircleCI-Public/browser-tools-orb/issues/90
https://github.com/CircleCI-Public/browser-tools-orb/issues/75

