### PR TITLE
`Minitest::Spec` of dust

### DIFF
--- a/bullet_train/test/lib/tasks/bullet_train_tasks_test.rb
+++ b/bullet_train/test/lib/tasks/bullet_train_tasks_test.rb
@@ -1,55 +1,51 @@
 require "test_helper"
-require "minitest/spec"
 require "rake"
 Rails.application.load_tasks
 
-describe "rake bullet_train:resolve --interactive" do
-  before do
+module BulletTrain::Tasks; end
+class BulletTrain::Tasks::ResolveTaskTest < ActiveSupport::TestCase
+  setup do
     @original_stdin = $stdin
     @original_stdout = $stdout
     $stdout = StringIO.new
   end
 
-  after do
+  teardown do
     $stdin = @original_stdin
     $stdout = @original_stdout
   end
 
-  describe "when passed BEGIN absolute path from annotated view" do
-    it "resolves the path" do
-      inputs = [
-        "<!-- BEGIN /Users/andrewculver/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bullet_train-themes-light-1.0.10/app/views/themes/light/workflow/_box.html.erb -->",
-        "n", # Would you like to eject the file into the local project? (y/n):
-        "n" # Would you like to open `#{source_file[:absolute_path]}`? (y/n):
-      ]
-      stdin_mock = StringIO.new(inputs.join("\n"))
-      stdin_mock.define_singleton_method(:ready?) { false }
-      $stdin = stdin_mock
+  test "resolves the path when passed BEGIN absolute path from annotated view" do
+    inputs = [
+      "<!-- BEGIN /Users/andrewculver/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bullet_train-themes-light-1.0.10/app/views/themes/light/workflow/_box.html.erb -->",
+      "n", # Would you like to eject the file into the local project? (y/n):
+      "n" # Would you like to open `#{source_file[:absolute_path]}`? (y/n):
+    ]
+    stdin_mock = StringIO.new(inputs.join("\n"))
+    stdin_mock.define_singleton_method(:ready?) { false }
+    $stdin = stdin_mock
 
-      Rake::Task["bullet_train:resolve"].invoke("--interactive")
-      Rake::Task["bullet_train:resolve"].reenable
+    Rake::Task["bullet_train:resolve"].invoke("--interactive")
+    Rake::Task["bullet_train:resolve"].reenable
 
-      output = $stdout.string
-      assert output.include?("Absolute path:")
-    end
+    output = $stdout.string
+    assert output.include?("Absolute path:")
   end
 
-  describe "when passed END absolute path from annotated view" do
-    it "resolves the path" do
-      inputs = [
-        "<!-- END /Users/andrewculver/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bullet_train-themes-light-1.0.10/app/views/themes/light/workflow/_box.html.erb -->",
-        "n", # Would you like to eject the file into the local project? (y/n):
-        "n" # Would you like to open `#{source_file[:absolute_path]}`? (y/n):
-      ]
-      stdin_mock = StringIO.new(inputs.join("\n"))
-      stdin_mock.define_singleton_method(:ready?) { false }
-      $stdin = stdin_mock
+  test "resolves the path when passed END absolute path from annotated view" do
+    inputs = [
+      "<!-- END /Users/andrewculver/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bullet_train-themes-light-1.0.10/app/views/themes/light/workflow/_box.html.erb -->",
+      "n", # Would you like to eject the file into the local project? (y/n):
+      "n" # Would you like to open `#{source_file[:absolute_path]}`? (y/n):
+    ]
+    stdin_mock = StringIO.new(inputs.join("\n"))
+    stdin_mock.define_singleton_method(:ready?) { false }
+    $stdin = stdin_mock
 
-      Rake::Task["bullet_train:resolve"].invoke("--interactive")
-      Rake::Task["bullet_train:resolve"].reenable
+    Rake::Task["bullet_train:resolve"].invoke("--interactive")
+    Rake::Task["bullet_train:resolve"].reenable
 
-      output = $stdout.string
-      assert output.include?("Absolute path:")
-    end
+    output = $stdout.string
+    assert output.include?("Absolute path:")
   end
 end

--- a/bullet_train/test/lib/tasks/bullet_train_tasks_test.rb
+++ b/bullet_train/test/lib/tasks/bullet_train_tasks_test.rb
@@ -4,38 +4,39 @@ Rails.application.load_tasks
 
 module BulletTrain::Tasks; end
 class BulletTrain::Tasks::ResolveTaskTest < ActiveSupport::TestCase
-  setup { @original_stdin = $stdin }
-  teardown { $stdin = @original_stdin }
-
   test "resolves the path when passed BEGIN absolute path from annotated view" do
