### PR TITLE
Ship controller test for released versions of incoming webhooks gem

### DIFF
--- a/bullet_train-incoming_webhooks/bullet_train-incoming_webhooks.gemspec
+++ b/bullet_train-incoming_webhooks/bullet_train-incoming_webhooks.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   # spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
+    Dir["{app,config,db,lib}/**/*", "test/controllers/webhooks/incoming/bullet_train_webhooks_controller_test.rb", "MIT-LICENSE", "Rakefile", "README.md"]
   end
 
   spec.add_dependency "rails", ">= 6.0.0"

--- a/bullet_train-incoming_webhooks/lib/scaffolding/incoming_webhooks_transformer.rb
+++ b/bullet_train-incoming_webhooks/lib/scaffolding/incoming_webhooks_transformer.rb
@@ -10,15 +10,10 @@ class Scaffolding::IncomingWebhooksTransformer < Scaffolding::Transformer
   end
 
   def scaffold_incoming_webhook
-    gem_path = `bundle show bullet_train-incoming_webhooks`.chomp
-
     files = [
-      # Files in the starter repository.
       "./app/models/webhooks/incoming/bullet_train_webhook.rb",
       "./app/controllers/webhooks/incoming/bullet_train_webhooks_controller.rb",
-
-      # Files in bullet_train-incoming_webhooks.
-      "#{gem_path}/test/controllers/webhooks/incoming/bullet_train_webhooks_controller_test.rb"
+      "./test/controllers/webhooks/incoming/bullet_train_webhooks_controller_test.rb"
     ]
 
     files.each do |name|

--- a/bullet_train-incoming_webhooks/lib/scaffolding/incoming_webhooks_transformer.rb
+++ b/bullet_train-incoming_webhooks/lib/scaffolding/incoming_webhooks_transformer.rb
@@ -10,10 +10,15 @@ class Scaffolding::IncomingWebhooksTransformer < Scaffolding::Transformer
   end
 
   def scaffold_incoming_webhook
+    gem_path = `bundle show bullet_train-incoming_webhooks`.chomp
+
     files = [
+      # Files in the starter repository.
       "./app/models/webhooks/incoming/bullet_train_webhook.rb",
       "./app/controllers/webhooks/incoming/bullet_train_webhooks_controller.rb",
-      "./test/controllers/webhooks/incoming/bullet_train_webhooks_controller_test.rb"
+
+      # Files in bullet_train-incoming_webhooks.
+      "#{gem_path}/test/controllers/webhooks/incoming/bullet_train_webhooks_controller_test.rb"
     ]
 
     files.each do |name|


### PR DESCRIPTION
Joint PR
- https://github.com/bullet-train-co/bullet_train/pull/985

This file ejection logic was working fine when using a local version of `bullet_train-incoming_webhooks`, but the gem doesn't ship with the controller test, so the scaffolder was trying to copy a template that wasn't there. This PR ensures we ship the template so the scaffolder will work properly.