### PR TITLE
Check if model has foreign key to parent before Super Scaffolding

### DIFF
--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding.rb
@@ -8,6 +8,7 @@ require "bullet_train/super_scaffolding/scaffolders/join_model_scaffolder"
 require "bullet_train/super_scaffolding/scaffolders/oauth_provider_scaffolder"
 
 require "indefinite_article"
+require "colorizer"
 
 module BulletTrain
   module SuperScaffolding

--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb
@@ -37,10 +37,12 @@ module BulletTrain
 
           # Pull the parent foreign key from the `create_table` call
           # if a migration with `add_reference` hasn't been created.
-          migration_file_name = `grep "add_reference :#{child.tableize}, :#{parent.tableize.singularize}" db/migrate/*`.split(":").shift
-          migration_file_name ||= `grep "create_table :#{child.tableize}" db/migrate/*`.split(":").shift
-          parent_t_references = "t.references :#{parent.tableize.singularize}"
-          parent_add_reference = "add_reference :#{child.tableize}, :#{parent.tableize.singularize}"
+          tableized_child = child.tableize.gsub("/", "_") # Compensate for namespaced models (i.e. - `Projects::Deliverable` to `projects/deliverable`).
+          parent_reference = parent.tableize.singularize.gsub("/", "_")
+          migration_file_name = `grep "add_reference :#{tableized_child}, :#{parent_reference}" db/migrate/*`.split(":").shift
+          migration_file_name ||= `grep "create_table :#{tableized_child}" db/migrate/*`.split(":").shift
+          parent_t_references = "t.references :#{parent_reference}"
+          parent_add_reference = "add_reference :#{tableized_child}, :#{parent_reference}"
           parent_foreign_key = nil
           File.open(migration_file_name).readlines.each do |line|
             parent_foreign_key = line.match?(/#{parent_add_reference}|#{parent_t_references}/)

--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb
@@ -45,7 +45,7 @@ module BulletTrain
           unless parent_foreign_key
             raise "#{child} does not have a foreign key referencing #{parent}.\n" \
                   "Make sure you generate your model with a references type:\n" \
-                  "rails generate model Project team:references ...\n" \
+                  "rails generate model #{child} #{parent.tableize.singularize}:references ...\n" \
                   "\n"
           end
 

--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb
@@ -37,8 +37,8 @@ module BulletTrain
 
           # Pull the parent foreign key from the `create_table` call
           # if a migration with `add_reference` hasn't been created.
-          tableized_child = child.tableize.gsub("/", "_") # Compensate for namespaced models (i.e. - `Projects::Deliverable` to `projects/deliverable`).
-          parent_reference = parent.tableize.singularize.gsub("/", "_")
+          tableized_child = child.tableize.tr("/", "_") # Compensate for namespaced models (i.e. - `Projects::Deliverable` to `projects/deliverable`).
+          parent_reference = parent.tableize.singularize.tr("/", "_")
           migration_file_name = `grep "add_reference :#{tableized_child}, :#{parent_reference}" db/migrate/*`.split(":").shift
           migration_file_name ||= `grep "create_table :#{tableized_child}" db/migrate/*`.split(":").shift
           parent_t_references = "t.references :#{parent_reference}"

--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb
@@ -71,7 +71,7 @@ module BulletTrain
             puts "#{child} does not have a foreign key referencing #{parent}".red
             puts ""
             puts "Please re-generate your model, or execute the following to add the foreign key:"
-            puts "rails generate migration add_#{parent.tableize.singularize}_to_#{child.tableize} #{parent.tableize.singularize}:references\n"
+            puts "rails generate migration add_#{parent_reference}_to_#{tableized_child} #{parent_reference}:references\n"
             exit 1
           end
 


### PR DESCRIPTION
Closes #475.

# Super Scaffolding without `references`
```
> rails g model Project title:string
      invoke  active_record
      create    db/migrate/20230831123427_create_projects.rb
      create    app/models/project.rb
      invoke    test_unit
      create      test/models/project_test.rb
      invoke      factory_bot
      create        test/factories/projects.rb
> bin/super-scaffold crud Project Team title:text_field
rake aborted!
Project does not have a foreign key referencing Team.
Make sure you generate your model with a references type:
rails generate model Project team:references ...

/home/gazayas/work/bt/bullet_train/local/bullet_train-core/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb:46:in `run'
/home/gazayas/work/bt/bullet_train/local/bullet_train-core/bullet_train-super_scaffolding/lib/scaffolding/script.rb:104:in `<main>'
<internal:/home/gazayas/.rbenv/versions/3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
<internal:/home/gazayas/.rbenv/versions/3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
/home/gazayas/work/bt/bullet_train/local/bullet_train-core/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding.rb:25:in `run'
/home/gazayas/work/bt/bullet_train/local/bullet_train-core/bullet_train-super_scaffolding/lib/tasks/bullet_train/super_scaffolding_tasks.rake:10:in `block (2 levels) in <main>'
Tasks: TOP => bullet_train:super_scaffolding
(See full trace by running task with --trace)
```

# Super Scaffolding with `references`
```
> rails g model Site team:references name:string
      invoke  active_record
      create    db/migrate/20230831123454_create_sites.rb
      create    app/models/site.rb
      invoke    test_unit
      create      test/models/site_test.rb
      invoke      factory_bot
      create        test/factories/sites.rb
> bin/super-scaffold crud Site Team name:text_field
Writing './app/controllers/account/sites_controller.rb'.
Fixing Standard Ruby on './app/controllers/account/sites_controller.rb'.
Writing './app/views/account/sites/_index.html.erb'.
Writing './app/views/account/sites/_form.html.erb'.
Writing './app/views/account/sites/_menu_item.html.erb'.
Writing './app/views/account/sites/index.html.erb'.
Writing './app/views/account/sites/_site.html.erb'.

...
```
