### PR TITLE
Update to Masamune 2.0.2

### DIFF
--- a/bullet_train-super_scaffolding/bullet_train-super_scaffolding.gemspec
+++ b/bullet_train-super_scaffolding/bullet_train-super_scaffolding.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails", ">= 6.0.0"
   spec.add_dependency "bullet_train"
-  spec.add_dependency "masamune-ast", "~> 2.0.1"
+  spec.add_dependency "masamune-ast", "~> 2.0.2"
 
   # For Super Scaffolding: "select *a* team member" vs. "select *an* option".
   spec.add_dependency "indefinite_article"

--- a/bullet_train-super_scaffolding/bullet_train-super_scaffolding.gemspec
+++ b/bullet_train-super_scaffolding/bullet_train-super_scaffolding.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails", ">= 6.0.0"
   spec.add_dependency "bullet_train"
-  spec.add_dependency "masamune-ast", "~> 1.2.1"
+  spec.add_dependency "masamune-ast", "~> 2.0.1"
 
   # For Super Scaffolding: "select *a* team member" vs. "select *an* option".
   spec.add_dependency "indefinite_article"

--- a/bullet_train-super_scaffolding/lib/scaffolding/routes_file_manipulator.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/routes_file_manipulator.rb
@@ -227,8 +227,8 @@ class Scaffolding::RoutesFileManipulator
   # Finds namespace blocks no matter how many levels deep they are nested in resource blocks, etc.
   # However, will not find namespace blocks inside namespace blocks.
   def top_level_namespace_block_lines(within)
-    namespaces = @msmn.method_calls(name: "namespace")
-    namespace_line_numbers = namespaces.map { |namespace| namespace[:line_number] }
+    namespaces = @msmn.method_calls(token_value: "namespace")
+    namespace_line_numbers = namespaces.map(&:line_number)
 
     local_namespace_blocks = []
     Scaffolding::FileManipulator.lines_within(lines, within).each do |line|
@@ -239,7 +239,7 @@ class Scaffolding::RoutesFileManipulator
       # all other namespace blocks INSIDE the top-level namespace blocks are skipped
       if namespace_line_numbers.include?(line_index)
         # Grab the first symbol token on the same line as the namespace.
-        namespace_name = @msmn.symbols.find { |sym| sym[:line_number] == line_index }[:token]
+        namespace_name = @msmn.symbols.find { |sym| sym.line_number == line_index }.token_value
         local_namespace = find_namespaces([namespace_name], within)
         starting_line_number = local_namespace[namespace_name]
         local_namespace_block = ((starting_line_number + 1)..(Scaffolding::BlockManipulator.find_block_end(starting_from: starting_line_number, lines: lines) + 1))

--- a/bullet_train-themes-light/bullet_train-themes-light.gemspec
+++ b/bullet_train-themes-light/bullet_train-themes-light.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails", ">= 6.0.0"
   spec.add_dependency "bullet_train-themes-tailwind_css"
-  spec.add_dependency "masamune-ast", "~> 2.0.1"
+  spec.add_dependency "masamune-ast", "~> 2.0.2"
 end

--- a/bullet_train-themes-light/bullet_train-themes-light.gemspec
+++ b/bullet_train-themes-light/bullet_train-themes-light.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails", ">= 6.0.0"
   spec.add_dependency "bullet_train-themes-tailwind_css"
-  spec.add_dependency "masamune-ast", "~> 1.2.1"
+  spec.add_dependency "masamune-ast", "~> 2.0.1"
 end

--- a/bullet_train-themes-light/lib/tasks/application.rb
+++ b/bullet_train-themes-light/lib/tasks/application.rb
@@ -94,7 +94,7 @@ module BulletTrain
           msmn.method_calls(token_value: "require") +
           msmn.method_calls(token_value: "mattr_accessor") +
           msmn.comments.select { |comment| comment.token_value.match?("TODO") }
-        lines_to_skip = data_to_skip.map { |data| data.line_number- 1 }
+        lines_to_skip = data_to_skip.map { |data| data.line_number - 1 }
         new_lines = theme_file.readlines.select.with_index do |line, idx|
           !lines_to_skip.include?(idx) || line.match?("mattr_accessor :colors")
         end

--- a/bullet_train-themes-light/lib/tasks/application.rb
+++ b/bullet_train-themes-light/lib/tasks/application.rb
@@ -91,10 +91,10 @@ module BulletTrain
         theme_file = Pathname.new(target_path)
         msmn = Masamune::AbstractSyntaxTree.new(theme_file.readlines.join)
         data_to_skip =
-          msmn.method_calls(name: "require") +
-          msmn.method_calls(name: "mattr_accessor") +
-          msmn.comments.select { |comment| comment[:token].match?("TODO") }
-        lines_to_skip = data_to_skip.map { |data| data[:line_number] - 1 }
+          msmn.method_calls(token_value: "require") +
+          msmn.method_calls(token_value: "mattr_accessor") +
+          msmn.comments.select { |comment| comment.token_value.match?("TODO") }
+        lines_to_skip = data_to_skip.map { |data| data.line_number- 1 }
         new_lines = theme_file.readlines.select.with_index do |line, idx|
           !lines_to_skip.include?(idx) || line.match?("mattr_accessor :colors")
         end
@@ -213,9 +213,9 @@ module BulletTrain
       def self.install_theme(theme_name)
         helper = Pathname.new("./app/helpers/application_helper.rb")
         msmn = Masamune::AbstractSyntaxTree.new(helper.readlines.join)
-        current_theme_def = msmn.method_definitions(name: "current_theme").pop
-        current_theme = msmn.symbols.find { |node| node[:line_number] > current_theme_def[:line_number] }[:token]
-        helper.write msmn.replace(type: :symbol, old_token: current_theme, new_token: theme_name)
+        current_theme_def = msmn.method_definitions(token_value: "current_theme").pop
+        current_theme = msmn.symbols.find { |node| node.line_number > current_theme_def.line_number }.token_value
+        helper.write msmn.replace(type: :symbol, old_token_value: current_theme, new_token_value: theme_name)
 
         [Pathname.new("./Procfile.dev"), Pathname.new("./package.json")].each do |file|
           changed = file.read.gsub! current_theme, theme_name


### PR DESCRIPTION
Masamune now uses [Prism nodes](https://github.com/gazayas/masamune-ast/pull/60), so I feel much safer using this as an interface for other parts of Bullet Train.

Before getting to those other parts though, I wanted to update what we already have in place first. This PR takes care of that.