### PR TITLE
Move masamune ast dependency to using gems

### DIFF
--- a/bullet_train-super_scaffolding/bullet_train-super_scaffolding.gemspec
+++ b/bullet_train-super_scaffolding/bullet_train-super_scaffolding.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails", ">= 6.0.0"
   spec.add_dependency "bullet_train"
-  spec.add_dependency "masamune-ast", ">= 1.2.0"
+  spec.add_dependency "masamune-ast", ">= 1.2.1"
 
   # For Super Scaffolding: "select *a* team member" vs. "select *an* option".
   spec.add_dependency "indefinite_article"

--- a/bullet_train-super_scaffolding/bullet_train-super_scaffolding.gemspec
+++ b/bullet_train-super_scaffolding/bullet_train-super_scaffolding.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails", ">= 6.0.0"
   spec.add_dependency "bullet_train"
+  spec.add_dependency "masamune-ast", ">= 1.2.0"
 
   # For Super Scaffolding: "select *a* team member" vs. "select *an* option".
   spec.add_dependency "indefinite_article"

--- a/bullet_train-themes-light/bullet_train-themes-light.gemspec
+++ b/bullet_train-themes-light/bullet_train-themes-light.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails", ">= 6.0.0"
   spec.add_dependency "bullet_train-themes-tailwind_css"
+  spec.add_dependency "masamune-ast", ">= 1.2.0"
 end

--- a/bullet_train-themes-light/bullet_train-themes-light.gemspec
+++ b/bullet_train-themes-light/bullet_train-themes-light.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails", ">= 6.0.0"
   spec.add_dependency "bullet_train-themes-tailwind_css"
-  spec.add_dependency "masamune-ast", ">= 1.2.0"
+  spec.add_dependency "masamune-ast", ">= 1.2.1"
 end

--- a/bullet_train/Gemfile.lock
+++ b/bullet_train/Gemfile.lock
@@ -395,4 +395,4 @@ DEPENDENCIES
   standard
 
 BUNDLED WITH
-   2.3.8
+   2.4.20

--- a/bullet_train/Gemfile.lock
+++ b/bullet_train/Gemfile.lock
@@ -28,7 +28,6 @@ PATH
       hiredis
       http_accept_language
       image_processing
-      masamune-ast (>= 1.2.0)
       microscope
       nice_partials (~> 0.9)
       pagy
@@ -217,8 +216,6 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.2)
-    masamune-ast (1.2.0)
-      activesupport
     method_source (1.0.0)
     microscope (1.1.1)
       activerecord (>= 4.1.0)

--- a/bullet_train/bullet_train.gemspec
+++ b/bullet_train/bullet_train.gemspec
@@ -42,7 +42,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bullet_train-routes"
   spec.add_dependency "devise"
   spec.add_dependency "xxhash"
-  spec.add_dependency "masamune-ast", ">=1.2.0"
 
   spec.add_dependency "image_processing"
 


### PR DESCRIPTION
bullet_train-super_scaffolding and bullet_train-themes-light are the gems that use masamune-ast,
it doesn't seem like it's a fit in bullet_train itself.

I found this while working on https://github.com/bullet-train-co/bullet_train-core/pull/597, where I had to add this:

```ruby
gem "masamune-ast" # TODO: Move the bullet_train.gemspec dependency to super_scaffolding's gemspec.
```

Ref: https://github.com/bullet-train-co/bullet_train-core/pull/597/files#diff-68cca28f9c2368a9481c0ade06f7da3d4c5c13dd81597e53201ece7c00c8fa90R14

Technically, it means that users could run into require errors if they these libs without the bullet_train, however unlikely.