### PR TITLE
Introduce `other_options[:required]` for field partials

### DIFF
--- a/bullet_train-themes-light/app/views/themes/light/fields/_field.html.erb
+++ b/bullet_train-themes-light/app/views/themes/light/fields/_field.html.erb
@@ -20,7 +20,7 @@ other_options ||= {}
 other_options[:help] = [other_options[:help], labels.help].compact.join(" ")
 
 if !other_options.key?(:required)
-  other_options[:required] = options.key?(:required) ? options[:required] : presence_validated?(form.object, method)
+  other_options[:required] = options.fetch(:required) { presence_validated?(form.object, method) }
 end
 
 if other_options[:required]

--- a/bullet_train-themes-light/app/views/themes/light/fields/_field.html.erb
+++ b/bullet_train-themes-light/app/views/themes/light/fields/_field.html.erb
@@ -16,12 +16,16 @@ options[:id] ||= form.field_id(method)
 # options[:disabled] ||= !field_editable?(form.object, method) if user_signed_in?
 options[:placeholder] ||= labels.placeholder if labels.placeholder
 
-if !options.key?(:required)
-  options[:required] = presence_validated?(form.object, method)
-end
-
 other_options ||= {}
 other_options[:help] = [other_options[:help], labels.help].compact.join(" ")
+
+if !other_options.key?(:required)
+  other_options[:required] = options.key?(:required) ? options[:required] : presence_validated?(form.object, method)
+end
+
+if other_options[:required]
+  options[:"aria-required"] = true
+end
 
 errors = [method, method.to_s.gsub(/_id$/, '').to_sym].uniq.map { |attribute| form.object.errors.full_messages_for(attribute) }.flatten
 has_errors = errors.any? || partial.error? || other_options[:error].present?
@@ -36,7 +40,7 @@ end
 
 %>
 
-<div class="<%= 'required' if options[:required] %>">
+<div class="<%= 'required' if other_options[:required] %>">
 
   <% # the label. %>
   <% unless other_options[:hide_label] == true %>

--- a/bullet_train-themes-light/app/views/themes/light/fields/_field.html.erb
+++ b/bullet_train-themes-light/app/views/themes/light/fields/_field.html.erb
@@ -15,6 +15,11 @@ options ||= {}
 options[:id] ||= form.field_id(method)
 # options[:disabled] ||= !field_editable?(form.object, method) if user_signed_in?
 options[:placeholder] ||= labels.placeholder if labels.placeholder
+
+if !options.key?(:required)
+  options[:required] = presence_validated?(form.object, method)
+end
+
 other_options ||= {}
 other_options[:help] = [other_options[:help], labels.help].compact.join(" ")
 
@@ -31,7 +36,7 @@ end
 
 %>
 
-<div class="<%= 'required' if presence_validated?(form.object, method) %>">
+<div class="<%= 'required' if options[:required] %>">
 
   <% # the label. %>
   <% unless other_options[:hide_label] == true %>

--- a/bullet_train/app/views/account/onboarding/user_details/edit.html.erb
+++ b/bullet_train/app/views/account/onboarding/user_details/edit.html.erb
@@ -10,11 +10,11 @@
 
         <div class="grid grid-cols-1 gap-y gap-x sm:grid-cols-2">
           <div class="sm:col-span-1">
-            <%= render 'shared/fields/text_field', form: f, method: :first_name, options: {autofocus: true} %>
+            <%= render 'shared/fields/text_field', form: f, method: :first_name, other_options: {required: true}, options: {autofocus: true} %>
           </div>
 
           <div class="sm:col-span-1">
-            <%= render 'shared/fields/text_field', form: f, method: :last_name %>
+            <%= render 'shared/fields/text_field', form: f, method: :last_name, other_options: {required: true} %>
           </div>
 
           <% # only edit the team name if this user is an admin and they are the first user. %>
@@ -30,7 +30,7 @@
           <div class="sm:col-span-2">
             <%= render 'shared/fields/super_select', form: f, method: :time_zone,
               choices: time_zone_options_for_select(@user.time_zone, nil, ActiveSupport::TimeZone),
-              other_options: {search: true} %>
+              other_options: {search: true, required: true} %>
           </div>
         </div>
 

