### PR TITLE
Display Bullet Train version in Showcase

### DIFF
--- a/bullet_train-themes-light/app/views/showcase/engine/_head.html.erb
+++ b/bullet_train-themes-light/app/views/showcase/engine/_head.html.erb
@@ -45,8 +45,10 @@
 </script>
 
 <template id="bullet_train_theme_selects">
-  <section class="border-t w-full p-4 flex justify-end left-0 bottom-0 fixed bg-white dark:sc-bg-neutral-900" id="bt-theme-selector">
-    <h3 class="pt-2">Bullet Train Light theme options</h3>
+  <section class="border-t w-full p-4 flex space-between left-0 bottom-0 fixed bg-white dark:sc-bg-neutral-900" id="bt-theme-selector">
+    <span class="block pt-2 flex-grow">BulletTrain <%= BulletTrain::VERSION %></span>
+
+    <h3 class="pt-2">Light Theme options</h3>
 
     <div>
       <label for="bullet_train_color" class="pl-4">Color</label>


### PR DESCRIPTION
Fixes https://github.com/bullet-train-co/showcase/issues/75

Now it looks like this:

<img width="1110" alt="Screenshot 2023-09-26 at 19 35 34" src="https://github.com/bullet-train-co/bullet_train-core/assets/350807/ba7d5fdb-88d9-46e3-8fce-f20e7e3c2d84">
