### PR TITLE
Fix showcase partial lookup when ejecting a file

### DIFF
--- a/bullet_train/lib/bullet_train/resolver.rb
+++ b/bullet_train/lib/bullet_train/resolver.rb
@@ -58,7 +58,7 @@ module BulletTrain
               # Look for showcase preview.
               file_name = source_file[:absolute_path].split("/").last
               showcase_partials = Dir.glob(`bundle show bullet_train-themes-light`.chomp + "/app/views/showcase/**/*.html.erb")
-              showcase_preview = showcase_partials.find { _1.end_with?(file_name) }
+              showcase_preview = showcase_partials.find { |partial| partial.split("/").last == file_name }
               if showcase_preview
                 puts "Ejecting showcase preview for #{source_file[:relative_path]}"
                 partial_relative_path = showcase_preview.scan(/(?=app\/views\/showcase).*/).last


### PR DESCRIPTION
```
> bin/resolve shared/fields/field --eject
```

This yields a file that ends with `/_field.html.erb ` and there's no showcase partial for this, but the following showcase file was getting ejected to the starter repository:

```
app/views/showcase/previews/field_partials/_address_field.html.erb
```

The reason was that the `address_field.html.erb` matches the `end_with?` that I changed here.