### PR TITLE
Documentation about doing a stepwise upgrade

### DIFF
--- a/bullet_train/docs/upgrades.md
+++ b/bullet_train/docs/upgrades.md
@@ -75,7 +75,7 @@ git merge v1.4.1
 It's quite possible you'll get some merge conflicts at this point. No big deal! Just go through and
 resolve them like you would if you were integrating code from another developer on your team. We tend
 to comment our code heavily, but if you have any questions about the code you're trying to understand,
-let us know on Discord!
+let us know on [Discord!](https://discord.gg/bullettrain)
 
 One of the files that's likely to have conflicts, and which can be the most frustrating to resolve is
 `Gemfile.lock`. You can try to sort it out by hand, or you can checkout a clean copy and then let bundler

--- a/bullet_train/docs/upgrades.md
+++ b/bullet_train/docs/upgrades.md
@@ -76,6 +76,9 @@ resolve them like you would if you were integrating code from another developer 
 to comment our code heavily, but if you have any questions about the code you're trying to understand,
 let us know on Discord!
 
+Once you've resoled any conflicts it's a good idea to run `bundle install` just to make sure that your
+`Gemfile.lock` agrees with the new state of `Gemfile`.
+
 ```
 git diff
 git add -A

--- a/bullet_train/docs/upgrades.md
+++ b/bullet_train/docs/upgrades.md
@@ -14,7 +14,7 @@
 
 ## The Stepwise Upgrade Method
 
-This method will ensure that the version of the Bullet Train gems that you app uses will stay in sync with the appliation framework provided by the starter repo.
+This method will ensure that the version of the Bullet Train gems that your app uses will stay in sync with the appliation framework provided by the starter repo.
 If you've ever upgraded a Rails app from version to verison this process should feel fairly similar.
 
 ## Pulling Updates from the Starter Repository

--- a/bullet_train/docs/upgrades.md
+++ b/bullet_train/docs/upgrades.md
@@ -8,7 +8,7 @@
 
 ## Quick Links
 
-* [The Standard Method - Step-wise updates after version `1.4.0`](/docs/upgrades#the-standard-method)
+* [The Stepwise Method - For `1.4.0` and above](#the-stepwise-upgrade-method)
 * [Upgrade from any verison to `1.4.0`](/docs/upgrades/yolo-140.md)
 * [Upgrade from any version to `1.3.0`](/docs/upgrades/yolo-130.md)
 * [Upgrade from `1.3.x` to `1.4.0`](/docs/upgrades/yolo-140.md)
@@ -56,27 +56,19 @@ Depending on what version you're starting on, and what version you want to get t
 In general your two main options are:
 
 1. Upgrade directly from whatever version you happen to be on all the way to the latest published version.
-2. Do a series of step-wise upgrades from the version you're on to the version you want to get to.
+2. Do a series of stepwise upgrades from the version you're on to the version you want to get to.
 
-### Upgrade directly from any previous version to the latest version (aka The YOLO Method)
-
-This was the original upgrade method that Bullet Train used for many years. It's still a perfectly useable way of
-upgrading, though it feels a little... let's call it "uncontrolled" to some people. It can definitely lead to some
-hairy merge conflicts if you haven't updated in a long time.
-
-[Read more about The YOLO Method](/docs/upgrades/yolo.md)
-
-### Upgrade from `1.4.0` (or later) to any later version (aka The Standard Method)
+### Upgrade from `1.4.0` (or later) to any later version (aka The Stepwise Method)
 
 This is the new standard upgrade method that we recommend. If you've ever upgraded a Rails app from version to verison
 this process should feel fairly similar.
 
-[Read more about The Standard Method](/docs/upgrades/yolo-140.md)
+[Read more about The Stepwise Method](#the-stepwise-upgrade-method)
 
-### YOLO from any previous verison to version `1.4.0`
+### Upgrade from any previous verison to version `1.4.0`
 
-If you're on a version prior to `1.4.0` it's a little tricky to do a step-wise upgrade to get to `1.4.0`. It's not
-impossible (see below), but we recommend starting with making an attempt to YOLO your app directly to `1.4.0`.
+If you're on a version prior to `1.4.0` it's a little tricky to do a stepwise upgrade to get to `1.4.0`. It's not
+impossible (see below), but we recommend starting with making an attempt to upgrade your app directly to `1.4.0`.
 
 [Read more about going directly to `1.4.0`](/docs/upgrades/yolo-140.md)
 
@@ -90,12 +82,22 @@ directly to `1.3.0`. With a few extra steps in the upgrade process it's (hopeful
 ### Upgrade from `1.3.x` to version `1.4.0`
 
 Once you make it to the end of the `1.3.x` line you only have one more step to get to the `1.4.0` branch. It's the
-same instructions as if you wanted to YOLO to `1.4.0` from any previous version.
+same instructions as if you wanted to upgrade to `1.4.0` from any previous version.
 
 [Read more about going from `1.3.x` to `1.4.0`](/docs/upgrades/yolo-140.md)
 
+### Upgrade directly from any previous version to the latest version (aka The YOLO Method)
 
-## Upgrading the Framework
+This was the original upgrade method that Bullet Train used for many years. It's still a perfectly useable way of
+upgrading, though it feels a little... let's call it "uncontrolled" to some people. It can definitely lead to some
+hairy merge conflicts if you haven't updated in a long time.
+
+[Read more about The YOLO Method](/docs/upgrades/yolo.md)
+
+
+
+
+## The Stepwise Upgrade Method
 
 The vast majority of Bullet Train's functionality is distributed via Ruby gems, so you can pull the latest updates by running `bundle update`.
 

--- a/bullet_train/docs/upgrades.md
+++ b/bullet_train/docs/upgrades.md
@@ -12,20 +12,28 @@
   </p>
 </div>
 
-
-
-
 ## The Stepwise Upgrade Method
 
-The vast majority of Bullet Train's functionality is distributed via Ruby gems, so you can pull the latest updates by running `bundle update`.
+This method will ensure that the version of the Bullet Train gems that you app uses will stay in sync with the appliation framework provided by the starter repo.
 
 ## Pulling Updates from the Starter Repository
 
-There are times when you'll want to pull updates from the starter repository into your local application. Thankfully, `git merge` provides us with the perfect tool for just that. You can simply merge the upstream Bullet Train repository into your local repository. If you haven’t tinkered with the starter repository defaults at all, then this should happen with no meaningful conflicts at all. Simply run your automated tests (including the comprehensive integration tests Bullet Train ships with) to make sure everything is still working as it was before.
+There are times when you'll want to update Bullet Train gems and pull updates from the starter repository into your local application.
+Thankfully, `git merge` provides us with the perfect tool for just that. You can simply merge the upstream Bullet Train repository into
+your local repository. If you haven’t tinkered with the starter repository defaults at all, then this should happen with no meaningful
+conflicts at all. Simply run your automated tests (including the comprehensive integration tests Bullet Train ships with) to make sure
+everything is still working as it was before.
 
-If you _have_ modified some starter repository defaults _and_ we also happened to update that same logic upstream, then pulling the most recent version of the starter repository should cause a merge conflict in Git. This is actually great, because Git will then give you the opportunity to compare our upstream changes with your local customizations and allow you to resolve them in a way that makes sense for your application.
+If you _have_ modified some starter repository defaults _and_ we also happened to update that same logic upstream, then pulling the most
+recent version of the starter repository should cause a merge conflict in Git. This is actually great, because Git will then give you the
+opportunity to compare our upstream changes with your local customizations and allow you to resolve them in a way that makes sense for
+your application.
 
-### 1. Make sure you're working with a clean local copy.
+### 1. Decide which version you want to upgrade to
+
+For the purposes of these instructions we'll assume that you're on version `1.4.0` and are going to upgrade to version `1.4.1`.
+
+### 2. Make sure you're working with a clean local copy.
 
 ```
 git status
@@ -39,47 +47,57 @@ git checkout .
 git clean -d -f
 ```
 
-### 2. Fetch the latest and greatest from the Bullet Train repository.
+### 3. Fetch the latest and greatest from the Bullet Train repository.
 
 ```
 git fetch bullet-train
+git fetch --tags bullet-train
 ```
 
-### 3. Create a new "upgrade" branch off of your main branch.
+### 4. Create a new "upgrade" branch off of your main branch.
+
+It can be handy to include the version number that you're moving to in the branch name.
 
 ```
 git checkout main
-git checkout -b updating-bullet-train
+git checkout -b updating-bullet-train-1.4.1
 ```
 
-### 4. Merge in the newest stuff from Bullet Train and resolve any merge conflicts.
+### 5. Merge in the newest stuff from Bullet Train and resolve any merge conflicts.
+
+Each version of the starter repo is tagged, so you can merge in the tag from the upstread repo.
 
 ```
-git merge bullet-train/main
+git merge bullet-train/v1.4.1
 ```
 
-It's quite possible you'll get some merge conflicts at this point. No big deal! Just go through and resolve them like you would if you were integrating code from another developer on your team. We tend to comment our code heavily, but if you have any questions about the code you're trying to understand, let us know on Discord!
+It's quite possible you'll get some merge conflicts at this point. No big deal! Just go through and
+resolve them like you would if you were integrating code from another developer on your team. We tend
+to comment our code heavily, but if you have any questions about the code you're trying to understand,
+let us know on Discord!
 
 ```
 git diff
 git add -A
-git commit -m "Upgrading Bullet Train."
+git commit -m "Upgrading Bullet Train to v1.4.1."
 ```
 
-### 5. Run Tests.
+### 6. Run Tests.
 
 ```
 rails test
 rails test:system
 ```
 
-### 6. Merge into `main` and delete the branch.
+### 7. Merge into `main` and delete the branch.
 
 ```
 git checkout main
-git merge updating-bullet-train
+git merge updating-bullet-train-1.4.1
 git push origin main
-git branch -d updating-bullet-train
+git branch -d updating-bullet-train-1.4.1
 ```
 
-Alternatively, if you're using GitHub, you can push the `updating-bullet-train` branch up and create a PR from it and let your CI integration do it's thing and then merge in the PR and delete the branch there. (That's what we typically do.)
+Alternatively, if you're using GitHub, you can push the `updating-bullet-train` branch up and create a
+PR from it and let your CI integration do it's thing and then merge in the PR and delete the branch there.
+(That's what we typically do.)

--- a/bullet_train/docs/upgrades.md
+++ b/bullet_train/docs/upgrades.md
@@ -1,98 +1,16 @@
 # Upgrading Your Bullet Train Application
 
 <div class="rounded-md border bg-amber-100 border-amber-200 py-4 px-5 mb-3 not-prose">
-  <h3 class="text-sm text-amber-800 font-light">
+  <h3 class="text-sm text-amber-800 font-light mb-2">
     Note: These ugrade steps have recently changed.
   </h3>
+  <p class="text-sm text-amber-800 font-light mb-2">
+    These instructions assume that you're doing a stepwise upgrade on an app that's already on version <code>1.4.0</code> or later.
+  </p>
+  <p class="text-sm text-amber-800 font-light">
+    <a href="/docs/upgrades/options">Learn about other upgrade options.</a>
+  </p>
 </div>
-
-## Quick Links
-
-* [The Stepwise Method - For `1.4.0` and above](#the-stepwise-upgrade-method)
-* [Upgrade from any verison to `1.4.0`](/docs/upgrades/yolo-140.md)
-* [Upgrade from any version to `1.3.0`](/docs/upgrades/yolo-130.md)
-* [Upgrade from `1.3.x` to `1.4.0`](/docs/upgrades/yolo-140.md)
-* [The YOLO Method (The original upgrade method.)](/docs/upgrades/yolo.md)
-
-## About the upgrade process
-
-The vast majority of Bullet Train's functionality is distributed via Ruby gems, but those gems depend on certain
-hooks and initializers being present in the hosting application. Those hooks and initializers are provided by the
-starter repository.
-
-Starting in mid-August of 2023 we began to iterate on how we publish gems and how we ensure that the starter repo
-will get the version of the gems that it expects.
-
-Starting with version `1.3.0` we began to explicitly update the starter repo every time that we released new
-versions of the Bullet Train gems. Unfortunately, at that time we were only making changes to `Gemfile.lock`
-which kind of hides the dependencies, and is often a source of merge conflicts that can be hard to sort out.
-
-Starting with version `1.4.0` we added explicit version numbers for all of the Bullet Train gems to `Gemfile`,
-which is less hidden and is not as prone to having merge conflicts as `Gemfile.lock`.
-
-As a result of these changes, there are a few different ways that you might choose to upgrade your application
-depending on which version you're currently on.
-
-## How to find your current version
-
-1. First open `Gemfile` in your application and look/search for a line that begins with `BULLET_TRAIN_VERSION`.
-   For instance:
-    ```ruby
-    BULLET_TRAIN_VERSION = "1.4.0"
-    ```
-   If your `Gemfile` has such a line, that should be the verison you're on. In this case `1.4.0`.
-
-2. If you don't have a `BULLET_TRAIN_VERSION` line in `Gemfile`, then you need to open `Gemfile.lock` and look/search
-   for a line for the `bullet_train` gem. For instance:
-   ```ruby
-   bullet_train (1.2.24)
-   ```
-   In this case the app is on version `1.2.24`
-
-## How to upgrade
-
-Depending on what version you're starting on, and what version you want to get to, you have a few options.
-
-In general your two main options are:
-
-1. Upgrade directly from whatever version you happen to be on all the way to the latest published version.
-2. Do a series of stepwise upgrades from the version you're on to the version you want to get to.
-
-### Upgrade from `1.4.0` (or later) to any later version (aka The Stepwise Method)
-
-This is the new standard upgrade method that we recommend. If you've ever upgraded a Rails app from version to verison
-this process should feel fairly similar.
-
-[Read more about The Stepwise Method](#the-stepwise-upgrade-method)
-
-### Upgrade from any previous verison to version `1.4.0`
-
-If you're on a version prior to `1.4.0` it's a little tricky to do a stepwise upgrade to get to `1.4.0`. It's not
-impossible (see below), but we recommend starting with making an attempt to upgrade your app directly to `1.4.0`.
-
-[Read more about going directly to `1.4.0`](/docs/upgrades/yolo-140.md)
-
-### Upgrade from any previous verison to version `1.3.0` (and through the `1.3.x` line)
-
-Since we weren't tracking version numbers in `Gemfile` (only `Gemfile.lock`) it can be a little tricky to upgrade
-directly to `1.3.0`. With a few extra steps in the upgrade process it's (hopefully) not too terrible.
-
-[Read more about going directly to `1.3.0`](/docs/upgrades/yolo-130.md)
-
-### Upgrade from `1.3.x` to version `1.4.0`
-
-Once you make it to the end of the `1.3.x` line you only have one more step to get to the `1.4.0` branch. It's the
-same instructions as if you wanted to upgrade to `1.4.0` from any previous version.
-
-[Read more about going from `1.3.x` to `1.4.0`](/docs/upgrades/yolo-140.md)
-
-### Upgrade directly from any previous version to the latest version (aka The YOLO Method)
-
-This was the original upgrade method that Bullet Train used for many years. It's still a perfectly useable way of
-upgrading, though it feels a little... let's call it "uncontrolled" to some people. It can definitely lead to some
-hairy merge conflicts if you haven't updated in a long time.
-
-[Read more about The YOLO Method](/docs/upgrades/yolo.md)
 
 
 

--- a/bullet_train/docs/upgrades.md
+++ b/bullet_train/docs/upgrades.md
@@ -15,6 +15,7 @@
 ## The Stepwise Upgrade Method
 
 This method will ensure that the version of the Bullet Train gems that you app uses will stay in sync with the appliation framework provided by the starter repo.
+If you've ever upgraded a Rails app from version to verison this process should feel fairly similar.
 
 ## Pulling Updates from the Starter Repository
 
@@ -68,7 +69,7 @@ git checkout -b updating-bullet-train-1.4.1
 Each version of the starter repo is tagged, so you can merge in the tag from the upstread repo.
 
 ```
-git merge bullet-train/v1.4.1
+git merge v1.4.1
 ```
 
 It's quite possible you'll get some merge conflicts at this point. No big deal! Just go through and
@@ -76,8 +77,19 @@ resolve them like you would if you were integrating code from another developer 
 to comment our code heavily, but if you have any questions about the code you're trying to understand,
 let us know on Discord!
 
-Once you've resoled any conflicts it's a good idea to run `bundle install` just to make sure that your
-`Gemfile.lock` agrees with the new state of `Gemfile`.
+One of the files that's likely to have conflicts, and which can be the most frustrating to resolve is
+`Gemfile.lock`. You can try to sort it out by hand, or you can checkout a clean copy and then let bundler
+generate a new one that matches what you need:
+
+```
+git checkout HEAD -- Gemfile.lock
+bundle update
+```
+
+If you choose to sort out `Gemfile.lock` by hand it's a good idea to run `bundle install` just to make
+sure that your `Gemfile.lock` agrees with the new state of `Gemfile`.
+
+Once you've resolved all the conflicts go ahead and commit the changes.
 
 ```
 git diff

--- a/bullet_train/docs/upgrades.md
+++ b/bullet_train/docs/upgrades.md
@@ -15,7 +15,7 @@
 ## The Stepwise Upgrade Method
 
 This method will ensure that the version of the Bullet Train gems that your app uses will stay in sync with the appliation framework provided by the starter repo.
-If you've ever upgraded a Rails app from version to verison this process should feel fairly similar.
+If you've ever upgraded a Rails app from version to version this process should feel fairly similar.
 
 ## Pulling Updates from the Starter Repository
 

--- a/bullet_train/docs/upgrades.md
+++ b/bullet_train/docs/upgrades.md
@@ -1,5 +1,100 @@
 # Upgrading Your Bullet Train Application
 
+<div class="rounded-md border bg-amber-100 border-amber-200 py-4 px-5 mb-3 not-prose">
+  <h3 class="text-sm text-amber-800 font-light">
+    Note: These ugrade steps have recently changed.
+  </h3>
+</div>
+
+## Quick Links
+
+* [The Standard Method - Step-wise updates after version `1.4.0`](/docs/upgrades#the-standard-method)
+* [Upgrade from any verison to `1.4.0`](/docs/upgrades/yolo-140.md)
+* [Upgrade from any version to `1.3.0`](/docs/upgrades/yolo-130.md)
+* [Upgrade from `1.3.x` to `1.4.0`](/docs/upgrades/yolo-140.md)
+* [The YOLO Method (The original upgrade method.)](/docs/upgrades/yolo.md)
+
+## About the upgrade process
+
+The vast majority of Bullet Train's functionality is distributed via Ruby gems, but those gems depend on certain
+hooks and initializers being present in the hosting application. Those hooks and initializers are provided by the
+starter repository.
+
+Starting in mid-August of 2023 we began to iterate on how we publish gems and how we ensure that the starter repo
+will get the version of the gems that it expects.
+
+Starting with version `1.3.0` we began to explicitly update the starter repo every time that we released new
+versions of the Bullet Train gems. Unfortunately, at that time we were only making changes to `Gemfile.lock`
+which kind of hides the dependencies, and is often a source of merge conflicts that can be hard to sort out.
+
+Starting with version `1.4.0` we added explicit version numbers for all of the Bullet Train gems to `Gemfile`,
+which is less hidden and is not as prone to having merge conflicts as `Gemfile.lock`.
+
+As a result of these changes, there are a few different ways that you might choose to upgrade your application
+depending on which version you're currently on.
+
+## How to find your current version
+
+1. First open `Gemfile` in your application and look/search for a line that begins with `BULLET_TRAIN_VERSION`.
+   For instance:
+    ```ruby
+    BULLET_TRAIN_VERSION = "1.4.0"
+    ```
+   If your `Gemfile` has such a line, that should be the verison you're on. In this case `1.4.0`.
+
+2. If you don't have a `BULLET_TRAIN_VERSION` line in `Gemfile`, then you need to open `Gemfile.lock` and look/search
+   for a line for the `bullet_train` gem. For instance:
+   ```ruby
+   bullet_train (1.2.24)
+   ```
+   In this case the app is on version `1.2.24`
+
+## How to upgrade
+
+Depending on what version you're starting on, and what version you want to get to, you have a few options.
+
+In general your two main options are:
+
+1. Upgrade directly from whatever version you happen to be on all the way to the latest published version.
+2. Do a series of step-wise upgrades from the version you're on to the version you want to get to.
+
+### Upgrade directly from any previous version to the latest version (aka The YOLO Method)
+
+This was the original upgrade method that Bullet Train used for many years. It's still a perfectly useable way of
+upgrading, though it feels a little... let's call it "uncontrolled" to some people. It can definitely lead to some
+hairy merge conflicts if you haven't updated in a long time.
+
+[Read more about The YOLO Method](/docs/upgrades/yolo.md)
+
+### Upgrade from `1.4.0` (or later) to any later version (aka The Standard Method)
+
+This is the new standard upgrade method that we recommend. If you've ever upgraded a Rails app from version to verison
+this process should feel fairly similar.
+
+[Read more about The Standard Method](/docs/upgrades/yolo-140.md)
+
+### YOLO from any previous verison to version `1.4.0`
+
+If you're on a version prior to `1.4.0` it's a little tricky to do a step-wise upgrade to get to `1.4.0`. It's not
+impossible (see below), but we recommend starting with making an attempt to YOLO your app directly to `1.4.0`.
+
+[Read more about going directly to `1.4.0`](/docs/upgrades/yolo-140.md)
+
+### Upgrade from any previous verison to version `1.3.0` (and through the `1.3.x` line)
+
+Since we weren't tracking version numbers in `Gemfile` (only `Gemfile.lock`) it can be a little tricky to upgrade
+directly to `1.3.0`. With a few extra steps in the upgrade process it's (hopefully) not too terrible.
+
+[Read more about going directly to `1.3.0`](/docs/upgrades/yolo-130.md)
+
+### Upgrade from `1.3.x` to version `1.4.0`
+
+Once you make it to the end of the `1.3.x` line you only have one more step to get to the `1.4.0` branch. It's the
+same instructions as if you wanted to YOLO to `1.4.0` from any previous version.
+
+[Read more about going from `1.3.x` to `1.4.0`](/docs/upgrades/yolo-140.md)
+
+
 ## Upgrading the Framework
 
 The vast majority of Bullet Train's functionality is distributed via Ruby gems, so you can pull the latest updates by running `bundle update`.

--- a/bullet_train/docs/upgrades.md
+++ b/bullet_train/docs/upgrades.md
@@ -113,6 +113,6 @@ git push origin main
 git branch -d updating-bullet-train-1.4.1
 ```
 
-Alternatively, if you're using GitHub, you can push the `updating-bullet-train` branch up and create a
+Alternatively, if you're using GitHub, you can push the `updating-bullet-train-1.4.1` branch up and create a
 PR from it and let your CI integration do it's thing and then merge in the PR and delete the branch there.
 (That's what we typically do.)

--- a/bullet_train/docs/upgrades/options.md
+++ b/bullet_train/docs/upgrades/options.md
@@ -1,0 +1,91 @@
+# Options For Upgrading Your Bullet Train Application
+
+## Quick Links
+
+* [The Stepwise Method - For `1.4.0` and above](/docs/upgrades)
+* [Upgrade from any verison to `1.4.0`](/docs/upgrades/yolo-140.md)
+* [Upgrade from any version to `1.3.0`](/docs/upgrades/yolo-130.md)
+* [Upgrade from `1.3.x` to `1.4.0`](/docs/upgrades/yolo-140.md)
+* [The YOLO Method (The original upgrade method.)](/docs/upgrades/yolo.md)
+
+## About the upgrade process
+
+The vast majority of Bullet Train's functionality is distributed via Ruby gems, but those gems depend on certain
+hooks and initializers being present in the hosting application. Those hooks and initializers are provided by the
+starter repository.
+
+Starting in mid-August of 2023 we began to iterate on how we publish gems and how we ensure that the starter repo
+will get the version of the gems that it expects.
+
+Starting with version `1.3.0` we began to explicitly update the starter repo every time that we released new
+versions of the Bullet Train gems. Unfortunately, at that time we were only making changes to `Gemfile.lock`
+which kind of hides the dependencies, and is often a source of merge conflicts that can be hard to sort out.
+
+Starting with version `1.4.0` we added explicit version numbers for all of the Bullet Train gems to `Gemfile`,
+which is less hidden and is not as prone to having merge conflicts as `Gemfile.lock`.
+
+As a result of these changes, there are a few different ways that you might choose to upgrade your application
+depending on which version you're currently on.
+
+## How to find your current version
+
+1. First open `Gemfile` in your application and look/search for a line that begins with `BULLET_TRAIN_VERSION`.
+   For instance:
+    ```ruby
+    BULLET_TRAIN_VERSION = "1.4.0"
+    ```
+   If your `Gemfile` has such a line, that should be the verison you're on. In this case `1.4.0`.
+
+2. If you don't have a `BULLET_TRAIN_VERSION` line in `Gemfile`, then you need to open `Gemfile.lock` and look/search
+   for a line for the `bullet_train` gem. For instance:
+   ```ruby
+   bullet_train (1.2.24)
+   ```
+   In this case the app is on version `1.2.24`
+
+## How to upgrade
+
+Depending on what version you're starting on, and what version you want to get to, you have a few options.
+
+In general your two main options are:
+
+1. Upgrade directly from whatever version you happen to be on all the way to the latest published version.
+2. Do a series of stepwise upgrades from the version you're on to the version you want to get to.
+
+### Upgrade from `1.4.0` (or later) to any later version (aka The Stepwise Method)
+
+This is the new standard upgrade method that we recommend. If you've ever upgraded a Rails app from version to verison
+this process should feel fairly similar.
+
+[Read more about The Stepwise Method](/docs/upgrades)
+
+### Upgrade from any previous verison to version `1.4.0`
+
+If you're on a version prior to `1.4.0` it's a little tricky to do a stepwise upgrade to get to `1.4.0`. It's not
+impossible (see below), but we recommend starting with making an attempt to upgrade your app directly to `1.4.0`.
+
+[Read more about going directly to `1.4.0`](/docs/upgrades/yolo-140.md)
+
+### Upgrade from any previous verison to version `1.3.0` (and through the `1.3.x` line)
+
+Since we weren't tracking version numbers in `Gemfile` (only `Gemfile.lock`) it can be a little tricky to upgrade
+directly to `1.3.0`. With a few extra steps in the upgrade process it's (hopefully) not too terrible.
+
+[Read more about going directly to `1.3.0`](/docs/upgrades/yolo-130.md)
+
+### Upgrade from `1.3.x` to version `1.4.0`
+
+Once you make it to the end of the `1.3.x` line you only have one more step to get to the `1.4.0` branch. It's the
+same instructions as if you wanted to upgrade to `1.4.0` from any previous version.
+
+[Read more about going from `1.3.x` to `1.4.0`](/docs/upgrades/yolo-140.md)
+
+### Upgrade directly from any previous version to the latest version (aka The YOLO Method)
+
+This was the original upgrade method that Bullet Train used for many years. It's still a perfectly useable way of
+upgrading, though it feels a little... let's call it "uncontrolled" to some people. It can definitely lead to some
+hairy merge conflicts if you haven't updated in a long time.
+
+[Read more about The YOLO Method](/docs/upgrades/yolo.md)
+
+

--- a/bullet_train/docs/upgrades/options.md
+++ b/bullet_train/docs/upgrades/options.md
@@ -12,7 +12,7 @@
 
 The vast majority of Bullet Train's functionality is distributed via Ruby gems, but those gems depend on certain
 hooks and initializers being present in the hosting application. Those hooks and initializers are provided by the
-starter repository.
+[starter repository](https://github.com/bullet-train-co/bullet_train).
 
 Starting in mid-August of 2023 we began to iterate on how we publish gems and how we ensure that the starter repo
 will get the version of the gems that it expects.

--- a/bullet_train/docs/upgrades/options.md
+++ b/bullet_train/docs/upgrades/options.md
@@ -34,7 +34,7 @@ depending on which version you're currently on.
     ```ruby
     BULLET_TRAIN_VERSION = "1.4.0"
     ```
-   If your `Gemfile` has such a line, that should be the verison you're on. In this case `1.4.0`.
+   If your `Gemfile` has such a line, that should be the version you're on. In this case `1.4.0`.
 
 2. If you don't have a `BULLET_TRAIN_VERSION` line in `Gemfile`, then you need to open `Gemfile.lock` and look/search
    for a line for the `bullet_train` gem. For instance:

--- a/bullet_train/docs/upgrades/options.md
+++ b/bullet_train/docs/upgrades/options.md
@@ -62,7 +62,7 @@ hairy merge conflicts if you haven't updated in a long time.
 
 ### Upgrade from `1.4.0` (or later) to any later version (aka The Standard Stepwise Method)
 
-This is the new standard upgrade method that we recommend. If you've ever upgraded a Rails app from version to verison
+This is the new standard upgrade method that we recommend. If you've ever upgraded a Rails app from version to version
 this process should feel fairly similar.
 
 [Read more about The Stepwise Method](/docs/upgrades)

--- a/bullet_train/docs/upgrades/options.md
+++ b/bullet_train/docs/upgrades/options.md
@@ -4,7 +4,7 @@
 
 * [The YOLO Method (The original upgrade method)](/docs/upgrades/yolo.md)
 * [The Stepwise Method - For `1.4.0` and above](/docs/upgrades)
-* [Upgrade from any verison to `1.4.0`](/docs/upgrades/yolo-140.md)
+* [Upgrade from any version to `1.4.0`](/docs/upgrades/yolo-140.md)
 * [Upgrade from any version to `1.3.0`](/docs/upgrades/yolo-130.md)
 * [Upgrade from `1.3.x` to `1.4.0`](/docs/upgrades/yolo-140.md)
 

--- a/bullet_train/docs/upgrades/options.md
+++ b/bullet_train/docs/upgrades/options.md
@@ -2,11 +2,11 @@
 
 ## Quick Links
 
+* [The YOLO Method (The original upgrade method)](/docs/upgrades/yolo.md)
 * [The Stepwise Method - For `1.4.0` and above](/docs/upgrades)
 * [Upgrade from any verison to `1.4.0`](/docs/upgrades/yolo-140.md)
 * [Upgrade from any version to `1.3.0`](/docs/upgrades/yolo-130.md)
 * [Upgrade from `1.3.x` to `1.4.0`](/docs/upgrades/yolo-140.md)
-* [The YOLO Method (The original upgrade method.)](/docs/upgrades/yolo.md)
 
 ## About the upgrade process
 
@@ -52,17 +52,25 @@ In general your two main options are:
 1. Upgrade directly from whatever version you happen to be on all the way to the latest published version.
 2. Do a series of stepwise upgrades from the version you're on to the version you want to get to.
 
-### Upgrade from `1.4.0` (or later) to any later version (aka The Stepwise Method)
+### Upgrade directly from any previous version to the latest version (aka The YOLO Method)
+
+This was the original upgrade method that Bullet Train used for many years. It's still a perfectly useable way of
+upgrading, though it feels a little... let's call it "uncontrolled" to some people. It can definitely lead to some
+hairy merge conflicts if you haven't updated in a long time.
+
+[Read more about The YOLO Method](/docs/upgrades/yolo.md)
+
+### Upgrade from `1.4.0` (or later) to any later version (aka The Standard Stepwise Method)
 
 This is the new standard upgrade method that we recommend. If you've ever upgraded a Rails app from version to verison
 this process should feel fairly similar.
 
 [Read more about The Stepwise Method](/docs/upgrades)
 
-### Upgrade from any previous verison to version `1.4.0`
+### Upgrade from any previous verison to version `1.4.0` (a modified YOLO)
 
-If you're on a version prior to `1.4.0` it's a little tricky to do a stepwise upgrade to get to `1.4.0`. It's not
-impossible (see below), but we recommend starting with making an attempt to upgrade your app directly to `1.4.0`.
+If you're on a version prior to `1.4.0` it can be a little tricky to do a stepwise upgrade to get to `1.4.0`. It's not
+impossible (see below), but if you're feeling lucky you might start with making an attempt to upgrade your app directly to `1.4.0`.
 
 [Read more about going directly to `1.4.0`](/docs/upgrades/yolo-140.md)
 
@@ -80,12 +88,6 @@ same instructions as if you wanted to upgrade to `1.4.0` from any previous versi
 
 [Read more about going from `1.3.x` to `1.4.0`](/docs/upgrades/yolo-140.md)
 
-### Upgrade directly from any previous version to the latest version (aka The YOLO Method)
 
-This was the original upgrade method that Bullet Train used for many years. It's still a perfectly useable way of
-upgrading, though it feels a little... let's call it "uncontrolled" to some people. It can definitely lead to some
-hairy merge conflicts if you haven't updated in a long time.
-
-[Read more about The YOLO Method](/docs/upgrades/yolo.md)
 
 

--- a/bullet_train/docs/upgrades/options.md
+++ b/bullet_train/docs/upgrades/options.md
@@ -29,19 +29,16 @@ depending on which version you're currently on.
 
 ## How to find your current version
 
-1. First open `Gemfile` in your application and look/search for a line that begins with `BULLET_TRAIN_VERSION`.
-   For instance:
-    ```ruby
-    BULLET_TRAIN_VERSION = "1.4.0"
-    ```
-   If your `Gemfile` has such a line, that should be the version you're on. In this case `1.4.0`.
+You can easily find your current version by running `bundle show | grep "bullet_train "`.
 
-2. If you don't have a `BULLET_TRAIN_VERSION` line in `Gemfile`, then you need to open `Gemfile.lock` and look/search
-   for a line for the `bullet_train` gem. For instance:
-   ```ruby
-   bullet_train (1.2.24)
-   ```
-   In this case the app is on version `1.2.24`
+For example:
+
+```
+$ bundle show | grep "bullet_train "
+  * bullet_train (1.3.20)
+```
+
+This app is on version `1.3.20`
 
 ## How to upgrade
 

--- a/bullet_train/docs/upgrades/yolo-130.md
+++ b/bullet_train/docs/upgrades/yolo-130.md
@@ -1,0 +1,171 @@
+# Upgrading Your Bullet Train Application to Version `1.3.0`
+
+<div class="rounded-md border bg-amber-100 border-amber-200 py-4 px-5 mb-3 not-prose">
+  <p class="text-sm text-amber-800 font-light mb-2">
+    If you're already on version <code>1.4.0</code> or later you should use
+    <a href="/docs/upgrades">The Stepwise Upgrade Method</a>
+  </p>
+  <p class="text-sm text-amber-800 font-light">
+    <a href="/docs/upgrades/options">Learn about other upgrade options.</a>
+  </p>
+</div>
+
+
+
+## Pulling Updates from the Starter Repository
+
+
+
+### 1. Make sure you're working with a clean local copy.
+
+```
+git status
+```
+
+If you've got uncommitted or untracked files, you can clean them up with the following.
+
+```
+# ⚠️ This will destroy any uncommitted or untracked changes and files you have locally.
+git checkout .
+git clean -d -f
+```
+
+### 2. Fetch the latest and greatest from the Bullet Train repository.
+
+```
+git fetch bullet-train
+git fetch --tags bullet-train
+```
+
+### 3. Create a new "upgrade" branch off of your main branch.
+
+```
+git checkout main
+git checkout -b updating-bullet-train-v1.3.0
+```
+
+### 4. Merge in the newest stuff from Bullet Train and resolve any merge conflicts.
+
+```
+git merge v1.3.0
+```
+
+It's quite possible you'll get some merge conflicts at this point. No big deal! Just go through and
+resolve them like you would if you were integrating code from another developer on your team. We tend
+to comment our code heavily, but if you have any questions about the code you're trying to understand,
+let us know on Discord!
+
+One of the files that's likely to have conflicts, and which can be the most frustrating to resolve is
+`Gemfile.lock`. Unfortunately there are important changes in that file that we'll want to preserve.
+Luckily there's a way to do it without having to resolve conflicts manually. We'll handle that in the
+next step. For now you can just skip the updates in that file:
+
+```
+git checkout HEAD -- Gemfile.lock
+```
+
+Once you've resolved all the conflicts go ahead and commit the changes.
+
+```
+git diff
+git add -A
+git commit -m "Upgrading Bullet Train."
+```
+
+### 5. Update `Gemfile`
+
+Now we need to handle the situation with `Gemfile.lock` that we side-stepped earlier. you should open
+up your `Gemfile` and find this block of gems:
+
+```ruby
+# BULLET TRAIN GEMS
+# This section is the list of Ruby gems included by default for Bullet Train.
+
+
+# Core packages.
+gem "bullet_train"
+gem "bullet_train-super_scaffolding"
+gem "bullet_train-api"
+gem "bullet_train-outgoing_webhooks"
+gem "bullet_train-incoming_webhooks"
+gem "bullet_train-themes"
+gem "bullet_train-themes-light"
+gem "bullet_train-integrations"
+gem "bullet_train-integrations-stripe"
+
+
+# Optional support packages.
+gem "bullet_train-sortable"
+gem "bullet_train-scope_questions"
+gem "bullet_train-obfuscates_id"
+```
+
+Replace that entire block with this block:
+
+```ruby
+# BULLET TRAIN GEMS
+# This section is the list of Ruby gems included by default for Bullet Train.
+
+# We use a constant here so that we can ensure that all of the bullet_train-*
+# packages are on the same version.
+BULLET_TRAIN_VERSION = "1.3.0"
+
+# Core packages.
+gem "bullet_train", BULLET_TRAIN_VERSION
+gem "bullet_train-super_scaffolding", BULLET_TRAIN_VERSION
+gem "bullet_train-api", BULLET_TRAIN_VERSION
+gem "bullet_train-outgoing_webhooks", BULLET_TRAIN_VERSION
+gem "bullet_train-incoming_webhooks", BULLET_TRAIN_VERSION
+gem "bullet_train-themes", BULLET_TRAIN_VERSION
+gem "bullet_train-themes-light", BULLET_TRAIN_VERSION
+gem "bullet_train-integrations", BULLET_TRAIN_VERSION
+gem "bullet_train-integrations-stripe", BULLET_TRAIN_VERSION
+
+# Optional support packages.
+gem "bullet_train-sortable", BULLET_TRAIN_VERSION
+gem "bullet_train-scope_questions", BULLET_TRAIN_VERSION
+gem "bullet_train-obfuscates_id", BULLET_TRAIN_VERSION
+
+# Core gems that are dependencies of gems listed above. Technically they
+# shouldn't need to be listed here, but we list them so that we can keep
+# verion numbers in sync.
+gem "bullet_train-fields", BULLET_TRAIN_VERSION
+gem "bullet_train-has_uuid", BULLET_TRAIN_VERSION
+gem "bullet_train-roles", BULLET_TRAIN_VERSION
+gem "bullet_train-scope_validator", BULLET_TRAIN_VERSION
+gem "bullet_train-super_load_and_authorize_resource", BULLET_TRAIN_VERSION
+gem "bullet_train-themes-tailwind_css", BULLET_TRAIN_VERSION
+```
+
+(We have to do this since we didn't start explicitly tracking versions until `1.4.0` and
+want to make sure that our gem versions match what the starter repo expects.)
+
+Then run `bundle update`
+
+Then go ahead and commit the changes.
+
+```
+git diff
+git add -A
+git commit -m "Upgrading Bullet Train gems."
+```
+
+### 5. Run Tests.
+
+```
+rails test
+rails test:system
+```
+
+If anything fails, investigate the failures and get things working again, and commit those changes.
+
+### 6. Merge into `main` and delete the branch.
+
+```
+git checkout main
+git merge updating-bullet-train-v1.3.0
+git push origin main
+git branch -d updating-bullet-train-v1.3.0
+```
+
+Alternatively, if you're using GitHub, you can push the `updating-bullet-train-v1.3.0` branch up and create a PR from it and let your CI integration do it's thing and then merge in the PR and delete the branch there. (That's what we typically do.)

--- a/bullet_train/docs/upgrades/yolo-130.md
+++ b/bullet_train/docs/upgrades/yolo-130.md
@@ -1,4 +1,4 @@
-# Upgrading Your Bullet Train Application to Version `1.3.0`
+# Upgrading Your Bullet Train Application to Version `1.3.0` and through the `1.3.x` line
 
 <div class="rounded-md border bg-amber-100 border-amber-200 py-4 px-5 mb-3 not-prose">
   <p class="text-sm text-amber-800 font-light mb-2">
@@ -10,11 +10,7 @@
   </p>
 </div>
 
-
-
-## Pulling Updates from the Starter Repository
-
-
+## Getting to `1.3.0`
 
 ### 1. Make sure you're working with a clean local copy.
 
@@ -169,3 +165,114 @@ git branch -d updating-bullet-train-v1.3.0
 ```
 
 Alternatively, if you're using GitHub, you can push the `updating-bullet-train-v1.3.0` branch up and create a PR from it and let your CI integration do it's thing and then merge in the PR and delete the branch there. (That's what we typically do.)
+
+
+## Stepping to `1.3.x`
+
+Before doing this you should have already followed the instructions above to get to version `1.3.0`.
+
+For purposes of this example we'll assume that you're stepping up from `1.3.0` to `1.3.1`.
+
+### 1. Make sure you're working with a clean local copy.
+
+```
+git status
+```
+
+If you've got uncommitted or untracked files, you can clean them up with the following.
+
+```
+# ⚠️ This will destroy any uncommitted or untracked changes and files you have locally.
+git checkout .
+git clean -d -f
+```
+
+### 2. Fetch the latest and greatest from the Bullet Train repository.
+
+```
+git fetch bullet-train
+git fetch --tags bullet-train
+```
+
+### 3. Create a new "upgrade" branch off of your main branch.
+
+```
+git checkout main
+git checkout -b updating-bullet-train-v1.3.1
+```
+
+### 4. Merge in the newest stuff from Bullet Train and resolve any merge conflicts.
+
+```
+git merge v1.3.1
+```
+
+It's quite possible you'll get some merge conflicts at this point. No big deal! Just go through and
+resolve them like you would if you were integrating code from another developer on your team. We tend
+to comment our code heavily, but if you have any questions about the code you're trying to understand,
+let us know on Discord!
+
+One of the files that's likely to have conflicts, and which can be the most frustrating to resolve is
+`Gemfile.lock`. Unfortunately there are important changes in that file that we'll want to preserve.
+Luckily there's a way to do it without having to resolve conflicts manually. We'll handle that in the
+next step. For now you can just skip the updates in that file:
+
+```
+git checkout HEAD -- Gemfile.lock
+```
+
+Once you've resolved all the conflicts go ahead and commit the changes.
+
+```
+git diff
+git add -A
+git commit -m "Upgrading Bullet Train."
+```
+
+### 5. Update `Gemfile`
+
+Now we need to handle the situation with `Gemfile.lock` that we side-stepped earlier. you should open
+up your `Gemfile` and find this line:
+
+```ruby
+BULLET_TRAIN_VERSION = "1.3.0"
+```
+
+Update that line with the new version you're moving to:
+
+```ruby
+BULLET_TRAIN_VERSION = "1.3.1"
+```
+
+(We have to do this since we didn't start explicitly tracking versions until `1.4.0` and
+want to make sure that our gem versions match what the starter repo expects.)
+
+Then run `bundle update`
+
+Then go ahead and commit the changes.
+
+```
+git diff
+git add -A
+git commit -m "Upgrading Bullet Train gems."
+```
+
+### 5. Run Tests.
+
+```
+rails test
+rails test:system
+```
+
+If anything fails, investigate the failures and get things working again, and commit those changes.
+
+### 6. Merge into `main` and delete the branch.
+
+```
+git checkout main
+git merge updating-bullet-train-v1.3.1
+git push origin main
+git branch -d updating-bullet-train-v1.3.1`
+```
+
+Alternatively, if you're using GitHub, you can push the `updating-bullet-train-v1.3.1` branch up and create a PR from it and let your CI integration do it's thing and then merge in the PR and delete the branch there. (That's what we typically do.)

--- a/bullet_train/docs/upgrades/yolo-140.md
+++ b/bullet_train/docs/upgrades/yolo-140.md
@@ -1,0 +1,94 @@
+# Upgrading Your Bullet Train Application to Version `1.4.0`
+
+<div class="rounded-md border bg-amber-100 border-amber-200 py-4 px-5 mb-3 not-prose">
+  <p class="text-sm text-amber-800 font-light mb-2">
+    If you're already on version <code>1.4.0</code> or later you should use
+    <a href="/docs/upgrades">The Stepwise Upgrade Method</a>
+  </p>
+  <p class="text-sm text-amber-800 font-light">
+    <a href="/docs/upgrades/options">Learn about other upgrade options.</a>
+  </p>
+</div>
+
+## Getting to `1.4.0`
+
+### 1. Make sure you're working with a clean local copy.
+
+```
+git status
+```
+
+If you've got uncommitted or untracked files, you can clean them up with the following.
+
+```
+# ⚠️ This will destroy any uncommitted or untracked changes and files you have locally.
+git checkout .
+git clean -d -f
+```
+
+### 2. Fetch the latest and greatest from the Bullet Train repository.
+
+```
+git fetch bullet-train
+git fetch --tags bullet-train
+```
+
+### 3. Create a new "upgrade" branch off of your main branch.
+
+```
+git checkout main
+git checkout -b updating-bullet-train-v1.4.0
+```
+
+### 4. Merge in the newest stuff from Bullet Train and resolve any merge conflicts.
+
+```
+git merge v1.4.0
+```
+
+It's quite possible you'll get some merge conflicts at this point. No big deal! Just go through and
+resolve them like you would if you were integrating code from another developer on your team. We tend
+to comment our code heavily, but if you have any questions about the code you're trying to understand,
+let us know on Discord!
+
+One of the files that's likely to have conflicts, and which can be the most frustrating to resolve is
+`Gemfile.lock`. You can try to sort it out by hand, or you can checkout a clean copy and then let bundler
+generate a new one that matches what you need:
+
+```
+git checkout HEAD -- Gemfile.lock
+bundle update
+```
+
+If you choose to sort out `Gemfile.lock` by hand it's a good idea to run `bundle install` just to make
+sure that your `Gemfile.lock` agrees with the new state of `Gemfile`.
+
+Once you've resolved all the conflicts go ahead and commit the changes.
+
+```
+git diff
+git add -A
+git commit -m "Upgrading Bullet Train."
+```
+
+### 5. Run Tests.
+
+```
+rails test
+rails test:system
+```
+
+If anything fails, investigate the failures and get things working again, and commit those changes.
+
+### 6. Merge into `main` and delete the branch.
+
+```
+git checkout main
+git merge updating-bullet-train-v1.3.0
+git push origin main
+git branch -d updating-bullet-train-v1.3.0
+```
+
+Alternatively, if you're using GitHub, you can push the `updating-bullet-train-v1.3.0` branch up and create a PR from it and let your CI integration do it's thing and then merge in the PR and delete the branch there. (That's what we typically do.)
+
+

--- a/bullet_train/docs/upgrades/yolo.md
+++ b/bullet_train/docs/upgrades/yolo.md
@@ -1,0 +1,77 @@
+# The YOLO Approach To Upgrading Your Bullet Train Application
+
+<div class="rounded-md border bg-amber-100 border-amber-200 py-4 px-5 mb-3 not-prose">
+  <p class="text-sm text-amber-800 font-light">
+    Note: We don't really recommend using this method.
+    <a href="/docs/upgrades.md">Learn about other upgrade options.</a>
+  </p>
+</div>
+
+## Upgrading the Framework
+
+The vast majority of Bullet Train's functionality is distributed via Ruby gems, so you can pull the latest updates by running `bundle update`.
+
+## Pulling Updates from the Starter Repository
+
+There are times when you'll want to pull updates from the starter repository into your local application. Thankfully, `git merge` provides us with the perfect tool for just that. You can simply merge the upstream Bullet Train repository into your local repository. If you haven’t tinkered with the starter repository defaults at all, then this should happen with no meaningful conflicts at all. Simply run your automated tests (including the comprehensive integration tests Bullet Train ships with) to make sure everything is still working as it was before.
+
+If you _have_ modified some starter repository defaults _and_ we also happened to update that same logic upstream, then pulling the most recent version of the starter repository should cause a merge conflict in Git. This is actually great, because Git will then give you the opportunity to compare our upstream changes with your local customizations and allow you to resolve them in a way that makes sense for your application.
+
+### 1. Make sure you're working with a clean local copy.
+
+```
+git status
+```
+
+If you've got uncommitted or untracked files, you can clean them up with the following.
+
+```
+# ⚠️ This will destroy any uncommitted or untracked changes and files you have locally.
+git checkout .
+git clean -d -f
+```
+
+### 2. Fetch the latest and greatest from the Bullet Train repository.
+
+```
+git fetch bullet-train
+```
+
+### 3. Create a new "upgrade" branch off of your main branch.
+
+```
+git checkout main
+git checkout -b updating-bullet-train
+```
+
+### 4. Merge in the newest stuff from Bullet Train and resolve any merge conflicts.
+
+```
+git merge bullet-train/main
+```
+
+It's quite possible you'll get some merge conflicts at this point. No big deal! Just go through and resolve them like you would if you were integrating code from another developer on your team. We tend to comment our code heavily, but if you have any questions about the code you're trying to understand, let us know on Discord!
+
+```
+git diff
+git add -A
+git commit -m "Upgrading Bullet Train."
+```
+
+### 5. Run Tests.
+
+```
+rails test
+rails test:system
+```
+
+### 6. Merge into `main` and delete the branch.
+
+```
+git checkout main
+git merge updating-bullet-train
+git push origin main
+git branch -d updating-bullet-train
+```
+
+Alternatively, if you're using GitHub, you can push the `updating-bullet-train` branch up and create a PR from it and let your CI integration do it's thing and then merge in the PR and delete the branch there. (That's what we typically do.)

--- a/bullet_train/docs/upgrades/yolo.md
+++ b/bullet_train/docs/upgrades/yolo.md
@@ -1,15 +1,21 @@
 # The YOLO Approach To Upgrading Your Bullet Train Application
 
 <div class="rounded-md border bg-amber-100 border-amber-200 py-4 px-5 mb-3 not-prose">
-  <p class="text-sm text-amber-800 font-light">
+  <p class="text-sm text-amber-800 font-light mb-2">
     Note: We don't really recommend using this method.
-    <a href="/docs/upgrades.md">Learn about other upgrade options.</a>
+    <a href="/docs/upgrades/options">Learn about other upgrade options.</a>
+  </p>
+  <p class="text-sm text-amber-800 font-light">
+    If you're already on version <code>1.4.0</code> or later you should use
+    <a href="/docs/upgrades">The Stepwise Upgrade Method</a>
   </p>
 </div>
 
+
+
 ## Upgrading the Framework
 
-The vast majority of Bullet Train's functionality is distributed via Ruby gems, so you can pull the latest updates by running `bundle update`.
+First run `bundle update`.
 
 ## Pulling Updates from the Starter Repository
 

--- a/bullet_train/docs/upgrades/yolo.md
+++ b/bullet_train/docs/upgrades/yolo.md
@@ -11,12 +11,6 @@
   </p>
 </div>
 
-
-
-## Upgrading the Framework
-
-First run `bundle update`.
-
 ## Pulling Updates from the Starter Repository
 
 There are times when you'll want to pull updates from the starter repository into your local application. Thankfully, `git merge` provides us with the perfect tool for just that. You can simply merge the upstream Bullet Train repository into your local repository. If you haven’t tinkered with the starter repository defaults at all, then this should happen with no meaningful conflicts at all. Simply run your automated tests (including the comprehensive integration tests Bullet Train ships with) to make sure everything is still working as it was before.
@@ -57,6 +51,20 @@ git merge bullet-train/main
 ```
 
 It's quite possible you'll get some merge conflicts at this point. No big deal! Just go through and resolve them like you would if you were integrating code from another developer on your team. We tend to comment our code heavily, but if you have any questions about the code you're trying to understand, let us know on Discord!
+
+One of the files that's likely to have conflicts, and which can be the most frustrating to resolve is
+`Gemfile.lock`. You can try to sort it out by hand, or you can checkout a clean copy and then let bundler
+generate a new one that matches what you need:
+
+```
+git checkout HEAD -- Gemfile.lock
+bundle update
+```
+
+If you choose to sort out `Gemfile.lock` by hand it's a good idea to run `bundle install` just to make
+sure that your `Gemfile.lock` agrees with the new state of `Gemfile`.
+
+Once you've resolved all the conflicts go ahead and commit the changes.
 
 ```
 git diff


### PR DESCRIPTION
Fixes #470 

Related to #529 & https://github.com/bullet-train-co/bullet_train/pull/968

## Notes for reviewers:

This is currently a "forward looking" PR that is making some assumptions about a future state of affairs. I'm assuming that we'll end up merging #529 & https://github.com/bullet-train-co/bullet_train/pull/968, and I'm assuming that those will mark the `1.4.0` release.

Once those are merged (and once we're a little ways down the road, to `1.4.1` and beyond) we'll have a few scenarios that we should cover as far as upgrading:

* Apps currently on `1.2.x` (or earlier) could either
    * upgrade to `1.3.0` and then do stepwise upgrades through `1.3.x` until they get to `1.4.0`
    * upgrade directly to `1.4.0` and do stepwise from there
    * upgrade directly to `latest`
* Apps currently on `1.3.x` could either
    * do stepwise upgrades through `1.3.x` until they get to `1.4.0`
    * upgrade directly to `1.4.0` and do stepwise from there
    * upgrade directly to `latest`
* Apps currently on `1.4.x` could either
    * do stepwise upgrades through `1.4.x`
    * upgrade directly to `latest`

I've attempted to cover all of these scenarios. All of the scenarios are pretty similar, but in the places where they differ they're pretty big differences. I opted to duplicate some info in order to have each scenario documented in a way that can be read through top to bottom and is internally consistent. I thought that a bit of duplication would be better than trying to cram everything into one giant list that would then have a bunch of "If you're on x.x.x and moving to y.y.y do this, but if you're on y.y.y and moving to z.z.z then do that".