### PR TITLE
Refactor showcase partial lookup when ejecting files

### DIFF
--- a/bullet_train-themes-light/lib/tasks/application.rb
+++ b/bullet_train-themes-light/lib/tasks/application.rb
@@ -54,17 +54,8 @@ module BulletTrain
 
             # Look for showcase preview.
             file_name = target_file_or_directory.split("/").last
-            has_showcase_preview = false
-            showcase_preview = nil
-            showcase_partials.each do |partial|
-              has_showcase_preview = partial.match?(/#{file_name}$/)
-              if has_showcase_preview
-                showcase_preview = partial
-                break
-              end
-            end
-
-            if has_showcase_preview
+            showcase_preview = showcase_partials.find { _1.end_with?(file_name) }
+            if showcase_preview
               puts "Ejecting showcase preview for #{target_file_or_directory}"
               partial_relative_path = showcase_preview.scan(/(?=app\/views\/showcase).*/).last
               directory = partial_relative_path.split("/")[0..-2].join("/")

--- a/bullet_train/lib/bullet_train/resolver.rb
+++ b/bullet_train/lib/bullet_train/resolver.rb
@@ -58,17 +58,8 @@ module BulletTrain
               # Look for showcase preview.
               file_name = source_file[:absolute_path].split("/").last
               showcase_partials = Dir.glob(`bundle show bullet_train-themes-light`.chomp + "/app/views/showcase/**/*.html.erb")
-              has_showcase_partial = false
-              showcase_partial = nil
-              showcase_partials.each do |partial|
-                has_showcase_preview = partial.match?(/#{file_name}$/)
-                if has_showcase_preview
-                  showcase_partial = partial
-                  break
-                end
-              end
-
-              if has_showcase_partial
+              showcase_preview = showcase_partials.find { _1.end_with?(file_name) }
+              if showcase_preview
                 puts "Ejecting showcase preview for #{source_file[:relative_path]}"
                 partial_relative_path = showcase_preview.scan(/(?=app\/views\/showcase).*/).last
                 directory = partial_relative_path.split("/")[0..-2].join("/")


### PR DESCRIPTION
This PR refactors the showcase partial lookup logic as per @kaspth's [comment](https://github.com/bullet-train-co/bullet_train-core/pull/579#discussion_r1339416134) in #579.

I also have a question after looking at the starter repository.

Say we eject a custom theme with `rake bullet_train:themes:light:eject[foo]`. All of the partials that show up in the application are ejected to `app/views/themes/foo`. However, when we eject the showcase files, they get ejected to `app/views/showcase` and don't show up within the `foo` theme. Is this what we want? Do we want the showcase partials to be theme-specific?