### PR TITLE
Lock jbuilder-schema to a known good version

### DIFF
--- a/bullet_train-api/bullet_train-api.gemspec
+++ b/bullet_train-api/bullet_train-api.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pagy_cursor"
   spec.add_dependency "rack-cors"
   spec.add_dependency "doorkeeper"
-  spec.add_dependency "jbuilder-schema", "~> 2.6.1"
+  spec.add_dependency "jbuilder-schema", "2.6.2"
   spec.add_dependency "factory_bot"
 
   spec.add_dependency "bullet_train"


### PR DESCRIPTION
This gem is floating to the latest version in CI, and the latest version has a bug. So for now I'm locking it down.

We need to get the `jbuilder-schema` repo set up to pull down the starter repo and run it's test suite as part of the CI process for `jbuilder-schema`. We really need to catch these things before we release a new version instead of after.