### PR TITLE
Add documentation about notable versions

### DIFF
--- a/bullet_train/docs/upgrades.md
+++ b/bullet_train/docs/upgrades.md
@@ -36,6 +36,8 @@ your application.
 
 For the purposes of these instructions we'll assume that you're on version `1.4.0` and are going to upgrade to version `1.4.1`.
 
+[Be sure to check our Notable Versions list to see if there's anything tricky about the version you're moving to.](/docs/upgrades/notable-versions)
+
 ### 2. Make sure you're working with a clean local copy.
 
 ```

--- a/bullet_train/docs/upgrades/notable-versions.md
+++ b/bullet_train/docs/upgrades/notable-versions.md
@@ -1,0 +1,63 @@
+# Notable Versions
+
+## v1.4.11 / v1.5.0
+
+In v1.5.0 we made some fairly big changes to the format of system tests. In order to ease the
+transition we shipped a helper in 1.4.11 that you can use to modify your copy of the tests before
+you merge in version 1.5.0. Doing this should reduce the chances for merge conflicts.
+
+To use the helper to modify your tests run this in a console (after updating to v1.4.11):
+
+```
+bin/update/system_tests/use_device_test
+```
+
+Then you should:
+
+* Run the tests to make sure they still pass
+* Commit the updated test files
+* Update to v1.5.0
+
+### About this change
+
+We've introduced a new `device_test` helper that wraps up some of the implementation
+details about running system tests on a variety of devices.
+
+It simplifies the way that we write system tests like this:
+
+```diff
+-  @@test_devices.each do |device_name, display_details|
+-    test "user can so something on a #{device_name}" do
+-      resize_for(display_details)
+-      # actual tests here
+-    end
+-  end
++  device_test "user can do something" do
++    # actual test code
++  end
+```
+
+The specific changes are:
+
+* Remove the enclosing @@test_devices.each do block
+* Remove one level of indentation from test inside those blocks
+* Remove the resize_for(display_details) from tests in those blocks
+* Use `device_test` helper to handle running the test on different devices
+
+
+## v1.3.22
+
+In version 1.3.22 we added an `Address` model. If your app already had an `Address` model you'll
+probably want to reject some of the updates made to the starter repo in this version.
+
+TODO: Can we offer more direction here?
+
+
+## v1.3.0
+
+Version 1.3.0 is when we started explicitly bumping the Bullet Train gems within the starter repo
+every time that we release a new version of the `core` gems. Unfortunately, at that time we were
+only making changes to Gemfile.lock which kind of hides the dependencies, and is often a source of
+merge conflicts that can be hard to sort out.
+
+[See the upgrade guide for getting your app to version 1.3.0](/docs/upgrades/yolo-130)

--- a/bullet_train/docs/upgrades/options.md
+++ b/bullet_train/docs/upgrades/options.md
@@ -7,6 +7,8 @@
 * [Upgrade from any version to `1.4.0`](/docs/upgrades/yolo-140.md)
 * [Upgrade from any version to `1.3.0`](/docs/upgrades/yolo-130.md)
 * [Upgrade from `1.3.x` to `1.4.0`](/docs/upgrades/yolo-140.md)
+* [Notable versions](/docs/upgrades/notable-versions)
+
 
 ## About the upgrade process
 
@@ -26,6 +28,8 @@ which is less hidden and is not as prone to having merge conflicts as `Gemfile.l
 
 As a result of these changes, there are a few different ways that you might choose to upgrade your application
 depending on which version you're currently on.
+
+[Be sure to check our Notable Versions list to see if there's anything tricky about the version you're moving to.](/docs/upgrades/notable-versions)
 
 ## How to find your current version
 

--- a/bullet_train/docs/upgrades/yolo-130.md
+++ b/bullet_train/docs/upgrades/yolo-130.md
@@ -173,6 +173,8 @@ Before doing this you should have already followed the instructions above to get
 
 For purposes of this example we'll assume that you're stepping up from `1.3.0` to `1.3.1`.
 
+[Be sure to check our Notable Versions list to see if there's anything tricky about the version you're moving to.](/docs/upgrades/notable-versions)
+
 ### 1. Make sure you're working with a clean local copy.
 
 ```

--- a/bullet_train/docs/upgrades/yolo-140.md
+++ b/bullet_train/docs/upgrades/yolo-140.md
@@ -12,6 +12,8 @@
 
 ## Getting to `1.4.0`
 
+[Be sure to check our Notable Versions list to see if there's anything tricky about the version you're moving to.](/docs/upgrades/notable-versions)
+
 ### 1. Make sure you're working with a clean local copy.
 
 ```


### PR DESCRIPTION
Sometimes we release a version that will require downstream devs to do something, or we might release something that has the potential to conflict with downstream development. In such cases we need to have a place to let developers know what to do.