### PR TITLE
Fix docs to use `bundle install` instead of `bundle update`

### DIFF
--- a/bullet_train/docs/upgrades.md
+++ b/bullet_train/docs/upgrades.md
@@ -85,7 +85,7 @@ generate a new one that matches what you need:
 
 ```
 git checkout HEAD -- Gemfile.lock
-bundle update
+bundle install
 ```
 
 If you choose to sort out `Gemfile.lock` by hand it's a good idea to run `bundle install` just to make

--- a/bullet_train/docs/upgrades/yolo.md
+++ b/bullet_train/docs/upgrades/yolo.md
@@ -58,7 +58,7 @@ generate a new one that matches what you need:
 
 ```
 git checkout HEAD -- Gemfile.lock
-bundle update
+bundle install
 ```
 
 If you choose to sort out `Gemfile.lock` by hand it's a good idea to run `bundle install` just to make


### PR DESCRIPTION
This will result in a more conservative set of modifications to `Gemfile.lock` and will minimize unexpected updates or other gems.