### PR TITLE
Allow disabling of option and button partials

### DIFF
--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_buttons.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_buttons.html.erb
@@ -1,23 +1,29 @@
 <%
 stimulus_controller = 'fields--button-toggle'
 form ||= current_fields_form
+
+# Initialize options.
 html_options ||= {}
-html_options[:id] ||= form.field_id(method)
-multiple ||= false
+options ||= {}
 other_options ||= {}
-options ||= options_for(form, method)
+button_field_options ||= options_for(form, method)
+
+options.merge!(html_options) # For backwards compatibility.
+options[:id] ||= form.field_id(method)
+
+multiple ||= false
 %>
 
-<% content = render 'shared/fields/field', form: form, method: method, options: html_options, other_options: other_options do %>
+<% content = render 'shared/fields/field', form: form, method: method, options: options, other_options: other_options do %>
   <% content_for :field do %>
     <div>
-      <% options.each do |value, label| %>
+      <% button_field_options.each do |value, label| %>
         <% checked = form.object.send(method).is_a?(Array) ? form.object.send(method).map(&:to_s).include?(value.to_s) : form.object.send(method).to_s == value.to_s  %>
         <label class="btn-toggle" data-controller="<%= stimulus_controller %>">
           <% if multiple %>
-            <%= form.check_box method, {multiple: multiple, checked: checked, data: { "#{stimulus_controller}-target": 'shadowField' }}, value, "" %>
+            <%= form.check_box method, {multiple: multiple, checked: checked, data: { "#{stimulus_controller}-target": 'shadowField' }, **options}, value, "" %>
           <% else %>
-            <%= form.radio_button method, value, { data: { "#{stimulus_controller}-target": 'shadowField' }, checked: checked} %>
+            <%= form.radio_button method, value, { data: { "#{stimulus_controller}-target": 'shadowField' }, checked: checked, **options} %>
           <% end %>
           <button type="button" class="button-alternative mb-1.5 mr-1" data-action="<%= stimulus_controller %>#clickShadowField">
             <%= label %>

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_option.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_option.html.erb
@@ -1,10 +1,19 @@
 <%
 form ||= current_fields_form
+labels = labels_for(form, method) if form
+
+# Initialize options.
+# `options` is initialized in `_options` too,
+# but `_option` can also be rendered by itself.
+# In that case, we need to initialize options here.
+# If `_option` is being called from `_options`,
+# we assume `option_field_options` has already been
+# declared there, so we don't initialize it here.
+options ||= {}
+
 single_check_box ||= false
 multiple ||= false
-option_field_options ||= {}
 append_class ||= ''
-labels = labels_for(form, method) if form
 
 # Since we don't know at this point which tag we'll be using, we specify
 # the class only once here for simplicity and apply it to one of the following tags:
@@ -13,32 +22,32 @@ labels = labels_for(form, method) if form
 # 4. form.radio_button
 #
 # the `append_class` local can be used to append any other styles desired for the element.
-option_field_options[:class] ||= "focus:ring-primary-500 h-4 w-4 text-primary-500 border-slate-300 dark:bg-slate-800 dark:border-slate-900 #{"rounded" if multiple || single_check_box}"
-option_field_options[:class] += " #{append_class}"
+options[:class] ||= "focus:ring-primary-500 h-4 w-4 text-primary-500 border-slate-300 dark:bg-slate-800 dark:border-slate-900 #{"rounded" if multiple || single_check_box}"
+options[:class] += " #{append_class}"
 %>
 
 <% if single_check_box %>
   <% if form %>
     <div class="flex items-center">
-      <%= form.check_box method, option_field_options %>
+      <%= form.check_box method, options %>
       <%= form.label method, class: 'ml-2' %>
     </div>
   <% else %>
-    <% value = option_field_options.delete(:value) %>
-    <% checked = option_field_options.delete(:checked) %>
-    <%= check_box_tag method, value, checked, option_field_options %>
+    <% value = options.delete(:value) %>
+    <% checked = options.delete(:checked) %>
+    <%= check_box_tag method, value, checked, options %>
   <% end %>
 <% else %>
-  <% options.each do |value, label| %>
+  <% option_field_options.each do |value, label| %>
     <label class="relative flex items-start mb-3">
       <div class="flex items-center h-5">
         <% if multiple %>
           <% checked_value = form.object.send(method).nil? ? nil : form.object.send(method).map(&:to_s).include?(value.to_s) %>
           <%= form.check_box method, {
-            multiple: multiple, checked: checked_value, data: option_field_options[:data], class: option_field_options[:class]
+            multiple: multiple, checked: checked_value, **options
           }, value, "" %>
         <% else %>
-          <%= form.radio_button method, value, {class: option_field_options[:class]} %>
+          <%= form.radio_button method, value, **options %>
         <% end %>
       </div>
       <div class="ml-2.5 text-sm">

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_options.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_options.html.erb
@@ -9,27 +9,34 @@ end
 
 <%
 form ||= current_fields_form
+labels = labels_for(form, method)
+
+# Initialize options.
 html_options ||= {}
