### PR TITLE
Explicitly declare cancancan dependency for bullet_train-super_load_and_authorize_resource gem

### DIFF
--- a/bullet_train-super_load_and_authorize_resource/bullet_train-super_load_and_authorize_resource.gemspec
+++ b/bullet_train-super_load_and_authorize_resource/bullet_train-super_load_and_authorize_resource.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
     Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   end
 
+  spec.add_dependency "cancancan"
   spec.add_dependency "rails", ">= 6.0.0"
 
   spec.add_development_dependency "pry"


### PR DESCRIPTION
Adds an explicit declaration of the `bullet_train-super_load_and_authorize_resource` gem dependency on `cancancan`.