### PR TITLE
Add a missing translation

### DIFF
--- a/bullet_train/config/locales/en/memberships.en.yml
+++ b/bullet_train/config/locales/en/memberships.en.yml
@@ -49,6 +49,7 @@ en:
       user_profile_photo_id:
         name: &user_profile_photo_id Profile Photo
         label: *user_profile_photo_id
+        heading: *user_profile_photo_id
       user_profile_photo:
         name: &user_profile_photo Profile Photo
         label: *user_profile_photo


### PR DESCRIPTION
When updating to Rails 7.1.0 we started seeing a new error about a missing translation:

```
Error:
Api::OpenApiControllerTest#test_OpenAPI_document_is_valid:
ActionView::Template::Error: Translation missing: en.memberships.fields.user_profile_photo_id.heading
    app/views/api/v1/memberships/_membership.json.jbuilder:1
    bullet_train-api (1.6.1) app/helpers/api/open_api_helper.rb:62:in `automatic_components_for'
    app/views/api/v1/open_api/index.yaml.erb:20
    bullet_train-api (1.6.1) app/controllers/api/open_api_controller.rb:12:in `index'
    bullet_train (1.6.1) app/controllers/concerns/controllers/base.rb:95:in `set_locale'
    test/controllers/api/open_api_controller_test.rb:10:in `block in <class:OpenApiControllerTest>'
```

This PR adds that translation.