-html_options[:id] ||= form.field_id(method)
+options ||= {}
+other_options ||= {}
+option_field_options = options_for(form, method)
+
+# For backwards compatibility.
+options.merge!(html_options)
+options.merge!(option_field_options)
+
+options[:id] ||= form.field_id(method)
 multiple ||= false
 show_select_all_top ||= false
 show_select_all_bottom ||= false
 use_columns ||= false
-other_options ||= {}
-options ||= options_for(form, method)
-labels = labels_for(form, method)
 
-option_field_options ||= {}
-option_field_options[:data] ||= {}
-option_field_options[:data][:controller] ||= ""
-option_field_options[:data][:controller] += " fields--field"
+options[:data] ||= {}
+options[:data][:controller] ||= ""
+options[:data][:controller] += " fields--field"
 
 if multiple
-  option_field_options[:data] = option_field_options[:data].merge({
+  options[:data] = options[:data].merge({
     "select-all-target": 'checkbox'
   })
-  option_field_options[:data][:action] ||= ""
-  option_field_options[:data][:action] += " select-all#updateToggle"
+  options[:data][:action] ||= ""
+  options[:data][:action] += " select-all#updateToggle"
 end
 
 %>
@@ -51,10 +58,11 @@ end
       } do %>
         <label class="relative flex items-start">
           <div class="flex items-center h-5">
-            <%= check_box_tag "#{html_options[:id]}-select_all", 'select-all', false, data: {
+            <%= check_box_tag "#{options[:id]}-select_all", 'select-all', false, data: {
               "select-all-target": 'toggleCheckbox',
               'action': "select-all#selectAllOrNone"
-            }, class: "focus:ring-primary-500 h-4 w-4 text-primary-500 border-slate-300 rounded" %>
+            }, class: "focus:ring-primary-500 h-4 w-4 text-primary-500 border-slate-300 rounded",
+            disabled: options[:disabled] %>
           </div>
           <div class="ml-2.5 text-sm pr-4">
             <%= t("global.bulk_select.all") %>
@@ -66,7 +74,7 @@ end
   <% end %>
 <% end %>
 
-<%= render 'shared/fields/field', form: form, method: method, options: html_options, other_options: other_options do %>
+<%= render 'shared/fields/field', form: form, method: method, options: options, other_options: other_options do %>
   <% content_for :field do %>
     <%= tag.div class: "pt-1.5 pb-1 sm:col-span-2", data: {
       controller: "select-all",


### PR DESCRIPTION
Closes #571 and #572.

There were two issues at work here:
1. We weren't passing all of the options to each respective field (only select ones like `class`, `value`, etc.). Therefore, even if we declared `options: {disabled: true}`, it wasn't being passed to the Rails form field.
2. `options` and `html_options` were being used differently depending on the partial.

Concerning the second issue, here is an example of the `date_field` partial versus the `buttons` partial.

https://github.com/bullet-train-co/bullet_train-core/blob/0af4a51e7254b2412ee26509de0ee1d9ab0a9f43/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_date_field.html.erb#L23

https://github.com/bullet-train-co/bullet_train-core/blob/0af4a51e7254b2412ee26509de0ee1d9ab0a9f43/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_buttons.html.erb#L11

You can see that `html_options` is passed for `buttons`, so `options: {disabled: true}` wasn't working. I touched upon `html_options` briefly in [this comment](https://github.com/bullet-train-co/bullet_train-core/pull/499#issuecomment-1702270817) in #499, and as you can see here `options` and `html_options` were being used interchangeably depending on the partial.

The main reason for this is because the variable name for `options` was already reserved for the options' labels and values. So, for example, if we pry into the button partial against `main`, we get the following:

```
[1] pry(#<#<Class:0x00007fb80fba80c8>>)> options
=> {"one"=>"One", "two"=>"Two", "three"=>"Three"}
```

When reflecting on #499 I had [this code](https://github.com/bullet-train-co/bullet_train-core/blob/0af4a51e7254b2412ee26509de0ee1d9ab0a9f43/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb#L709-L789) in mind, and here we use `field_options` which adds another name to the mix. You can see in this line too that `super_select`, `buttons` and `options` are handled differently.

https://github.com/bullet-train-co/bullet_train-core/blob/0af4a51e7254b2412ee26509de0ee1d9ab0a9f43/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb#L757C39-L757C39

So, in this PR, I've done my best to unify the names and to make them easier to understand.

## Unifying our `options` name conventions
As far as the `buttons` partial, we already had `option_field_options` in the `_option` partial, so I decided to use `button_field_options` so it has a similar name. Again, this represents values like "one" "two" "three" in the hash above.

We touch upon `html_options` briefly in the docs [here](https://bullettrain.co/docs/field-partials/super-select#allowing-multiple-option-selections), but should we just do away with it altogether and just use `options` and `other_options`? I'll have to think through this in a little more depth now that we're standardizing on those two. I also would like to do something about `field_options` in the Transformer to avoid confusion.

## Other field partials
There are other fields that we can't currently disable, like the color picker, which should be updated as well.
