### PR TITLE
Super Scaffold `vanilla` ID attributes properly

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/attribute.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/attribute.rb
@@ -111,8 +111,10 @@ class Scaffolding::Attribute
     if is_ids?
       # user_ids should be 'Users'
       name_without_ids.humanize.titlecase
+    elsif is_id? && is_vanilla?
+      "#{name.humanize.titlecase} ID"
     else
-      "#{name.humanize.titlecase}#{" ID" if is_id?}"
+      name.humanize.titlecase
     end
   end
 

--- a/bullet_train-super_scaffolding/lib/scaffolding/attribute.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/attribute.rb
@@ -111,10 +111,8 @@ class Scaffolding::Attribute
     if is_ids?
       # user_ids should be 'Users'
       name_without_ids.humanize.titlecase
-    elsif is_id?
-      name_without_id.humanize.titlecase
     else
-      name.humanize.titlecase
+      "#{name.humanize.titlecase}#{" ID" if is_id?}"
     end
   end
 

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -820,7 +820,7 @@ class Scaffolding::Transformer
 
         # this gets stripped and is one line, so indentation isn't a problem.
         field_content = <<-ERB
-          <%= render 'shared/attributes/#{attribute.partial_name}', attribute: :#{attribute.name} %>
+          <%= render 'shared/attributes/#{attribute.partial_name}', attribute: :#{attribute.is_vanilla? ? attribute.name : attribute.name_without_id_suffix} %>
         ERB
 
         if attribute.type == "password_field"
@@ -839,7 +839,7 @@ class Scaffolding::Transformer
       unless cli_options["skip-table"]
 
         # table header.
-        field_content = "<th#{cell_attributes.present? ? " " + cell_attributes : ""}><%= t('.fields.#{attribute.name}.heading') %></th>"
+        field_content = "<th#{cell_attributes.present? ? " " + cell_attributes : ""}><%= t('.fields.#{attribute.is_vanilla? ? attribute.name : attribute.name_without_id_suffix}.heading') %></th>"
 
         unless ["Team", "User"].include?(child)
           scaffold_add_line_to_file("./app/views/account/scaffolding/completely_concrete/tangible_things/_index.html.erb", field_content, "<%# 🚅 super scaffolding will insert new field headers above this line. %>", prepend: true)
@@ -867,7 +867,7 @@ class Scaffolding::Transformer
 
         # this gets stripped and is one line, so indentation isn't a problem.
         field_content = <<-ERB
-          <td#{cell_attributes}><%= render 'shared/attributes/#{attribute.partial_name}', attribute: :#{attribute.name}#{", #{table_cell_options.join(", ")}" if table_cell_options.any?} %></td>
+          <td#{cell_attributes}><%= render 'shared/attributes/#{attribute.partial_name}', attribute: :#{attribute.is_vanilla? ? attribute.name : attribute.name_without_id_suffix}#{", #{table_cell_options.join(", ")}" if table_cell_options.any?} %></td>
         ERB
 
         if attribute.type == "password_field"

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -820,7 +820,7 @@ class Scaffolding::Transformer
 
         # this gets stripped and is one line, so indentation isn't a problem.
         field_content = <<-ERB
-          <%= render 'shared/attributes/#{attribute.partial_name}', attribute: :#{attribute.name_without_id_suffix} %>
+          <%= render 'shared/attributes/#{attribute.partial_name}', attribute: :#{attribute.name} %>
         ERB
 
         if attribute.type == "password_field"
@@ -839,7 +839,7 @@ class Scaffolding::Transformer
       unless cli_options["skip-table"]
 
         # table header.
-        field_content = "<th#{cell_attributes.present? ? " " + cell_attributes : ""}><%= t('.fields.#{attribute.name_without_id_suffix}.heading') %></th>"
+        field_content = "<th#{cell_attributes.present? ? " " + cell_attributes : ""}><%= t('.fields.#{attribute.name}.heading') %></th>"
 
         unless ["Team", "User"].include?(child)
           scaffold_add_line_to_file("./app/views/account/scaffolding/completely_concrete/tangible_things/_index.html.erb", field_content, "<%# 🚅 super scaffolding will insert new field headers above this line. %>", prepend: true)
@@ -867,7 +867,7 @@ class Scaffolding::Transformer
 
         # this gets stripped and is one line, so indentation isn't a problem.
         field_content = <<-ERB