--- a/bullet_train/app/views/devise/registrations/new.html.erb
+++ b/bullet_train/app/views/devise/registrations/new.html.erb
@@ -17,7 +17,7 @@
            <%= render 'shared/fields/password_field', form: f, method: :password, options: {show_strength_indicator: true} %>
          </div>
          <div>
-           <%= render 'shared/fields/password_field', form: f, method: :password_confirmation, options:{ required: true }, other_options: {error: f.object.errors.full_messages_for(:password).first, hide_custom_error: true} %>
+           <%= render 'shared/fields/password_field', form: f, method: :password_confirmation, other_options: {required: true, error: f.object.errors.full_messages_for(:password).first, hide_custom_error: true} %>
          </div>
        </div>
 

--- a/bullet_train/app/views/devise/registrations/new.html.erb
+++ b/bullet_train/app/views/devise/registrations/new.html.erb
@@ -17,7 +17,7 @@
            <%= render 'shared/fields/password_field', form: f, method: :password, options: {show_strength_indicator: true} %>
          </div>
          <div>
-           <%= render 'shared/fields/password_field', form: f, method: :password_confirmation, other_options: {error: f.object.errors.full_messages_for(:password).first, hide_custom_error: true} %>
+           <%= render 'shared/fields/password_field', form: f, method: :password_confirmation, options:{ required: true }, other_options: {error: f.object.errors.full_messages_for(:password).first, hide_custom_error: true} %>
          </div>
        </div>
 

--- a/bullet_train/docs/field-partials.md
+++ b/bullet_train/docs/field-partials.md
@@ -63,6 +63,29 @@ For example, to suppress a label on any field, we can use the `hide_label` optio
 | `help` | string | Display a specific help string. |
 | `error` | string | Display a specific error string. |
 | `hide_label` | boolean | Hide the field label. |
