### PR TITLE
Write more detailed path in comment when ejecting views

### DIFF
--- a/bullet_train/lib/bullet_train/resolver.rb
+++ b/bullet_train/lib/bullet_train/resolver.rb
@@ -11,12 +11,16 @@ module BulletTrain
     def run(eject: false, open: false, force: false, interactive: false)
       # Try to figure out what kind of thing they're trying to look up.
       source_file = calculate_source_file_details
+      source_file[:relative_path] = nil
 
       if source_file[:absolute_path]
         puts ""
         puts "Absolute path:".green
         puts "  #{source_file[:absolute_path]}".green
         puts ""
+
+        source_file[:relative_path] = source_file[:absolute_path].split(/(?=#{source_file[:package_name]})/).pop
+
         if source_file[:package_name].present?
           puts "Package name:".green
           puts "  #{source_file[:package_name]}".green
@@ -44,9 +48,9 @@ module BulletTrain
               File.open((source_file[:project_path]).to_s, "w+") do |file|
                 case source_file[:project_path].split(".").last
                 when "rb", "yml"
-                  file.puts "# Ejected from `#{source_file[:package_name]}`.\n\n"
+                  file.puts "# Ejected from `#{source_file[:relative_path] || source_file[:package_name]}`.\n\n"
                 when "erb"
-                  file.puts "<% # Ejected from `#{source_file[:package_name]}`. %>\n\n"
+                  file.puts "<% # Ejected from `#{source_file[:relative_path] || source_file[:package_name]}`. %>\n\n"
                 end
               end
               `cat #{source_file[:absolute_path]} >> #{source_file[:project_path]}`.strip

--- a/bullet_train/lib/tasks/bullet_train_tasks.rake
+++ b/bullet_train/lib/tasks/bullet_train_tasks.rake
@@ -102,6 +102,10 @@ namespace :bullet_train do
             puts "Ejecting #{path_in_locale}..."
             File.new("config/locales#{path_in_locale}", "w")
             `cp #{locale} config/locales#{path_in_locale}`
+            file = Pathname.new("config/locales#{path_in_locale}")
+            lines = file.readlines
+            lines.unshift("# Ejected from #{relative_path}\n\n")
+            file.write(lines.join)
           end
         end
       end

--- a/bullet_train/lib/tasks/bullet_train_tasks.rake
+++ b/bullet_train/lib/tasks/bullet_train_tasks.rake
@@ -87,15 +87,15 @@ namespace :bullet_train do
 
         puts "Found locales. Ejecting to your application...".green
         locales.each do |locale|
-          relative_path = locale.split("/config/locales").pop
-          path_parts = relative_path.split("/")
+          path_in_locale = locale.split("/config/locales").pop
+          path_parts = path_in_locale.split("/")
           base_path = path_parts.join("/")
           FileUtils.mkdir_p("./config/locales#{base_path}") unless Dir.exist?("./config/locales#{base_path}")
 
-          unless File.exist?("config/locales#{relative_path}")
-            puts "Ejecting #{relative_path}..."
-            File.new("config/locales#{relative_path}", "w")
-            `cp #{locale} config/locales#{relative_path}`
+          unless File.exist?("config/locales#{path_in_locale}")
+            puts "Ejecting #{path_in_locale}..."
+            File.new("config/locales#{path_in_locale}", "w")
+            `cp #{locale} config/locales#{path_in_locale}`
           end
         end
       end

--- a/bullet_train/lib/tasks/bullet_train_tasks.rake
+++ b/bullet_train/lib/tasks/bullet_train_tasks.rake
@@ -82,15 +82,21 @@ namespace :bullet_train do
       gem_names.each do |gem|
         puts "Searching for locales in #{gem}...".blue
         gem_path = `bundle show #{gem}`.chomp
+        gem_with_version = gem_path.split("/").last
         locales = Dir.glob("#{gem_path}/**/config/locales/**/*.yml").reject { |path| path.match?("dummy") }
         next if locales.empty?
 
         puts "Found locales. Ejecting to your application...".green
         locales.each do |locale|
+          relative_path = locale.split(/(?=#{gem_with_version}\/config\/locales)/).last
           path_in_locale = locale.split("/config/locales").pop
-          path_parts = path_in_locale.split("/")
-          base_path = path_parts.join("/")
-          FileUtils.mkdir_p("./config/locales#{base_path}") unless Dir.exist?("./config/locales#{base_path}")
+
+          base_path = relative_path.split("/")
+          base_path.pop
+          base_path = base_path.join("/")
+          starter_repo_locale_path = base_path.gsub(gem_with_version, ".")
+
+          FileUtils.mkdir_p(starter_repo_locale_path) unless Dir.exist?(starter_repo_locale_path)
 
           unless File.exist?("config/locales#{path_in_locale}")
             puts "Ejecting #{path_in_locale}..."


### PR DESCRIPTION
Closes #557, related to #558.

# Changes
1. **`bin/resolve`**: Write a detailed path instead of just a package name when ejecting files (i.e. - `bin/resolve shared/attributes/date --eject`).
2. **`rake bullet_train:themes:light:eject[foo]`**: Ensure the path ejected files are coming from are written as a comment when ejecting a new theme.
3. **`rake bullet_train:eject[locales]`**: Do the same thing for the `eject[locales]` task.