### PR TITLE
Remove now unneeded inline billing support code.

### DIFF
--- a/bullet_train/app/models/concerns/memberships/base.rb
+++ b/bullet_train/app/models/concerns/memberships/base.rb
@@ -39,11 +39,6 @@ module Memberships::Base
     scope :current_and_invited, -> { includes(:invitation).where("user_id IS NOT NULL OR invitations.id IS NOT NULL").references(:invitation) }
     scope :current, -> { where("user_id IS NOT NULL") }
     scope :tombstones, -> { includes(:invitation).where("user_id IS NULL AND invitations.id IS NULL AND platform_agent IS FALSE").references(:invitation) }
-
-    # TODO Probably we can provide a way for gem packages to define these kinds of extensions.
-    if billing_enabled?
-      scope :billable, -> { current_and_invited }
-    end
   end
 
   def name

--- a/bullet_train/app/models/concerns/records/base.rb
+++ b/bullet_train/app/models/concerns/records/base.rb
@@ -36,14 +36,6 @@ module Records::Base
     scope :newest_updated, -> { order("updated_at DESC") }
     scope :oldest_updated, -> { order("updated_at ASC") }
 
-    # TODO Probably we can provide a way for gem packages to define these kinds of extensions.
-    if billing_enabled?
-      # By default, any model in a collection is considered active for billing purposes.
-      # This can be overloaded in the child model class to specify more specific criteria for billing.
-      # See `app/models/concerns/memberships/base.rb` for an example.
-      scope :billable, -> { order("TRUE") }
-    end
-
     # Microscope adds useful scopes targeting ActiveRecord `boolean`, `date` and `datetime` attributes.
     # https://github.com/mirego/microscope
     acts_as_microscope

--- a/bullet_train/app/models/concerns/teams/base.rb
+++ b/bullet_train/app/models/concerns/teams/base.rb
@@ -22,17 +22,6 @@ module Teams::Base
     # integrations
     has_many :integrations_stripe_installations, class_name: "Integrations::StripeInstallation", dependent: :destroy if stripe_enabled?
 
-    # TODO Probably we can provide a way for gem packages to define these kinds of extensions.
-    if billing_enabled?
-      # subscriptions
-      has_many :billing_subscriptions, class_name: "Billing::Subscription", dependent: :destroy, foreign_key: :team_id
-
-      # TODO We need a way for `bullet_train-billing-stripe` to define these.
-      if defined?(Billing::Stripe::Subscription)
-        has_many :billing_stripe_subscriptions, class_name: "Billing::Stripe::Subscription", dependent: :destroy, foreign_key: :team_id
-      end
-    end
-
     # validations
     validates :name, presence: true
     validates :time_zone, inclusion: {in: ActiveSupport::TimeZone.all.map(&:name)}, allow_nil: true
@@ -66,20 +55,6 @@ module Teams::Base
     # some generic features appeal to the `team` method for security or scoping purposes, but sometimes those same
     # generic functions need to function for a team model as well, so we do this.
     self
-  end
-
-  # TODO Probably we can provide a way for gem packages to define these kinds of extensions.
-  if billing_enabled?
-    def current_billing_subscription
-      # If by some bug we have two subscriptions, we want to use the one that existed first.
-      # The reasoning here is that it's more likely to be on some legacy plan that benefits the customer.
-      billing_subscriptions.active.order(:created_at).first
-    end
-
-    def needs_billing_subscription?
-      return false if freemium_enabled?
-      billing_subscriptions.active.empty?
-    end
   end
 
   ActiveSupport.run_load_hooks :bullet_train_teams_base, self


### PR DESCRIPTION
We inserted load hooks in https://github.com/bullet-train-co/bullet_train-core/pull/335, and then used them in https://github.com/bullet-train-pro/bullet_train-billing/pull/19

We've shipped releases with that new code, so we can remove our inline backing code from here.