### PR TITLE
Bug fix for super scaffolding an address_field

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/script.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/script.rb
@@ -8,7 +8,7 @@ require "scaffolding/routes_file_manipulator"
 require_relative "../bullet_train/terminal_commands"
 
 FIELD_PARTIALS = {
-  address_field: "string",
+  address_field: nil,
   boolean: "boolean",
   buttons: "string",
   cloudinary_image: "string",
@@ -165,7 +165,8 @@ def check_required_options_for_attributes(scaffolding_type, attributes, child, p
 
     # For join models, we don't want to generate a migration when
     # running the crud-field scaffolder in the last step, so we skip *_ids.
-    unless name.match?(/_ids$/)
+    # Addresses belong_to :addressable, so they don't hae to be represented in a migration.
+    unless name.match?(/_ids$/) || data_type.nil?
       generation_command += " #{name_without_id || name}:#{data_type}"
       attributes_to_generate << name
     end


### PR DESCRIPTION
The PR for testing super scaffolding of Addresses (https://github.com/bullet-train-co/bullet_train/pull/986) landed right before the PR for automatically generating a migration during super scaffolding (https://github.com/bullet-train-co/bullet_train-core/pull/547). As a result a bug / test-failure crept in.

https://app.circleci.com/pipelines/github/bullet-train-co/bullet_train/2585/workflows/1d20bad0-bcad-45f3-96e3-9ac377eec600/jobs/13420?invite=true#step-115-1450_67

The `Address` model `belongs_to :addressable`, which means that the relation is stored on the `Address` side, and not on the owning model. So that means that when we super scaffold an address field it turns out that we don't need to represent that in the migration for the model that will own the address.