+| `required` | boolean | Display an asterisk by the field label to indicate the field is required. |
+
+## `options: {required: true}` vs. `other_options:{required: true}`
+
+In short:
+
+* `options: {required: true}` gives a visual indicator that the field is required AND triggers client-side validation.
+* `other_options: {required: true}` only gives a visual indicator that the field is required.
+
+We will attempt to determine a value for the `other_options[:required]` option if it is not passed in explicitly.
+If `other_options[:required]` is not passed in we'll check to see if `options[:required]` is passed in.
+If so, we'll use that value. If neither option is explicitly passed in then we fallback to checking whether
+there is a validation for `presence` on the attribute for that field.
+
+Usually you should stick to using `other_options[:required]` to mark fields as required (_only_ if they don't get marked automatically).
+
+If you pass `options[:required]` you'll be triggering a client-side validation, and many browsers would prvent the form from being submitted with out a value.
+
+The way that browsers communicate info about client-side validations varies from browser to browswer and is not easily controller or styled.
+
+For these reasons we generally recommend that you start with server-side validations and avoid using client-side validations for most simple forms.
+
+If you want to use client-side validations, and you want to be able to control the user experience [this article should give you a good starting place to work from.](https://www.jorgemanrubia.com/2019/02/16/form-validations-with-html5-and-modern-rails/)
 
 ## Reducing Repetition
 When you're including multiple fields, you can DRY up redundant settings (e.g. `form: form`) like so:

--- a/bullet_train/docs/field-partials.md
+++ b/bullet_train/docs/field-partials.md
@@ -65,27 +65,14 @@ For example, to suppress a label on any field, we can use the `hide_label` optio
 | `hide_label` | boolean | Hide the field label. |
 | `required` | boolean | Display an asterisk by the field label to indicate the field is required. |
 
-## `options: {required: true}` vs. `other_options:{required: true}`
+## `required`: through presence validation vs. `options: {required: true}` vs. `other_options:{required: true}`
 
-In short:
+By default, where there's a presence validation on the model attribute, we add an asterisk to indicate the field is required. For fields without a presence validation, you have options to pass the `:required` detail:
 
-* `options: {required: true}` gives a visual indicator that the field is required AND triggers client-side validation.
-* `other_options: {required: true}` only gives a visual indicator that the field is required.
+1. `other_options: {required: true}` adds the asterisk to the field manually.
+2. `options: {required: true}` adds asterisk but also triggers client-side validation via the [`required`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/required) attribute.
 
-We will attempt to determine a value for the `other_options[:required]` option if it is not passed in explicitly.
-If `other_options[:required]` is not passed in we'll check to see if `options[:required]` is passed in.
-If so, we'll use that value. If neither option is explicitly passed in then we fallback to checking whether
-there is a validation for `presence` on the attribute for that field.
-
-Usually you should stick to using `other_options[:required]` to mark fields as required (_only_ if they don't get marked automatically).
-
-If you pass `options[:required]` you'll be triggering a client-side validation, and many browsers would prvent the form from being submitted with out a value.
-
-The way that browsers communicate info about client-side validations varies from browser to browswer and is not easily controller or styled.
-
-For these reasons we generally recommend that you start with server-side validations and avoid using client-side validations for most simple forms.
-
-If you want to use client-side validations, and you want to be able to control the user experience [this article should give you a good starting place to work from.](https://www.jorgemanrubia.com/2019/02/16/form-validations-with-html5-and-modern-rails/)
+Since client-side validations vary from browser to browser, we recommend relying on server-side validation for most forms, and thus mostly using `other_options[:required]`.
 
 ## Reducing Repetition
 When you're including multiple fields, you can DRY up redundant settings (e.g. `form: form`) like so:


### PR DESCRIPTION
Fixes https://github.com/bullet-train-co/bullet_train-core/issues/379

Supersedes #499, based on [refinements suggested by @pascallaliberte](https://github.com/bullet-train-co/bullet_train-core/pull/499#issuecomment-1701010343)

## The Problem

Currently we show the red asterisk on required fields **only** if the object represented by the form has a validation for `presence` on that field. For instance on the user registration form we don't show an asterisk for `password_confirmation` because Devise doesn't setup a `validates_presence` validation for that field.

![CleanShot 2023-08-30 at 10 45 51](https://github.com/bullet-train-co/bullet_train-core/assets/58702/fe69d021-10a5-4913-971d-189bf4fe8e57)

But the field really is required. If you fill in a password, but no confirmation and then submit the form, it causes an error.

![CleanShot 2023-08-30 at 10 52 33](https://github.com/bullet-train-co/bullet_train-core/assets/58702/616d16e3-da55-4819-bdeb-194d752bf9db)

If a developer were to eject the devise form they could add `options: { required: true}` to the form:

```diff
  <%= render 'shared/fields/password_field', form: f,
    method: :password_confirmation,
+   options: { required: true },
    other_options: {
        error: f.object.errors.full_messages_for(:password).first,
        hide_custom_error: true
    }
  %>
```

That will have the effect of setting the `required` attribute on the password field that ends up getting rendered. That leads to a confusing experience where the label does not indicate that the field is required, but the browser does complain that it's not filled in. 

![CleanShot 2023-08-30 at 10 42 29](https://github.com/bullet-train-co/bullet_train-core/assets/58702/805c60a3-770c-4511-bf94-469f005ed2c9)

(And if they didn't also add it to the main `password` field they would not see the browser complain about _that_ field being blank.)

## The fix

This PR makes it so that if `required` is passed into the `other_options` hash (instead of the `options` hash) that the field partial that renders the asterisk will use that value first, and will fallback to the existing validation method if it's not passed in. And it will not trigger a client-side presence check.

```diff
  <%= render 'shared/fields/password_field', form: f,
    method: :password_confirmation,
    other_options: {
+       required: true,
        error: f.object.errors.full_messages_for(:password).first,
        hide_custom_error: true
    }
  %>
```

That makes it so that the red asterisk will show up.

![CleanShot 2023-09-01 at 10 16 36](https://github.com/bullet-train-co/bullet_train-core/assets/58702/9b318ff7-f920-4dca-a189-61f1f4378d4c)

If `required` is passed in `options`, indicating that the developer wants to trigger a client-side check, we'll copy that value into `other_options` so that the asterisk will show up (or not, if they pass `required: false`).

Any time that we are showing the asterisk that indicates a field is required, we also add an `aria-required="true"` attribute to the underlying field that we render. This indicates to browsers and screen-readers that the a value is required, without triggering browser-based validation for presence.

## Possible problems

I think these changes resolve the possible problems mentioned in #499. It will preserve all existing behavior, and just enhance some existing screens by adding `aria-required="true"` to form fields that are required.

There is some potential for confusion over the difference between `options: {required: true}` and `other_options: {required: true}`, but I've tried to address that by updating the docs.