### PR TITLE
Add a `default_message` option to the `days_ago` attribute partial

### DIFF
--- a/bullet_train-themes/app/views/themes/base/attributes/_days_ago.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_days_ago.html.erb
@@ -1,11 +1,12 @@
 <% object ||= current_attributes_object %>
 <% strategy ||= current_attributes_strategy || :none %>
 <% url ||= nil %>
+<% default_message = local_assigns[:default_message] || t("global.never") %>
 
 <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
-  <% if object.send(attribute) %>
+  <% if object.public_send(attribute) %>
     <%= t("global.time_ago", time: time_ago_in_words(object.send(attribute))) %>
   <% else %>
-    <%= t("global.never") %>
+    <%= default_message %>
   <% end %>
 <% end %>


### PR DESCRIPTION
This allows you to control what is displayed in the event that the date attribute in question is blank.

For instance, if you wanted to have a single instance of `days_ago` that would dispaly "Not even once" when the `selected_at` attribute is blank you could call the partial like this:

```erb
<%= render 'shared/attributes/days_ago',
      attribute: :selected_at,
      default_message: "Not even once"
%>
```

(The `global.never` translation string will be used if a `default_message` is not explicitly passed in.)

Fixes https://github.com/bullet-train-co/bullet_train-core/issues/560