### PR TITLE
remove assign_date and assign_date_and_time scaffolding

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -1106,10 +1106,6 @@ class Scaffolding::Transformer
         end
 
         special_processing = case type
-        when "date_field"
-          "assign_date(strong_params, :#{name})"
-        when "date_and_time_field"
-          "assign_date_and_time(strong_params, :#{name})"
         when "buttons"
           if boolean_buttons
             "assign_boolean(strong_params, :#{name})"


### PR DESCRIPTION
In the Themes localization PR (#393 ) I removed the scaffolding of assign_date and assign_date_and_time.
In order to remove a monkey patch of the super-scaffolding method from our codebase I need to remove it as well from this branch.
