### PR TITLE
Change `bundle update` => `bundle install` in upgrade instructions

### DIFF
--- a/bullet_train/docs/upgrades/yolo-130.md
+++ b/bullet_train/docs/upgrades/yolo-130.md
@@ -136,7 +136,7 @@ gem "bullet_train-themes-tailwind_css", BULLET_TRAIN_VERSION
 (We have to do this since we didn't start explicitly tracking versions until `1.4.0` and
 want to make sure that our gem versions match what the starter repo expects.)
 
-Then run `bundle update`
+Then run `bundle install`
 
 Then go ahead and commit the changes.
 
@@ -247,7 +247,7 @@ BULLET_TRAIN_VERSION = "1.3.1"
 (We have to do this since we didn't start explicitly tracking versions until `1.4.0` and
 want to make sure that our gem versions match what the starter repo expects.)
 
-Then run `bundle update`
+Then run `bundle install`
 
 Then go ahead and commit the changes.
 

--- a/bullet_train/docs/upgrades/yolo-140.md
+++ b/bullet_train/docs/upgrades/yolo-140.md
@@ -57,7 +57,7 @@ generate a new one that matches what you need:
 
 ```
 git checkout HEAD -- Gemfile.lock
-bundle update
+bundle install
 ```
 
 If you choose to sort out `Gemfile.lock` by hand it's a good idea to run `bundle install` just to make


### PR DESCRIPTION
Fixes https://github.com/bullet-train-co/bullet_train-core/issues/540

This will minimize the chances for unintended updates to gems that don't have a version specified in `Gemfile`.