### PR TITLE
Eject showcase preview when ejecting partials

### DIFF
--- a/bullet_train-themes-light/lib/tasks/application.rb
+++ b/bullet_train-themes-light/lib/tasks/application.rb
@@ -36,6 +36,8 @@ module BulletTrain
           "bullet_train-themes-light" => "light"
         }.each do |gem, theme_name|
           gem_path = `bundle show --paths #{gem}`.chomp
+          showcase_partials = Dir.glob("#{gem_path}/app/views/showcase/**/*.html.erb")
+
           `find #{gem_path}/app/views/themes`.lines.map(&:chomp).each do |file_or_directory|
             target_file_or_directory = file_or_directory.gsub(gem_path, "").gsub("/#{theme_name}", "/#{ejected_theme_name}")
             target_file_or_directory = Rails.root.to_s + target_file_or_directory
@@ -48,6 +50,28 @@ module BulletTrain
               `cp #{file_or_directory} #{target_file_or_directory}`
               gem_with_version = gem_path.split("/").last
               new_files[target_file_or_directory] = file_or_directory.split(/(?=#{gem_with_version})/).last
+            end
+
+            # Look for showcase preview.
+            file_name = target_file_or_directory.split("/").last
+            has_showcase_preview = false
+            showcase_preview = nil
+            showcase_partials.each do |partial|
+              has_showcase_preview = partial.match?(/#{file_name}$/)
+              if has_showcase_preview
+                showcase_preview = partial
+                break
+              end
+            end
+
+            if has_showcase_preview
+              puts "Ejecting showcase preview for #{target_file_or_directory}"
+              partial_relative_path = showcase_preview.scan(/(?=app\/views\/showcase).*/).last
+              directory = partial_relative_path.split("/")[0..-2].join("/")
+              FileUtils.mkdir_p(directory)
+              FileUtils.touch(partial_relative_path)
+              `cp #{showcase_preview} #{partial_relative_path}`
+              new_files[partial_relative_path] = showcase_preview
             end
           end
         end

--- a/bullet_train/lib/bullet_train/resolver.rb
+++ b/bullet_train/lib/bullet_train/resolver.rb
@@ -54,6 +54,28 @@ module BulletTrain
                 end
               end
               `cat #{source_file[:absolute_path]} >> #{source_file[:project_path]}`.strip
+
+              # Look for showcase preview.
+              file_name = source_file[:absolute_path].split("/").last
+              showcase_partials = Dir.glob(`bundle show bullet_train-themes-light`.chomp + "/app/views/showcase/**/*.html.erb")
+              has_showcase_partial = false
+              showcase_partial = nil
+              showcase_partials.each do |partial|
+                has_showcase_preview = partial.match?(/#{file_name}$/)
+                if has_showcase_preview
+                  showcase_partial = partial
+                  break
+                end
+              end
+
+              if has_showcase_partial
+                puts "Ejecting showcase preview for #{source_file[:relative_path]}"
+                partial_relative_path = showcase_preview.scan(/(?=app\/views\/showcase).*/).last
+                directory = partial_relative_path.split("/")[0..-2].join("/")
+                FileUtils.mkdir_p(directory)
+                FileUtils.touch(partial_relative_path)
+                `cp #{showcase_preview} #{partial_relative_path}`
+              end
             end
 
             # Just in case they try to open the file, open it from the new location.


### PR DESCRIPTION
Closes #576.

I know there's duplicate code here, but we don't currently use the `eject` logic that lives within `BulletTrain::Resolver` when ejecting an entire theme (the ejection logic [there](https://github.com/bullet-train-co/bullet_train-core/blob/4a5818ed1b10893ddf1ebd8198fdb91269610932/bullet_train-themes-light/lib/tasks/application.rb#L6) is all inline).
