### PR TITLE
Fix Membership foreign key constraint for Team deletion, refactor Team deletion logic

### DIFF
--- a/bullet_train/app/controllers/concerns/account/teams/controller_base.rb
+++ b/bullet_train/app/controllers/concerns/account/teams/controller_base.rb
@@ -111,17 +111,14 @@ module Account::Teams::ControllerBase
   # # DELETE /teams/1
   # # DELETE /teams/1.json
   def destroy
-    if current_user.teams.size == 1
-      respond_to do |format|
-        format.html { redirect_to edit_account_team_url(@team), alert: t("account.teams.notifications.cannot_delete_last_team") }
-        format.json { head :no_content }
-      end
-    else
+    respond_to do |format|
+      raise RemovingLastTeamException if current_user.one_team?
       @team.destroy
-      respond_to do |format|
-        format.html { redirect_to account_teams_url, notice: t("account.teams.notifications.destroyed") }
-        format.json { head :no_content }
-      end
+      format.html { redirect_to account_teams_url, notice: t("account.teams.notifications.destroyed") }
+      format.json { head :no_content }
+    rescue RemovingLastTeamException => _
+      format.html { redirect_to edit_account_team_url(@team), alert: t("account.teams.notifications.cannot_delete_last_team") }
+      format.json { head :no_content }
     end
   end
 

--- a/bullet_train/app/models/concerns/teams/base.rb
+++ b/bullet_train/app/models/concerns/teams/base.rb
@@ -7,6 +7,10 @@ module Teams::Base
       has_many :scaffolding_absolutely_abstract_creative_concepts, class_name: "Scaffolding::AbsolutelyAbstract::CreativeConcept", dependent: :destroy, enable_cable_ready_updates: true
     end
 
+    # added_by_id is a foreign_key to other Memberships on the same team,
+    # so we nullify this to remove the constraint to delete the team.
+    before_destroy { Membership.where(team: self).update_all(added_by_id: nil) }
+
     # memberships and invitations
     has_many :memberships, dependent: :destroy
     has_many :users, through: :memberships


### PR DESCRIPTION
Joint PR
- https://github.com/bullet-train-co/bullet_train/pull/1027

I feel much better adding this `RemovingLastTeamException` class (refer to [this comment](https://github.com/bullet-train-co/bullet_train-core/pull/570#discussion_r1334145101))

In the comment in Discord linked in #231 there was the following code which the developer had placed in their Membership model:
```ruby
before_destroy do  
  Membership.where(added_by_id: self.id).update_all(added_by_id: nil)       
end
```

This, however, was before we implemented any Team deletion logic, so instead of calling this for every Membership that's being deleted, I just call the `before_destroy` callback once in the Team model instead.

cc/ @brennanlawrence Tagging you in case you had any better suggestions, or if there were any underlying issues you think we should be aware of.