### PR TITLE
Fix unneccessary removal in eject theme task

### DIFF
--- a/bullet_train-themes-light/lib/tasks/application.rb
+++ b/bullet_train-themes-light/lib/tasks/application.rb
@@ -75,8 +75,8 @@ module BulletTrain
         data_to_skip =
           msmn.method_calls(name: "require") +
           msmn.method_calls(name: "mattr_accessor") +
-          msmn.comments.select{|comment| comment[:token].match?("TODO")}
-        lines_to_skip = data_to_skip.map {|data| data[:line_number] - 1}
+          msmn.comments.select { |comment| comment[:token].match?("TODO") }
+        lines_to_skip = data_to_skip.map { |data| data[:line_number] - 1 }
         new_lines = theme_file.readlines.select.with_index do |line, idx|
           line if !lines_to_skip.include?(idx) || line.match?("mattr_accessor :colors")
         end.compact

--- a/bullet_train-themes-light/lib/tasks/application.rb
+++ b/bullet_train-themes-light/lib/tasks/application.rb
@@ -78,8 +78,8 @@ module BulletTrain
           msmn.comments.select { |comment| comment[:token].match?("TODO") }
         lines_to_skip = data_to_skip.map { |data| data[:line_number] - 1 }
         new_lines = theme_file.readlines.select.with_index do |line, idx|
-          line if !lines_to_skip.include?(idx) || line.match?("mattr_accessor :colors")
-        end.compact
+          !lines_to_skip.include?(idx) || line.match?("mattr_accessor :colors")
+        end
         theme_file.write new_lines.join
 
         `standardrb --fix #{target_path}`


### PR DESCRIPTION
When ejecting a new theme, we run this code on [bullet_train-themes-light/lib/bullet_train/themes/light.rb](https://github.com/bullet-train-co/bullet_train-core/blob/main/bullet_train-themes-light/lib/bullet_train/themes/light.rb) in the eject task:

https://github.com/bullet-train-co/bullet_train-core/blob/3b9366861f767fad751372c5e46a01becc8e7835/bullet_train-themes-light/lib/tasks/application.rb#L72-L75

This was removing `mattr_accessor :colors` which we want to stay, so it was causing a syntax error when trying to access the application after ejecting a custom theme:

```
rake bullet_train:themes:light:eject[foo]
```

<img width="1050" alt="スクリーンショット 2023-09-08 20 23 05" src="https://github.com/bullet-train-co/bullet_train-core/assets/10546292/b67121a2-3abe-49a1-8ce3-7ed8572c4010">

## The Fix
I used Masamune again, especially because we introduced it in the same file in #312, but we can do this with just Pathname if we want to (I'm open either way):

```ruby
# Something like this, although I haven't tried it yet locally.
theme_file = Pathname.new(target_path)
new_lines = theme_file.readlines.select do |line|
  !line.match?(/require|mattr_accessor|TODO/) || line.match?(/mattr_accessor :colors/)
end
theme_file.write new_lines.join
```