### PR TITLE
Try to pin jbuilder-schema to a version

### DIFF
--- a/bullet_train-api/bullet_train-api.gemspec
+++ b/bullet_train-api/bullet_train-api.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pagy_cursor"
   spec.add_dependency "rack-cors"
   spec.add_dependency "doorkeeper"
-  spec.add_dependency "jbuilder-schema", "~> 2.6.0"
+  spec.add_dependency "jbuilder-schema", "~> 2.6.1"
   spec.add_dependency "factory_bot"
 
   spec.add_dependency "bullet_train"

--- a/bullet_train-api/bullet_train-api.gemspec
+++ b/bullet_train-api/bullet_train-api.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pagy_cursor"
   spec.add_dependency "rack-cors"
   spec.add_dependency "doorkeeper"
-  spec.add_dependency "jbuilder-schema", ">= 2.4.0"
+  spec.add_dependency "jbuilder-schema", "~> 2.6.0"
   spec.add_dependency "factory_bot"
 
   spec.add_dependency "bullet_train"


### PR DESCRIPTION
We seem to be having problems in CI where we're not getting a consistent version for `jbuilder-schema`. So this is an attempt to make sure we get the (currently) latest version. We may need to do some more work to make sure this stays in sync with what the gems & starter repo expect. (Does it need to be a first-class dependency that we list in `Gemfile` of the starter repo?)