### PR TITLE
Bump `jbuilder-schema` to `2.4.0`

### DIFF
--- a/bullet_train-api/bullet_train-api.gemspec
+++ b/bullet_train-api/bullet_train-api.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pagy_cursor"
   spec.add_dependency "rack-cors"
   spec.add_dependency "doorkeeper"
-  spec.add_dependency "jbuilder-schema", ">= 2.3.0"
+  spec.add_dependency "jbuilder-schema", ">= 2.4.0"
   spec.add_dependency "factory_bot"
 
   spec.add_dependency "bullet_train"

--- a/bullet_train/config/locales/en/memberships.en.yml
+++ b/bullet_train/config/locales/en/memberships.en.yml
@@ -49,6 +49,7 @@ en:
       user_profile_photo_id:
         name: &user_profile_photo_id Profile Photo
         label: *user_profile_photo_id
+        heading: *user_profile_photo_id
       user_profile_photo:
         name: &user_profile_photo Profile Photo
         label: *user_profile_photo

--- a/bullet_train/config/locales/en/memberships.en.yml
+++ b/bullet_train/config/locales/en/memberships.en.yml
@@ -49,7 +49,6 @@ en:
       user_profile_photo_id:
         name: &user_profile_photo_id Profile Photo
         label: *user_profile_photo_id
-        heading: *user_profile_photo_id
       user_profile_photo:
         name: &user_profile_photo Profile Photo
         label: *user_profile_photo


### PR DESCRIPTION
In [trying to update to Rails 7.1.0](https://github.com/bullet-train-co/bullet_train/pull/1064) we're seeing some test failures like this:

```
Error:
Api::OpenApiControllerTest#test_OpenAPI_document_is_valid:
ActionView::Template::Error: undefined method `deep_stringify_keys' for "{:type=>:object, :title=>\"Teams\", :description=>\"Teams\", :required=>[\"id\", \"name\"], :properties=>{\"id\"=>{:type=>:integer, :description=>\"Team ID\"}, \"name\"=>{:type=>:string, :description=>\"Team\"}, \"time_zone\"=>{:type=>[:string, \"null\"], :description=>\"Primary Time Zone\"}, \"locale\"=>{:type=>[:string, \"null\"], :description=>\"Language\"}, \"created_at\"=>{:type=>[:string, \"null\"], :format=>\"date-time\", :description=>\"Signed Up At\"}, \"updated_at\"=>{:type=>[:string, \"null\"], :format=>\"date-time\", :description=>\"Updated At\"}}, :example=>{\"id\"=>172, \"name\"=>\"EXAMPLE Generic Team 1\", \"time_zone\"=>\"International Date Line West\", \"locale\"=>\"en\", \"created_at\"=>\"2023-10-06T19:23:27.244+09:00\", \"updated_at\"=>\"2023-10-06T19:23:27.244+09:00\"}}":String
    core/bullet_train-api/app/helpers/api/open_api_helper.rb:62:in `automatic_components_for'
    app/views/api/v1/open_api/index.yaml.erb:18
    core/bullet_train-api/app/controllers/api/open_api_controller.rb:12:in `index'
    core/bullet_train/app/controllers/concerns/controllers/base.rb:95:in `set_locale'
    test/controllers/api/open_api_controller_test.rb:10:in `block in <class:OpenApiControllerTest>'
```

This was fixed in `jbuilder-schema` here: https://github.com/bullet-train-co/jbuilder-schema/pull/57