### PR TITLE
Stop Super Scaffolding if model already exists

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/script.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/script.rb
@@ -60,7 +60,7 @@ end
 
 # All untracked files begin with a tab (i.e. - "\tapp/models/model.rb").
 def get_untracked_files(status_lines)
-  `git ls-files --other --directory --exclude-standard`.split("\n")
+  `git ls-files --other --exclude-standard`.split("\n")
 end
 
 def check_required_options_for_attributes(scaffolding_type, attributes, child, parent = nil)

--- a/bullet_train-super_scaffolding/lib/scaffolding/script.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/script.rb
@@ -60,8 +60,7 @@ end
 
 # All untracked files begin with a tab (i.e. - "\tapp/models/model.rb").
 def get_untracked_files(status_lines)
-  idx = status_lines.index("Untracked files:")
-  status_lines[idx..].select { |lines| lines.match?(/\t/) }
+  `git ls-files --other --directory --exclude-standard`.split("\n")
 end
 
 def check_required_options_for_attributes(scaffolding_type, attributes, child, parent = nil)

--- a/bullet_train-super_scaffolding/lib/scaffolding/script.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/script.rb
@@ -204,8 +204,13 @@ def check_required_options_for_attributes(scaffolding_type, attributes, child, p
 
       newly_untracked_files = has_untracked_files?(git_status) ? get_untracked_files(git_status) : []
       if (newly_untracked_files - untracked_files).size.zero?
-        # Rails will output an error if nothing was generated,
-        # so we don't have to write anything extra upon exiting.
+        error_message = <<~MESSAGE
+          Since you have already created the #{child} model, Super Scaffolding won't allow you to re-create it.
+          You can either delete the model and try Super Scaffolding again, or add the `--skip-migration-generation`
+          flag to Super Scaffold the classic Bullet Train way.
+        MESSAGE
+        puts ""
+        puts error_message.red
         exit 1
       end
     end


### PR DESCRIPTION
Closes #603.

I tried using `spawn`, `IO.popen` and `trap` as @kaspth suggested in the issue, but couldn't quite get it to work. What I decided to do was wait for the process to end, then compare `git status` before running `bin/rails generate model` and after running it.

Now we get the following if the model exists:
```
> rails g model Foo team:references title:string
      invoke  active_record
      create    db/migrate/20231006051223_create_foos.rb
      create    app/models/foo.rb
      invoke    test_unit
      create      test/models/foo_test.rb
      invoke      factory_bot
      create        test/factories/foos.rb
> bin/super-scaffold crud Foo Team title:text_field
Generating Foo model with 'bin/rails generate model Foo team:references title:string'

The name 'Foo' is either already used in your application or reserved by Ruby on Rails. Please choose an alternative or use --skip-collision-check or --force to skip this check and run this generator again.
> 
```

If this doesn't suffice I can look into those methods I mentioned at the beginning again, but I wanted to at least push this.