### PR TITLE
Show relative path when ejecting showcase partials

### DIFF
--- a/bullet_train-themes-light/lib/tasks/application.rb
+++ b/bullet_train-themes-light/lib/tasks/application.rb
@@ -62,7 +62,7 @@ module BulletTrain
               FileUtils.mkdir_p(directory)
               FileUtils.touch(partial_relative_path)
               `cp #{showcase_preview} #{partial_relative_path}`
-              new_files[partial_relative_path] = showcase_preview
+              new_files[partial_relative_path] = "#{gem_path.scan(/#{gem}.*/).pop}/#{partial_relative_path}"
             end
           end
         end


### PR DESCRIPTION
Fixes #613.

This is hard to test locally because released gem paths look like `bullet_train-themes-light-1.6.3` when local gems don't have the version number. This should work though.