### PR TITLE
Update the upgrading documentation concerning ejected views

### DIFF
--- a/bullet_train/docs/upgrades.md
+++ b/bullet_train/docs/upgrades.md
@@ -68,7 +68,7 @@ git checkout -b updating-bullet-train-1.4.1
 
 ### 5. Merge in the newest stuff from Bullet Train and resolve any merge conflicts.
 
-Each version of the starter repo is tagged, so you can merge in the tag from the upstread repo.
+Each version of the starter repo is tagged, so you can merge in the tag from the upstream repo.
 
 ```
 git merge v1.4.1
@@ -116,5 +116,5 @@ git branch -d updating-bullet-train-1.4.1
 ```
 
 Alternatively, if you're using GitHub, you can push the `updating-bullet-train-1.4.1` branch up and create a
-PR from it and let your CI integration do it's thing and then merge in the PR and delete the branch there.
+PR from it and let your CI integration do its thing and then merge in the PR and delete the branch there.
 (That's what we typically do.)

--- a/bullet_train/docs/upgrades.md
+++ b/bullet_train/docs/upgrades.md
@@ -30,6 +30,8 @@ recent version of the starter repository should cause a merge conflict in Git. T
 opportunity to compare our upstream changes with your local customizations and allow you to resolve them in a way that makes sense for
 your application.
 
+⚠️ If you have ejected files or a new custom theme, there is a possibility that those ejected files need to be updated although no merge conflicts arose from `git merge`. You will need to compare your ejected views with the original views in [bullet_train-core](https://github.com/bullet-train-co/bullet_train-core) to ensure everything is working properly. Please refer to the documentation on [indirection](indirection) to find out more about ejected views.
+
 ### 1. Decide which version you want to upgrade to
 
 For the purposes of these instructions we'll assume that you're on version `1.4.0` and are going to upgrade to version `1.4.1`.

--- a/bullet_train/docs/upgrades/yolo-130.md
+++ b/bullet_train/docs/upgrades/yolo-130.md
@@ -272,7 +272,7 @@ If anything fails, investigate the failures and get things working again, and co
 git checkout main
 git merge updating-bullet-train-v1.3.1
 git push origin main
-git branch -d updating-bullet-train-v1.3.1`
+git branch -d updating-bullet-train-v1.3.1
 ```
 
-Alternatively, if you're using GitHub, you can push the `updating-bullet-train-v1.3.1` branch up and create a PR from it and let your CI integration do it's thing and then merge in the PR and delete the branch there. (That's what we typically do.)
+Alternatively, if you're using GitHub, you can push the `updating-bullet-train-v1.3.1` branch up and create a PR from it and let your CI integration do its thing and then merge in the PR and delete the branch there. (That's what we typically do.)

--- a/bullet_train/docs/upgrades/yolo-140.md
+++ b/bullet_train/docs/upgrades/yolo-140.md
@@ -84,11 +84,11 @@ If anything fails, investigate the failures and get things working again, and co
 
 ```
 git checkout main
-git merge updating-bullet-train-v1.3.0
+git merge updating-bullet-train-v1.4.0
 git push origin main
-git branch -d updating-bullet-train-v1.3.0
+git branch -d updating-bullet-train-v1.4.0
 ```
 
-Alternatively, if you're using GitHub, you can push the `updating-bullet-train-v1.3.0` branch up and create a PR from it and let your CI integration do it's thing and then merge in the PR and delete the branch there. (That's what we typically do.)
+Alternatively, if you're using GitHub, you can push the `updating-bullet-train-v1.4.0` branch up and create a PR from it and let your CI integration do it's thing and then merge in the PR and delete the branch there. (That's what we typically do.)
 
 


### PR DESCRIPTION
I didn't write a review on #532, but I read through the new documentation to upgrade a personal Bullet Train application I'm working on to 1.4.3, and the process went smoothly 🚀

One thing I noticed was that if you're upgrading to a new version and you have an ejected theme, no merge conflicts arise for those ejected themes because they're originally from `bullet_train-core` and not the starter repository. I struggled for a while trying to find out why my tests weren't passing although everything was working fine on the starter repository. I eventually found out it was because my ejected files hadn't been updated (specifically `_date_and_time.html.erb` and `_date.html.erb` since we updated the daterangepicker logic recently), so I had to manually copy and paste the contents from `bullet_train-core` to get my tests working again.

Since I usually work on the starter repository itself day to day it wasn't difficult for me to compare the tests there with my Bullet Train app, but I think most developers will only create a new app and not have a local setup of just the raw starter repository on their machine. For that reason they'll only have the context of their personal app, look at the tests and perhaps simply think that the new version is broken, or that they took a wrong step in resolving merge conflicts. I added this comment to the upgrading documentation to guide developers to review `bullet_train-core` just in case if they ejected files which may be outdated.

I also think we should write the comment at the top of ejected files more specifically. For example:

```
> bin/resolve shared/attributes/date --eject
```

```
<% # What currently gets written to ejected files %>
<% # Ejected from `bullet_train-themes-1.4.3`. %>

<% # What we should write %>
<%# Ejected from bullet_train-themes-1.4.3/app/views/themes/base/attributes/_date.html.erb #>
```

It should also be noted that we don't write **ANY** comment at all to ejected views when ejecting the files for a new theme:
```
> rake bullet_train:themes:light:eject[foo]
```

Lastly, I also fixed some typos along the way.