### PR TITLE
Super Scaffold incoming webhooks test

### DIFF
--- a/bullet_train-incoming_webhooks/config/routes.rb
+++ b/bullet_train-incoming_webhooks/config/routes.rb
@@ -1,2 +1,7 @@
 Rails.application.routes.draw do
+  namespace :webhooks do
+    namespace :incoming do
+      resources :bullet_train_webhooks
+    end
+  end
 end

--- a/bullet_train-incoming_webhooks/lib/scaffolding/incoming_webhooks_transformer.rb
+++ b/bullet_train-incoming_webhooks/lib/scaffolding/incoming_webhooks_transformer.rb
@@ -12,7 +12,8 @@ class Scaffolding::IncomingWebhooksTransformer < Scaffolding::Transformer
   def scaffold_incoming_webhook
     files = [
       "./app/models/webhooks/incoming/bullet_train_webhook.rb",
-      "./app/controllers/webhooks/incoming/bullet_train_webhooks_controller.rb"
+      "./app/controllers/webhooks/incoming/bullet_train_webhooks_controller.rb",
+      "./test/controllers/webhooks/incoming/bullet_train_webhooks_controller_test.rb"
     ]
 
     files.each do |name|
@@ -23,8 +24,9 @@ class Scaffolding::IncomingWebhooksTransformer < Scaffolding::Transformer
       end
     end
 
-    file_name_hook = "bullet_train_webhook"
-    new_model_file_name, _ = files.map { |file| file.gsub(file_name_hook, replacement_for(file_name_hook)) }
+    new_model_file_name = files.first.gsub("bullet_train_webhook", replacement_for("bullet_train_webhook"))
+    new_test_file_name = files.last.gsub("bullet_train_webhooks", replacement_for("bullet_train_webhooks"))
+
 
     # Set up the model's `verify_authenticity` method to return `true`.
     model_file_lines = File.readlines(new_model_file_name)

--- a/bullet_train-incoming_webhooks/lib/scaffolding/incoming_webhooks_transformer.rb
+++ b/bullet_train-incoming_webhooks/lib/scaffolding/incoming_webhooks_transformer.rb
@@ -27,7 +27,6 @@ class Scaffolding::IncomingWebhooksTransformer < Scaffolding::Transformer
     new_model_file_name = files.first.gsub("bullet_train_webhook", replacement_for("bullet_train_webhook"))
     new_test_file_name = files.last.gsub("bullet_train_webhooks", replacement_for("bullet_train_webhooks"))
 
