### PR TITLE
[relese process] Make the bin scripts smarter and more flexible

### DIFF
--- a/bin/bump-all
+++ b/bin/bump-all
@@ -97,34 +97,11 @@ class CoreBumpCLI < Thor
     end
 
     def ruby_gems
-      %w(
-        bullet_train
-        bullet_train-api
-        bullet_train-fields
-        bullet_train-has_uuid
-        bullet_train-incoming_webhooks
-        bullet_train-integrations
-        bullet_train-integrations-stripe
-        bullet_train-obfuscates_id
-        bullet_train-outgoing_webhooks
-        bullet_train-roles
-        bullet_train-scope_questions
-        bullet_train-scope_validator
-        bullet_train-sortable
-        bullet_train-super_load_and_authorize_resource
-        bullet_train-super_scaffolding
-        bullet_train-themes
-        bullet_train-themes-light
-        bullet_train-themes-tailwind_css
-      )
+      Dir.glob("*/*.gemspec").map{|gemspec| gemspec.split("/").first }
     end
 
     def npm_packages
-      %w(
-        bullet_train
-        bullet_train-fields
-        bullet_train-sortable
-      )
+      Dir.glob("*/package.json").map{|gemspec| gemspec.split("/").first }
     end
   end
 end

--- a/bin/release-all
+++ b/bin/release-all
@@ -95,34 +95,11 @@ class CoreBumpCLI < Thor
     end
 
     def ruby_gems
-      %w(
-        bullet_train
-        bullet_train-api
-        bullet_train-fields
-        bullet_train-has_uuid
-        bullet_train-incoming_webhooks
-        bullet_train-integrations
-        bullet_train-integrations-stripe
-        bullet_train-obfuscates_id
-        bullet_train-outgoing_webhooks
-        bullet_train-roles
-        bullet_train-scope_questions
-        bullet_train-scope_validator
-        bullet_train-sortable
-        bullet_train-super_load_and_authorize_resource
-        bullet_train-super_scaffolding
-        bullet_train-themes
-        bullet_train-themes-light
-        bullet_train-themes-tailwind_css
-      )
+      Dir.glob("*/*.gemspec").map{|gemspec| gemspec.split("/").first }
     end
 
     def npm_packages
-      %w(
-        bullet_train
-        bullet_train-fields
-        bullet_train-sortable
-      )
+      Dir.glob("*/package.json").map{|gemspec| gemspec.split("/").first }
     end
   end
 end


### PR DESCRIPTION
This replaces a few hard coded lists of packages with a more flexible method. This makes it so that we won't have to remember to add packages to these lists in the future when we create new BT packages.

Fixes https://github.com/bullet-train-co/bullet_train-core/issues/422