### PR TITLE
Remove `rails g model` suggestions from `bin/super-scaffolding` help text

### DIFF
--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/crud_field_scaffolder.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/crud_field_scaffolder.rb
@@ -8,7 +8,6 @@ module BulletTrain
             puts "🚅  usage: bin/super-scaffold crud-field <Model> <attribute:type> <attribute:type> ... [options]"
             puts ""
             puts "E.g. add a description and body to Pages:"
-            puts "  rails g migration add_description_etc_to_pages description:text body:text"
             puts "  bin/super-scaffold crud-field Page description:text_area body:text_area"
             puts ""
             puts "Options:"

--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb
@@ -8,18 +8,15 @@ module BulletTrain
             puts "🚅  usage: bin/super-scaffold crud <Model> <ParentModel[s]> <attribute:type> <attribute:type> ..."
             puts ""
             puts "E.g. a Team has many Sites with some attributes:"
-            puts "  rails g model Site team:references name:string url:text"
             puts "  bin/super-scaffold crud Site Team name:text_field url:text_area"
             puts ""
             puts "E.g. a Section belongs to a Page, which belongs to a Site, which belongs to a Team:"
-            puts "  rails g model Section page:references title:string body:text"
             puts "  bin/super-scaffold crud Section Page,Site,Team title:text_field body:text_area"
             puts ""
             puts "E.g. an Image belongs to either a Page or a Site:"
             puts "  Doable! See https://bit.ly/2NvO8El for a step by step guide."
             puts ""
             puts "E.g. Pages belong to a Site and are sortable via drag-and-drop:"
-            puts "  rails g model Page site:references name:string path:text"
             puts "  bin/super-scaffold crud Page Site,Team name:text_field path:text_area --sortable"
             puts ""
             puts "🏆 Protip: Commit your other changes before running Super Scaffolding so it's easy to undo if you (or we) make any mistakes."
@@ -83,7 +80,6 @@ module BulletTrain
           unless parents.include?("Team")
             raise "Parents for #{child} should trace back to the Team model, but Team wasn't provided. Please confirm that all of the parents tracing back to the Team model are present and try again.\n" \
               "E.g.:\n" \
-              "rails g model Section page:references title:text body:text\n" \
               "bin/super-scaffold crud Section Page,Site,Team title:text body:text\n"
           end
 

--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/join_model_scaffolder.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/join_model_scaffolder.rb
@@ -11,29 +11,21 @@ module BulletTrain
             puts ""
             puts "  Given the following example models:".blue
             puts ""
-            puts "    rails g model Project team:references name:string description:text"
             puts "    bin/super-scaffold crud Project Team name:text_field description:trix_editor"
             puts ""
-            puts "    rails g model Projects::Tag team:references name:string"
             puts "    bin/super-scaffold crud Projects::Tag Team name:text_field"
             puts ""
-            puts "  1️⃣  Use the standard Rails model generator to generate the join model:".blue
-            puts ""
-            puts "    rails g model Projects::AppliedTag project:references tag:references"
-            puts ""
-            puts "    👋 Don't run migrations yet! Sometimes Super Scaffolding updates them for you.".yellow
-            puts ""
-            puts "  2️⃣  Use `join-model` scaffolding to prepare the join model for use in `crud-field` scaffolding:".blue
+            puts "  1️⃣   Use `join-model` scaffolding to generate the join model for use in `crud-field` scaffolding:".blue
             puts ""
             puts "    bin/super-scaffold join-model Projects::AppliedTag project_id{class_name=Project} tag_id{class_name=Projects::Tag}"
             puts ""
-            puts "  3️⃣  Now you can use `crud-field` scaffolding to actually add the field to the form of the parent model:".blue
+            puts "  2️⃣  Now you can use `crud-field` scaffolding to actually add the field to the form of the parent model:".blue
             puts ""
             puts "    bin/super-scaffold crud-field Project tag_ids:super_select{class_name=Projects::Tag}"
             puts ""
             puts "    👋 Heads up! There will be one follow-up step output by this command that you need to take action on."
             puts ""
-            puts "  4️⃣  Now you can run your migrations.".blue
+            puts "  3️⃣  Now you can run your migrations.".blue
             exit
           end
 

--- a/bullet_train/docs/getting-started.md
+++ b/bullet_train/docs/getting-started.md
@@ -19,7 +19,6 @@ If you're using Bullet Train for the first time, begin by learning these five im
 2. Use `bin/super-scaffold crud-field` to add a new field to a model you've already scaffolded:
 
     ```
-    rails g migration add_description_to_projects description:text
     bin/super-scaffold crud-field Project description:trix_editor
     ```
 

--- a/bullet_train/docs/super-scaffolding/sortable.md
+++ b/bullet_train/docs/super-scaffolding/sortable.md
@@ -4,7 +4,6 @@ When issuing a `bin/super-scaffold crud` command, you can pass the `--sortable` 
 
 ```
 # E.g. Pages belong to a Site and are sortable via drag-and-drop:
-rails g model Page site:references name:string path:text
 bin/super-scaffold crud Page Site,Team name:text_field path:text_area --sortable
 ```
 


### PR DESCRIPTION
This just makes some documentation and help text match our current functionality.

Fixes https://github.com/bullet-train-co/bullet_train-core/issues/625