### PR TITLE
Add Delete Team button

### DIFF
--- a/bullet_train/app/controllers/concerns/account/teams/controller_base.rb
+++ b/bullet_train/app/controllers/concerns/account/teams/controller_base.rb
@@ -110,13 +110,20 @@ module Account::Teams::ControllerBase
 
   # # DELETE /teams/1
   # # DELETE /teams/1.json
-  # def destroy
-  #   @team.destroy
-  #   respond_to do |format|
-  #     format.html { redirect_to account_teams_url, notice: 'Team was successfully destroyed.' }
-  #     format.json { head :no_content }
-  #   end
-  # end
+  def destroy
+    if current_user.teams.size == 1
+      respond_to do |format|
+        format.html { redirect_to edit_account_team_url(@team), alert: t("account.teams.notifications.cannot_delete_last_team") }
+        format.json { head :no_content }
+      end
+    else
+      @team.destroy
+      respond_to do |format|
+        format.html { redirect_to account_teams_url, notice: t("account.teams.notifications.destroyed") }
+        format.json { head :no_content }
+      end
+    end
+  end
 
   private
 

--- a/bullet_train/app/views/account/teams/_form.html.erb
+++ b/bullet_train/app/views/account/teams/_form.html.erb
@@ -17,6 +17,9 @@
 
   <div class="buttons">
     <%= form.submit (form.object.persisted? ? t('.buttons.update') : t('.buttons.create')), class: "button" %>
+    <% if controller.action_name == "edit" %>
+      <%= link_to t('account.teams.buttons.destroy'), [:account, team], method: :delete, data: { confirm: t('account.teams.buttons.confirmations.destroy') } %>
+    <% end %>
     <%= link_to t('global.buttons.cancel'), form.object.persisted? ? [:account, team] : [:account, :teams], class: "button-secondary" %>
   </div>
 <% end %>

--- a/bullet_train/config/locales/en/teams.en.yml
+++ b/bullet_train/config/locales/en/teams.en.yml
@@ -13,6 +13,9 @@ en:
       create: Create Team
       edit: Edit Team
       update: Update Team
+      destroy: Delete Team
+      confirmations:
+        destroy: Are you sure you want to delete this team?
     index:
       section: Teams
       header: Your Teams
@@ -40,7 +43,9 @@ en:
     notifications:
       created: Team was successfully created.
       updated: Team was successfully updated.
+      destroyed: Team was successfully destroyed.
       invitation_only: Creating new teams is currently limited to users who have been invited for early access. If you've received an early access URL, please visit it before trying again.
+      cannot_delete_last_team: You cannot delete the last team you belong to.
     form:
       buttons: *buttons
     fields: &fields


### PR DESCRIPTION
This doesn't close #231 because that one deals with a foreign key issue with Memberships, but this at least sets us up so we can delete teams. If we're okay with this, I'll try to figure out the foreign key issue too.

Joint PR
- https://github.com/bullet-train-co/bullet_train/pull/1023
