### PR TITLE
Add gem version to original path for `bin/hack --link`

### DIFF
--- a/bullet_train/lib/tasks/bullet_train_tasks.rake
+++ b/bullet_train/lib/tasks/bullet_train_tasks.rake
@@ -263,7 +263,7 @@ namespace :bullet_train do
     version_regexp = /^[\d|.]$/
 
     packages.each do |package|
-      original_path = "gem \"#{package}\""
+      original_path = "gem \"#{package}\", BULLET_TRAIN_VERSION"
       local_path = "gem \"#{package}\", path: \"local/bullet_train-core/#{package}\""
       match_found = false
 


### PR DESCRIPTION
This is a simple fix, but it ensures our gems are correctly checked out when using `bin/hack --link` and `bin/hack --reset`. Otherwise, we get this error:

```
/home/gazayas/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/dsl.rb:49:in `instance_eval':  (Bundler::Dsl::DSLError)
[!] There was an error parsing `Gemfile`: syntax error, unexpected '\n', expecting => - ...t_train-core/bullet_train-super_scaffolding", BULLET_TRAIN_V...
...                              ^
/home/gazayas/work/bt/bullet_train/Gemfile:109: syntax error, unexpected '\n', expecting =>
...rain-api", BULLET_TRAIN_VERSION
...                               ^
/home/gazayas/work/bt/bullet_train/Gemfile:110: syntax error, unexpected '\n', expecting =>
...core/bullet_train-outgoing_webhooks", BULLET_TRAIN_VERSION
...                              ^
/home/gazayas/work/bt/bullet_train/Gemfile:111: syntax error, unexpected '\n', expecting =>
...webhooks", BULLET_TRAIN_VERSION

...
```