### PR TITLE
Fix breadcrumbs for edit pages

### DIFF
--- a/bullet_train-super_scaffolding/.circleci/config.yml
+++ b/bullet_train-super_scaffolding/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
-  ruby: circleci/ruby@0.1.2
-  browser-tools: circleci/browser-tools@1.1
+  ruby: circleci/ruby@2.0.0
+  browser-tools: circleci/browser-tools@1.4.1
 aliases:
   - &restore_bundler_cache
       name: Restore Bundler cache

--- a/bullet_train/app/views/account/teams/_breadcrumbs.html.erb
+++ b/bullet_train/app/views/account/teams/_breadcrumbs.html.erb
@@ -11,8 +11,8 @@
   <% end %>
 <% end %>
 
-<%if action_name == 'edit' %>
+<% if (action_name == 'edit' && controller_name == 'teams') %>
   <%= render 'account/shared/breadcrumb', label: t('.team_settings') %>
-<%else %>
+<% else %>
   <%= render 'account/shared/breadcrumbs/actions', only_for: 'teams' %>
 <% end %>


### PR DESCRIPTION
This partial is included in all generated _breadcrumb partials, so all edit pages are always showing 'team settings', not just the team pages.

This fixes, so it's only shown when editing 'team', not any other model.