### PR TITLE
Use `build` in ExampleBot instead of `create` + `rollback`

### DIFF
--- a/bullet_train-api/lib/bullet_train/api/example_bot.rb
+++ b/bullet_train-api/lib/bullet_train/api/example_bot.rb
@@ -2,7 +2,6 @@ require_relative "../../../app/helpers/api/open_api_helper"
 
 module FactoryBot
   module ExampleBot
-
     def example(model, **options)
       FactoryBot.build(factory(model), **options)
     end

--- a/bullet_train-api/lib/bullet_train/api/example_bot.rb
+++ b/bullet_train-api/lib/bullet_train/api/example_bot.rb
@@ -7,15 +7,7 @@ module FactoryBot
     def example(model, **options)
       @tables_to_reset = [model.to_s.pluralize]
 
-      object = nil
-
-      #ActiveRecord::Base.transaction do
-        #instance = FactoryBot.create(factory(model), **options)
-        #object = deep_clone(instance)
-        #raise ActiveRecord::Rollback
-      #end
       object = FactoryBot.build(factory(model), **)
-      object.id = 42
 
       object
     ensure
@@ -24,18 +16,6 @@ module FactoryBot
 
     def example_list(model, quantity, **options)
       @tables_to_reset = [model.to_s.pluralize]
-
-      objects = []
-
-      #ActiveRecord::Base.transaction do
-        #instances = FactoryBot.create_list(factory(model), quantity, **options)
-
-        #instances.each do |instance|
-          #objects << deep_clone(instance)
-        #end
-
-        #raise ActiveRecord::Rollback
-      #end
 
       objects = FactoryBot.build_list(factory(model), quantity, **)
 

--- a/bullet_train-api/lib/bullet_train/api/example_bot.rb
+++ b/bullet_train-api/lib/bullet_train/api/example_bot.rb
@@ -9,12 +9,13 @@ module FactoryBot
 
       object = nil
 
-      ActiveRecord::Base.transaction do
-        instance = FactoryBot.create(factory(model), **options)
-        object = deep_clone(instance)
-
-        raise ActiveRecord::Rollback
-      end
+      #ActiveRecord::Base.transaction do
+        #instance = FactoryBot.create(factory(model), **options)
+        #object = deep_clone(instance)
+        #raise ActiveRecord::Rollback
+      #end
+      object = FactoryBot.build(factory(model), **)
+      object.id = 42
 
       object
     ensure
@@ -26,15 +27,17 @@ module FactoryBot
 
       objects = []
 
-      ActiveRecord::Base.transaction do
-        instances = FactoryBot.create_list(factory(model), quantity, **options)
+      #ActiveRecord::Base.transaction do
+        #instances = FactoryBot.create_list(factory(model), quantity, **options)
 
-        instances.each do |instance|
-          objects << deep_clone(instance)
-        end
+        #instances.each do |instance|
+          #objects << deep_clone(instance)
+        #end
 
-        raise ActiveRecord::Rollback
-      end
+        #raise ActiveRecord::Rollback
+      #end
+
+      objects = FactoryBot.build_list(factory(model), quantity, **)
 
       objects
     ensure

--- a/bullet_train-api/lib/bullet_train/api/example_bot.rb
+++ b/bullet_train-api/lib/bullet_train/api/example_bot.rb
@@ -3,12 +3,12 @@ require_relative "../../../app/helpers/api/open_api_helper"
 module FactoryBot
   module ExampleBot
 
-    def example(model, **)
-      FactoryBot.build(factory(model), **)
+    def example(model, **options)
+      FactoryBot.build(factory(model), **options)
     end
 
-    def example_list(model, quantity, **)
-      FactoryBot.build_list(factory(model), quantity, **)
+    def example_list(model, quantity, **options)
+      FactoryBot.build_list(factory(model), quantity, **options)
     end
 
     REST_METHODS = %i[get_examples get_example post_example post_parameters put_example put_parameters patch_example patch_parameters]


### PR DESCRIPTION
Joint PR: https://github.com/bullet-train-co/bullet_train/pull/965

This PR makes it so that we use `FactoryBot.build` when generating example records in `ExampleBot`.

Doing this so that we don't have to actually create live records, clone them, rollback, then reset primary keys. Doing all of that work is slow so it's best to avoid doing it. (And having to reset primary keys for something that we expect to be a normal thing kind of gives me the willies.)