### PR TITLE
Delete unneeded session key in invite-only mode

### DIFF
--- a/bullet_train/app/controllers/concerns/controllers/base.rb
+++ b/bullet_train/app/controllers/concerns/controllers/base.rb
@@ -82,6 +82,9 @@ module Controllers::Base
       unless helpers.invited?
         redirect_to [:account, :teams], notice: t("teams.notifications.invitation_only")
       end
+
+      # We only want the session to store the key on the redirect from InviteOnlySupport.
+      session[:invitation_key] = nil
     end
   end
 

--- a/bullet_train/app/controllers/concerns/controllers/base.rb
+++ b/bullet_train/app/controllers/concerns/controllers/base.rb
@@ -84,7 +84,7 @@ module Controllers::Base
       end
 
       # We only want the session to store the key on the redirect from InviteOnlySupport.
-      session[:invitation_key] = nil
+      session.delete(:invitation_key) if session[:invitation_key]
     end
   end
 

--- a/bullet_train/app/controllers/concerns/registrations/controller_base.rb
+++ b/bullet_train/app/controllers/concerns/registrations/controller_base.rb
@@ -13,6 +13,9 @@ module Registrations::ControllerBase
         unless session[:invitation_uuid] || session[:invitation_key]
           return redirect_to root_path
         end
+
+        # We only want the session to store the key on the redirect from InviteOnlySupport.
+        session[:invitation_key] = nil
       end
 
       # do all the regular devise stuff.

--- a/bullet_train/app/controllers/concerns/registrations/controller_base.rb
+++ b/bullet_train/app/controllers/concerns/registrations/controller_base.rb
@@ -15,7 +15,7 @@ module Registrations::ControllerBase
         end
 
         # We only want the session to store the key on the redirect from InviteOnlySupport.
-        session[:invitation_key] = nil
+        session.delete(:invitation_key) if session[:invitation_key]
       end
 
       # do all the regular devise stuff.


### PR DESCRIPTION
Fixes the issue discussed on Discord.

Also, I looked into the session logic for general invitations as well, and I'm not seeing anything in particular that seems to need attention.

We delete the uuid here:

https://github.com/bullet-train-co/bullet_train-core/blob/74333901d4ea56baec8e0066a444471bbe650ecf/bullet_train/app/controllers/concerns/account/invitations/controller_base.rb#L58

And also here for omniauth callbacks:

https://github.com/bullet-train-co/bullet_train-core/blob/74333901d4ea56baec8e0066a444471bbe650ecf/bullet_train-integrations/app/controllers/concerns/account/oauth/omniauth_callbacks/controller_base.rb#L165-L166

The first one deletes the key upon account creation, so the invitation uuid stays in the session until then. During that time, users can only access the new registration page and the new sign in page.

## Tests

I'm getting a failing test for the "Update Profile" button so I'll see if I can fix that.