### PR TITLE
Make the showcase theme selector sticky

### DIFF
--- a/bullet_train-themes-light/app/views/showcase/engine/_head.html.erb
+++ b/bullet_train-themes-light/app/views/showcase/engine/_head.html.erb
@@ -36,11 +36,13 @@
   document.addEventListener("DOMContentLoaded", () => {
     const node = document.getElementById("bullet_train_theme_selects").content.cloneNode(true)
     document.querySelector("main").appendChild(node)
+    const selectorNode = document.getElementById("bt-theme-selector")
+    document.querySelector("main").style.paddingBottom = selectorNode.offsetHeight + "px"
   })
 </script>
 
 <template id="bullet_train_theme_selects">
-  <section class="border-t w-full p-4 flex justify-end left-0 bottom-0">
+  <section class="border-t w-full p-4 flex justify-end left-0 bottom-0 fixed bg-white dark:sc-bg-neutral-900" id="bt-theme-selector">
     <h3 class="pt-2">Bullet Train Light theme options</h3>
 
     <div>

--- a/bullet_train-themes-light/app/views/showcase/engine/_head.html.erb
+++ b/bullet_train-themes-light/app/views/showcase/engine/_head.html.erb
@@ -33,12 +33,15 @@
   BulletTrain.theme = new ___theme()
   BulletTrain.theme.start()
 
-  document.addEventListener("DOMContentLoaded", () => {
+  function placeThemeSelector() {
     const node = document.getElementById("bullet_train_theme_selects").content.cloneNode(true)
     document.querySelector("main").appendChild(node)
     const selectorNode = document.getElementById("bt-theme-selector")
     document.querySelector("main").style.paddingBottom = selectorNode.offsetHeight + "px"
-  })
+  }
+
+  document.addEventListener("DOMContentLoaded", placeThemeSelector);
+  document.addEventListener("turbo:load", placeThemeSelector);
 </script>
 
 <template id="bullet_train_theme_selects">


### PR DESCRIPTION
Adding `fixed` to the theme selector make it stick to the bottom of the browser window instead of being stuck all the way at the bottom of the scroll.

But if we _just_ add the `fixed` class, then the theme selector will overlap the content at the very bottom of the page and we have no way to get to it.

![CleanShot 2023-09-01 at 12 41 45](https://github.com/bullet-train-co/bullet_train-core/assets/58702/6b602cb2-3979-40d0-ad08-9319825daa5b)

We can fix that by using a little bit of JS to calculate the height of the theme selector and then set that amount of padding on the bottom of the `main` container.

Doing that makes it so that there is a scrollbar if the theme selector will overlap any content at the bottom of the `main` container.

![CleanShot 2023-09-01 at 12 38 56](https://github.com/bullet-train-co/bullet_train-core/assets/58702/635bd1ab-c35c-4a40-b1ce-9f2f60903a3f)

And makes it so that you can scroll all the way down and see all of the content.

![CleanShot 2023-09-01 at 12 39 08](https://github.com/bullet-train-co/bullet_train-core/assets/58702/d2be0819-caf5-462d-b3a1-14a33ad3d3fa)