-          <td#{cell_attributes}><%= render 'shared/attributes/#{attribute.partial_name}', attribute: :#{attribute.name_without_id_suffix}#{", #{table_cell_options.join(", ")}" if table_cell_options.any?} %></td>
+          <td#{cell_attributes}><%= render 'shared/attributes/#{attribute.partial_name}', attribute: :#{attribute.name}#{", #{table_cell_options.join(", ")}" if table_cell_options.any?} %></td>
         ERB
 
         if attribute.type == "password_field"


### PR DESCRIPTION
Closes #476.

Most of the fixes are are straightforward, but the most important one to focus on here is the definition of `title_case`. It was introduced in https://github.com/bullet-train-co/bullet-train-tailwind-css/commit/a1c2eb1ab2c7b70fdbea680c731899cc54a39f63, updated in https://github.com/bullet-train-co/bullet-train-tailwind-css/commit/36788a3f3860a7e243385cdee72cf34c4867cada, and looked like the following before #124 was introduced:

```ruby
title_case = if is_ids
  # user_ids should be 'Users'
  name_without_ids.humanize.titlecase
elsif is_id
  name_without_id.humanize.titlecase
else
  name.humanize.titlecase
end
```

In #476, the locale is expected to return `title_case` as `Circle Ci ID`. However, even if we write `name.humanize.titlecase` instead of `name_without_id.humanize.titlecase` above, `ID` is removed by `humanize`:

```
> rails c
Loading development environment (Rails 7.0.7.2)
irb(main):001> "circle_ci_id".humanize
=> "Circle ci"
irb(main):002> "circle_ci_id".humanize.titlecase
=> "Circle Ci"
```

It *doesn't* remove `ids` though, so I kept `name_without_ids` for the first conditional.

## Tests

I'm assuming we want to keep/remove the `_id` suffix only when scaffolding vanilla attributes, so I used the ternary operator to distinguish between the two for most of these fixes. The tests are passing after scaffolding the following example models (in accordance with #476), and also with the `super_scaffolding_test.rb` and `super_scaffolding_partial_test.rb`.

Example models:
```
rails g model Project team:references title:string && \
bin/super-scaffold crud Project Team title:text_field --navbar="ti-world" && \
rails g model Workflow project:references title:string && \
bin/super-scaffold crud Workflow Project,Team title:text_field && \
rails g model Job workflow:references name:string circle_ci_id:string && \
bin/super-scaffold crud Job Workflow,Project,Team name:text_field circle_ci_id:text_field{vanilla}
```

One thing to note about the Super Scaffolding test is that it scaffolds some models that use the `_id` suffix, but not the `{vanilla}` option. These tests were failing when trying to keep the suffix:

https://github.com/bullet-train-co/bullet_train/blob/76617c1931da08fa21eb6a4caae7873407f67c1d/test/bin/setup-super-scaffolding-system-test#L74-L76

You can see that these errors are in line with the attribute being an association or not.

```
Error:
SuperScaffoldingSystemTest#test_developers_can_generate_a_Personality::Disposition_and_a_nested_Personality::Note_model:
ActionView::Template::Error: undefined method `label_string' for 7:Integer
    local/bullet_train-core/bullet_train-themes/app/views/themes/base/attributes/_belongs_to.html.erb:11
    local/bullet_train-core/bullet_train-themes/app/views/themes/base/attributes/_attribute.html.erb:7
    local/bullet_train-core/bullet_train-themes/app/helpers/theme_helper.rb:19:in `render'
    local/bullet_train-core/bullet_train-themes/app/views/themes/base/attributes/_attribute.html.erb:5
    local/bullet_train-core/bullet_train-themes/app/helpers/theme_helper.rb:19:in `render'
    local/bullet_train-core/bullet_train-themes/app/views/themes/base/attributes/_belongs_to.html.erb:7
    local/bullet_train-core/bullet_train-themes/app/helpers/theme_helper.rb:19:in `render'
    app/views/account/personality/notes/show.html.erb:16
    local/bullet_train-core/bullet_train/app/helpers/attributes_helper.rb:13:in `with_attribute_settings'
    app/views/account/personality/notes/show.html.erb:13
    app/views/account/personality/notes/show.html.erb:12
    local/bullet_train-core/bullet_train-themes/app/helpers/theme_helper.rb:19:in `render'
    app/views/account/personality/notes/show.html.erb:5
    app/views/account/personality/notes/show.html.erb:4
    app/views/account/personality/notes/show.html.erb:3
    local/bullet_train-core/bullet_train-themes/app/helpers/theme_helper.rb:19:in `render'
    app/views/account/personality/notes/show.html.erb:1
    local/bullet_train-core/bullet_train/app/controllers/concerns/controllers/base.rb:95:in `set_locale'
```