-    inputs = [
+    mock_stdin_with [
       "<!-- BEGIN /Users/andrewculver/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bullet_train-themes-light-1.0.10/app/views/themes/light/workflow/_box.html.erb -->",
       "n", # Would you like to eject the file into the local project? (y/n):
       "n" # Would you like to open `#{source_file[:absolute_path]}`? (y/n):
-    ]
-    stdin_mock = StringIO.new(inputs.join("\n"))
-    stdin_mock.define_singleton_method(:ready?) { false }
-    $stdin = stdin_mock
-
-    assert_output /Absolute path:/ do
-      Rake::Task["bullet_train:resolve"].invoke("--interactive")
-      Rake::Task["bullet_train:resolve"].reenable
+    ] do
+      assert_output /Absolute path:/ do
+        Rake::Task["bullet_train:resolve"].invoke("--interactive")
+        Rake::Task["bullet_train:resolve"].reenable
+      end
     end
   end
 
   test "resolves the path when passed END absolute path from annotated view" do
-    inputs = [
+    mock_stdin_with [
       "<!-- END /Users/andrewculver/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bullet_train-themes-light-1.0.10/app/views/themes/light/workflow/_box.html.erb -->",
       "n", # Would you like to eject the file into the local project? (y/n):
       "n" # Would you like to open `#{source_file[:absolute_path]}`? (y/n):
-    ]
-    stdin_mock = StringIO.new(inputs.join("\n"))
-    stdin_mock.define_singleton_method(:ready?) { false }
-    $stdin = stdin_mock
-
-    assert_output /Absolute path:/ do
-      Rake::Task["bullet_train:resolve"].invoke("--interactive")
-      Rake::Task["bullet_train:resolve"].reenable
+    ] do
+      assert_output /Absolute path:/ do
+        Rake::Task["bullet_train:resolve"].invoke("--interactive")
+        Rake::Task["bullet_train:resolve"].reenable
+      end
     end
+  end
+
+  private
+
+  def mock_stdin_with(inputs)
+    old_stdin, $stdin = $stdin, StringIO.new(inputs.join("\n"))
+    def $stdin.ready? = false # StringIO doens't have `IO#ready?`, so we stub a method on the singleton.
+    yield
+  ensure
+    $stdin = old_stdin
   end
 end

--- a/bullet_train/test/lib/tasks/bullet_train_tasks_test.rb
+++ b/bullet_train/test/lib/tasks/bullet_train_tasks_test.rb
@@ -4,16 +4,8 @@ Rails.application.load_tasks
 
 module BulletTrain::Tasks; end
 class BulletTrain::Tasks::ResolveTaskTest < ActiveSupport::TestCase
-  setup do
-    @original_stdin = $stdin
-    @original_stdout = $stdout
-    $stdout = StringIO.new
-  end
-
-  teardown do
-    $stdin = @original_stdin
-    $stdout = @original_stdout
-  end
+  setup { @original_stdin = $stdin }
+  teardown { $stdin = @original_stdin }
 
   test "resolves the path when passed BEGIN absolute path from annotated view" do
     inputs = [
@@ -25,11 +17,10 @@ class BulletTrain::Tasks::ResolveTaskTest < ActiveSupport::TestCase
     stdin_mock.define_singleton_method(:ready?) { false }
     $stdin = stdin_mock
 
-    Rake::Task["bullet_train:resolve"].invoke("--interactive")
-    Rake::Task["bullet_train:resolve"].reenable
-
-    output = $stdout.string
-    assert output.include?("Absolute path:")
+    assert_output /Absolute path:/ do
+      Rake::Task["bullet_train:resolve"].invoke("--interactive")
+      Rake::Task["bullet_train:resolve"].reenable
+    end
   end
 
   test "resolves the path when passed END absolute path from annotated view" do
@@ -42,10 +33,9 @@ class BulletTrain::Tasks::ResolveTaskTest < ActiveSupport::TestCase
     stdin_mock.define_singleton_method(:ready?) { false }
     $stdin = stdin_mock
 
-    Rake::Task["bullet_train:resolve"].invoke("--interactive")
-    Rake::Task["bullet_train:resolve"].reenable
-
-    output = $stdout.string
-    assert output.include?("Absolute path:")
+    assert_output /Absolute path:/ do
+      Rake::Task["bullet_train:resolve"].invoke("--interactive")
+      Rake::Task["bullet_train:resolve"].reenable
+    end
   end
 end


### PR DESCRIPTION
I'm porting over some `Minitest::Spec` instances we've got to standard minitest/tests. I'll the routes and block scaffolding manipulator tests for a separate PR.

Ref: https://github.com/bullet-train-co/bullet_train-core/issues/588