### PR TITLE
Point BT gems not originally in Gemfile to custom path with `bin/hack --link`, add roles gem

### DIFF
--- a/bullet_train/config/locales/en/framework_packages.yml
+++ b/bullet_train/config/locales/en/framework_packages.yml
@@ -20,6 +20,8 @@ en:
       git: "bullet-train-co/bullet_train-core"
     bullet_train-outgoing_webhooks:
       git: "bullet-train-co/bullet_train-core"
+    bullet_train-roles:
+      git: "bullet-train-co/bullet_train-core"
     bullet_train-scope_questions:
       git: "bullet-train-co/bullet_train-core"
     bullet_train-scope_validator:

--- a/bullet_train/lib/tasks/bullet_train_tasks.rake
+++ b/bullet_train/lib/tasks/bullet_train_tasks.rake
@@ -311,6 +311,8 @@ namespace :bullet_train do
             "#{original_path.chomp}, git: 'http://github.com/bullet-train-co/bullet_train-core.git'\n"
           elsif link_flag_value&.match?(version_regexp)
             "#{original_path.chomp}, \"#{link_flag_value}\"\n"
+          elsif link_flag_value
+            "#{original_path.chomp}, path: \"#{link_flag_value}/#{package}\"\n"
           else
             "#{local_path}\n"
           end


### PR DESCRIPTION
Closes #506

The addition to `framework_packages.yml` also ensures that `bullet_train-roles` is added to the Gemfile.