-
     # Set up the model's `verify_authenticity` method to return `true`.
     model_file_lines = File.readlines(new_model_file_name)
     comment_lines = [

--- a/bullet_train-incoming_webhooks/lib/scaffolding/incoming_webhooks_transformer.rb
+++ b/bullet_train-incoming_webhooks/lib/scaffolding/incoming_webhooks_transformer.rb
@@ -24,8 +24,9 @@ class Scaffolding::IncomingWebhooksTransformer < Scaffolding::Transformer
       end
     end
 
-    file_name_hook = "bullet_train_webhook"
-    new_model_file_name, _ = files.map { |file| file.gsub(file_name_hook, replacement_for(file_name_hook)) }
+    new_model_file_name = files.first.gsub("bullet_train_webhook", replacement_for("bullet_train_webhook"))
+    new_test_file_name = files.last.gsub("bullet_train_webhooks", replacement_for("bullet_train_webhooks"))
+
 
     # Set up the model's `verify_authenticity` method to return `true`.
     model_file_lines = File.readlines(new_model_file_name)

--- a/bullet_train-incoming_webhooks/lib/scaffolding/incoming_webhooks_transformer.rb
+++ b/bullet_train-incoming_webhooks/lib/scaffolding/incoming_webhooks_transformer.rb
@@ -24,8 +24,8 @@ class Scaffolding::IncomingWebhooksTransformer < Scaffolding::Transformer
       end
     end
 
-    new_model_file_name = files.first.gsub("bullet_train_webhook", replacement_for("bullet_train_webhook"))
-    new_test_file_name = files.last.gsub("bullet_train_webhooks", replacement_for("bullet_train_webhooks"))
+    file_name_hook = "bullet_train_webhook"
+    new_model_file_name, _ = files.map { |file| file.gsub(file_name_hook, replacement_for(file_name_hook)) }
 
     # Set up the model's `verify_authenticity` method to return `true`.
     model_file_lines = File.readlines(new_model_file_name)

--- a/bullet_train-incoming_webhooks/test/controllers/webhooks/incoming/bullet_train_webhooks_controller_test.rb
+++ b/bullet_train-incoming_webhooks/test/controllers/webhooks/incoming/bullet_train_webhooks_controller_test.rb
@@ -3,46 +3,40 @@ require "test_helper"
 class Webhooks::Incoming::BulletTrainWebhooksControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
-  # We can only run this test when Scaffolding things are enabled
-  # because the default webhook triggers come from `CreativeConcept`, etc.
-  unless scaffolding_things_disabled?
-    def setup
-      super
-      @user = FactoryBot.create(:onboarded_user)
-      sign_in @user
-      @team = @user.current_team
-    end
+  def setup
+    super
+    @user = FactoryBot.create(:onboarded_user)
+    @membership = @user.memberships.first
+    @team = @user.current_team
+  end
 
-    test "should get incoming webhook" do
-      creative_concept = Scaffolding::AbsolutelyAbstract::CreativeConcept.create(name: "Test Concept")
-
-      webhook_params = {
+  test "should get incoming webhook" do
+    webhook_params = {
+      data: {
         data: {
-          data: {
-            name: "Test",
-            team_id: {
-              id: @team.id,
-              slug: nil,
-              locale: nil,
-              time_zone: @team.time_zone,
-              created_at: creative_concept.created_at,
-              updated_at: creative_concept.updated_at,
-              being_destroyed: nil,
-            },
-            description: ""
+          name: "Test",
+          team_id: {
+            id: @team.id,
+            slug: nil,
+            locale: nil,
+            time_zone: @team.time_zone,
+            created_at: @membership.created_at,
+            updated_at: @membership.updated_at,
+            being_destroyed: nil,
           },
-          event_type: "scaffolding/absolutely_abstract/creative_concept.created",
-          subject_type: "Scaffolding::AbsolutelyAbstract::CreativeConcept"
+          description: ""
         },
-        verified_at: nil,
-        processed_at: nil,
-      }
+        event_type: "membership.created",
+        subject_type: "Membership"
+      },
+      verified_at: nil,
+      processed_at: nil,
+    }
 
-      post "/webhooks/incoming/bullet_train_webhooks", params: webhook_params.to_json
-      assert_equal response.parsed_body, {"status" => "OK"}
+    post "/webhooks/incoming/bullet_train_webhooks", params: webhook_params.to_json
+    assert_equal response.parsed_body, {"status" => "OK"}
 
-      webhook = Webhooks::Incoming::BulletTrainWebhook.first
-      assert_equal webhook.data.to_json, webhook_params.to_json
-    end
+    webhook = Webhooks::Incoming::BulletTrainWebhook.first
+    assert_equal webhook.data.to_json, webhook_params.to_json
   end
 end

--- a/bullet_train-incoming_webhooks/test/controllers/webhooks/incoming/bullet_train_webhooks_controller_test.rb
+++ b/bullet_train-incoming_webhooks/test/controllers/webhooks/incoming/bullet_train_webhooks_controller_test.rb
@@ -3,46 +3,42 @@ require "test_helper"
 class Webhooks::Incoming::BulletTrainWebhooksControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
-  # We can only run this test when Scaffolding things are enabled
-  # because the default webhook triggers come from `CreativeConcept`, etc.
-  unless scaffolding_things_disabled?
-    def setup
-      super
-      @user = FactoryBot.create(:onboarded_user)
-      sign_in @user
-      @team = @user.current_team
-    end
+  def setup
+    super
+    @user = FactoryBot.create(:onboarded_user)
+    sign_in @user
+    @team = @user.current_team
+  end
 
-    test "should get incoming webhook" do
-      creative_concept = Scaffolding::AbsolutelyAbstract::CreativeConcept.create(name: "Test Concept")
+  test "should get incoming webhook" do
+    creative_concept = Scaffolding::AbsolutelyAbstract::CreativeConcept.create(name: "Test Concept")
 
-      webhook_params = {
+    webhook_params = {
+      data: {
         data: {
-          data: {
-            name: "Test",
-            team_id: {
-              id: @team.id,
-              slug: nil,
-              locale: nil,
-              time_zone: @team.time_zone,
-              created_at: creative_concept.created_at,
-              updated_at: creative_concept.updated_at,
-              being_destroyed: nil,
-            },
-            description: ""
+          name: "Test",
+          team_id: {
+            id: @team.id,
+            slug: nil,
+            locale: nil,
+            time_zone: @team.time_zone,
+            created_at: creative_concept.created_at,
+            updated_at: creative_concept.updated_at,
+            being_destroyed: nil,
           },
-          event_type: "scaffolding/absolutely_abstract/creative_concept.created",
-          subject_type: "Scaffolding::AbsolutelyAbstract::CreativeConcept"
+          description: ""
         },
-        verified_at: nil,
-        processed_at: nil,
-      }
+        event_type: "scaffolding/absolutely_abstract/creative_concept.created",
+        subject_type: "Scaffolding::AbsolutelyAbstract::CreativeConcept"
+      },
+      verified_at: nil,
+      processed_at: nil,
+    }
 
-      post "/webhooks/incoming/bullet_train_webhooks", params: webhook_params.to_json
-      assert_equal response.parsed_body, {"status" => "OK"}
+    post "/webhooks/incoming/bullet_train_webhooks", params: webhook_params.to_json
+    assert_equal response.parsed_body, {"status"=>"OK"}
 
-      webhook = Webhooks::Incoming::BulletTrainWebhook.first
-      assert_equal webhook.data.to_json, webhook_params.to_json
-    end
+    webhook = Webhooks::Incoming::BulletTrainWebhook.first
+    assert_equal webhook.data.to_json, webhook_params.to_json
   end
 end

--- a/bullet_train-incoming_webhooks/test/controllers/webhooks/incoming/bullet_train_webhooks_controller_test.rb
+++ b/bullet_train-incoming_webhooks/test/controllers/webhooks/incoming/bullet_train_webhooks_controller_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+class Webhooks::Incoming::BulletTrainWebhooksControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  def setup
+    super
+    @user = FactoryBot.create(:onboarded_user)
+    sign_in @user
+    @team = @user.current_team
+  end
+
+  test "should get incoming webhook" do
+    creative_concept = Scaffolding::AbsolutelyAbstract::CreativeConcept.create(name: "Test Concept")
+
+    webhook_params = {
+      data: {
+        data: {
+          name: "Test",
+          team_id: {
+            id: @team.id,
+            slug: nil,
+            locale: nil,
+            time_zone: @team.time_zone,
+            created_at: creative_concept.created_at,
+            updated_at: creative_concept.updated_at,
+            being_destroyed: nil,
+          },
+          description: ""
+        },
+        event_type: "scaffolding/absolutely_abstract/creative_concept.created",
+        subject_type: "Scaffolding::AbsolutelyAbstract::CreativeConcept"
+      },
+      verified_at: nil,
+      processed_at: nil,
+    }
+
+    post "/webhooks/incoming/bullet_train_webhooks", params: webhook_params.to_json
+    assert_equal response.parsed_body, {"status"=>"OK"}
+
+    webhook = Webhooks::Incoming::BulletTrainWebhook.first
+    assert_equal webhook.data.to_json, webhook_params.to_json
+  end
+end

--- a/bullet_train-incoming_webhooks/test/controllers/webhooks/incoming/bullet_train_webhooks_controller_test.rb
+++ b/bullet_train-incoming_webhooks/test/controllers/webhooks/incoming/bullet_train_webhooks_controller_test.rb
@@ -36,7 +36,7 @@ class Webhooks::Incoming::BulletTrainWebhooksControllerTest < ActionDispatch::In
     }
 
     post "/webhooks/incoming/bullet_train_webhooks", params: webhook_params.to_json
-    assert_equal response.parsed_body, {"status"=>"OK"}
+    assert_equal response.parsed_body, {"status" => "OK"}
 
     webhook = Webhooks::Incoming::BulletTrainWebhook.first
     assert_equal webhook.data.to_json, webhook_params.to_json

--- a/bullet_train-incoming_webhooks/test/controllers/webhooks/incoming/bullet_train_webhooks_controller_test.rb
+++ b/bullet_train-incoming_webhooks/test/controllers/webhooks/incoming/bullet_train_webhooks_controller_test.rb
@@ -3,42 +3,46 @@ require "test_helper"
 class Webhooks::Incoming::BulletTrainWebhooksControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
-  def setup
-    super
-    @user = FactoryBot.create(:onboarded_user)
-    sign_in @user
-    @team = @user.current_team
-  end
+  # We can only run this test when Scaffolding things are enabled
+  # because the default webhook triggers come from `CreativeConcept`, etc.
+  unless scaffolding_things_disabled?
+    def setup
+      super
+      @user = FactoryBot.create(:onboarded_user)
+      sign_in @user
+      @team = @user.current_team
+    end
 
-  test "should get incoming webhook" do
-    creative_concept = Scaffolding::AbsolutelyAbstract::CreativeConcept.create(name: "Test Concept")
+    test "should get incoming webhook" do
+      creative_concept = Scaffolding::AbsolutelyAbstract::CreativeConcept.create(name: "Test Concept")
 
-    webhook_params = {
-      data: {
+      webhook_params = {
         data: {
-          name: "Test",
-          team_id: {
-            id: @team.id,
-            slug: nil,
-            locale: nil,
-            time_zone: @team.time_zone,
-            created_at: creative_concept.created_at,
-            updated_at: creative_concept.updated_at,
-            being_destroyed: nil,
+          data: {
+            name: "Test",
+            team_id: {
+              id: @team.id,
+              slug: nil,
+              locale: nil,
+              time_zone: @team.time_zone,
+              created_at: creative_concept.created_at,
+              updated_at: creative_concept.updated_at,
+              being_destroyed: nil,
+            },
+            description: ""
           },
-          description: ""
+          event_type: "scaffolding/absolutely_abstract/creative_concept.created",
+          subject_type: "Scaffolding::AbsolutelyAbstract::CreativeConcept"
         },
-        event_type: "scaffolding/absolutely_abstract/creative_concept.created",
-        subject_type: "Scaffolding::AbsolutelyAbstract::CreativeConcept"
-      },
-      verified_at: nil,
-      processed_at: nil,
-    }
+        verified_at: nil,
+        processed_at: nil,
+      }
 
-    post "/webhooks/incoming/bullet_train_webhooks", params: webhook_params.to_json
-    assert_equal response.parsed_body, {"status" => "OK"}
+      post "/webhooks/incoming/bullet_train_webhooks", params: webhook_params.to_json
+      assert_equal response.parsed_body, {"status" => "OK"}
 
-    webhook = Webhooks::Incoming::BulletTrainWebhook.first
-    assert_equal webhook.data.to_json, webhook_params.to_json
+      webhook = Webhooks::Incoming::BulletTrainWebhook.first
+      assert_equal webhook.data.to_json, webhook_params.to_json
+    end
   end
 end


### PR DESCRIPTION
Closes https://github.com/bullet-train-co/bullet_train-core/issues/453

Joint PR
- https://github.com/bullet-train-co/bullet_train/pull/947

I was stuck on this one for a while for a couple of reasons:
1. I originally tried to write system tests but decided it would be more beneficial to write controller tests. Also, getting the webhook parameters right for this one took some fine-tuning.
2. Since we usually use `Scaffolding::CompletelyConcrete::TangibleThing` and such to transform strings, I initially set out to scaffold using those kinds of strings. It wasn't until I was working in the `bullet_train-incoming_webhooks` transformer itself that it dawned on me that we were already doing this with `Webhooks::Incoming::BulletTrainWebhook` :man_facepalming:

## Try it out
```
bin/super-scaffold incoming-webhooks SomeProvider
```

This will now scaffold a working controller test file.