### PR TITLE
[CI] Be more explicit about some dependencies

### DIFF
--- a/bullet_train-api/.gitignore
+++ b/bullet_train-api/.gitignore
@@ -8,7 +8,6 @@
 /test/dummy/log/*.log
 /test/dummy/storage/
 /test/dummy/tmp/
-Gemfile.lock
 yarn.lock
 /node_modules
 /.idea/

--- a/bullet_train-api/Gemfile
+++ b/bullet_train-api/Gemfile
@@ -8,8 +8,10 @@ gem "sqlite3"
 
 gem "sprockets-rails"
 
-gem "bullet_train"
-gem "bullet_train-super_scaffolding"
+gem "bullet_train", path: "../bullet_train"
+gem "bullet_train-fields", path: "../bullet_train-fields"
+gem "bullet_train-super_scaffolding", path: "../bullet_train-super_scaffolding"
+gem "bullet_train-super_load_and_authorize_resource", path: "../bullet_train-super_load_and_authorize_resource"
 
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"

--- a/bullet_train-api/Gemfile.lock
+++ b/bullet_train-api/Gemfile.lock
@@ -1,16 +1,17 @@
 PATH
-  remote: ../bullet_train-api
+  remote: ../bullet_train-fields
   specs:
-    bullet_train-api (1.6.13)
-      bullet_train
-      bullet_train-super_scaffolding
-      colorizer
-      doorkeeper
-      factory_bot
-      jbuilder-schema (= 2.6.2)
-      pagy
-      pagy_cursor
-      rack-cors
+    bullet_train-fields (1.6.13)
+      chronic
+      cloudinary
+      phonelib
+      rails (>= 6.0.0)
+
+PATH
+  remote: ../bullet_train-super_load_and_authorize_resource
+  specs:
+    bullet_train-super_load_and_authorize_resource (1.6.13)
+      cancancan
       rails (>= 6.0.0)
 
 PATH
@@ -23,92 +24,8 @@ PATH
       rails (>= 6.0.0)
 
 PATH
-  remote: .
+  remote: ../bullet_train
   specs:
-    bullet_train-fields (1.6.13)
-      chronic
-      cloudinary
-      phonelib
-      rails (>= 6.0.0)
-
-GEM
-  remote: https://rubygems.org/
-  specs:
-    actioncable (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      nio4r (~> 2.0)
-      websocket-driver (>= 0.6.1)
-    actionmailbox (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activestorage (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      mail (>= 2.7.1)
-      net-imap
-      net-pop
-      net-smtp
-    actionmailer (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      actionview (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      mail (~> 2.5, >= 2.5.4)
-      net-imap
-      net-pop
-      net-smtp
-      rails-dom-testing (~> 2.0)
-    actionpack (7.0.3.1)
-      actionview (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      rack (~> 2.0, >= 2.2.0)
-      rack-test (>= 0.6.3)
-      rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actiontext (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activestorage (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      globalid (>= 0.6.0)
-      nokogiri (>= 1.8.5)
-    actionview (7.0.3.1)
-      activesupport (= 7.0.3.1)
-      builder (~> 3.1)
-      erubi (~> 1.4)
-      rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    active_hash (3.2.1)
-      activesupport (>= 5.0.0)
-    activejob (7.0.3.1)
-      activesupport (= 7.0.3.1)
-      globalid (>= 0.3.6)
-    activemodel (7.0.3.1)
-      activesupport (= 7.0.3.1)
-    activerecord (7.0.3.1)
-      activemodel (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-    activestorage (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      marcel (~> 1.0)
-      mini_mime (>= 1.1.0)
-    activesupport (7.0.3.1)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      tzinfo (~> 2.0)
-    addressable (2.8.5)
-      public_suffix (>= 2.0.2, < 6.0)
-    ast (2.4.2)
-    awesome_print (1.9.2)
-    aws_cf_signer (0.1.3)
-    base64 (0.2.0)
-    bcrypt (3.1.19)
-    builder (3.2.4)
     bullet_train (1.6.13)
       awesome_print
       bullet_train-fields
@@ -141,21 +58,112 @@ GEM
       unicode-emoji
       valid_email
       xxhash
-    bullet_train-has_uuid (1.6.13)
+
+PATH
+  remote: .
+  specs:
+    bullet_train-api (1.6.13)
+      bullet_train
+      bullet_train-super_scaffolding
+      colorizer
+      doorkeeper
+      factory_bot
+      jbuilder-schema (= 2.6.2)
+      pagy
+      pagy_cursor
+      rack-cors
       rails (>= 6.0.0)
-    bullet_train-roles (1.6.13)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (7.0.8)
+      actionpack (= 7.0.8)
+      activesupport (= 7.0.8)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+    actionmailbox (7.0.8)
+      actionpack (= 7.0.8)
+      activejob (= 7.0.8)
+      activerecord (= 7.0.8)
+      activestorage (= 7.0.8)
+      activesupport (= 7.0.8)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.0.8)
+      actionpack (= 7.0.8)
+      actionview (= 7.0.8)
+      activejob (= 7.0.8)
+      activesupport (= 7.0.8)
+      mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
+      rails-dom-testing (~> 2.0)
+    actionpack (7.0.8)
+      actionview (= 7.0.8)
+      activesupport (= 7.0.8)
+      rack (~> 2.0, >= 2.2.4)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actiontext (7.0.8)
+      actionpack (= 7.0.8)
+      activerecord (= 7.0.8)
+      activestorage (= 7.0.8)
+      activesupport (= 7.0.8)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (7.0.8)
+      activesupport (= 7.0.8)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_hash (3.2.0)
+      activesupport (>= 5.0.0)
+    activejob (7.0.8)
+      activesupport (= 7.0.8)
+      globalid (>= 0.3.6)
+    activemodel (7.0.8)
+      activesupport (= 7.0.8)
+    activerecord (7.0.8)
+      activemodel (= 7.0.8)
+      activesupport (= 7.0.8)
+    activestorage (7.0.8)
+      actionpack (= 7.0.8)
+      activejob (= 7.0.8)
+      activerecord (= 7.0.8)
+      activesupport (= 7.0.8)
+      marcel (~> 1.0)
+      mini_mime (>= 1.1.0)
+    activesupport (7.0.8)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    addressable (2.8.5)
+      public_suffix (>= 2.0.2, < 6.0)
+    ast (2.4.2)
+    awesome_print (1.9.2)
+    aws_cf_signer (0.1.3)
+    base64 (0.1.1)
+    bcrypt (3.1.19)
+    builder (3.2.4)
+    bullet_train-has_uuid (1.4.6)
+      rails (>= 6.0.0)
+    bullet_train-roles (1.4.6)
       active_hash
       activesupport
       cancancan
     bullet_train-routes (1.0.0)
       rails (>= 6.0.0)
-    bullet_train-scope_validator (1.6.13)
-    bullet_train-super_load_and_authorize_resource (1.6.13)
-      cancancan
+    bullet_train-scope_validator (1.4.6)
+    bullet_train-themes (1.4.6)
       rails (>= 6.0.0)
-    bullet_train-themes (1.6.13)
-      rails (>= 6.0.0)
-    cable_ready (5.0.3)
+    cable_ready (5.0.1)
       actionpack (>= 5.2)
       actionview (>= 5.2)
       activesupport (>= 5.2)
@@ -169,13 +177,13 @@ GEM
       rest-client (>= 2.0.0)
     colorizer (0.0.2)
     commonmarker (0.23.10)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crass (1.0.6)
     css_parser (1.16.0)
       addressable
-    date (3.3.4)
-    devise (4.9.3)
+    date (3.3.3)
+    devise (4.9.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)
@@ -188,14 +196,13 @@ GEM
     doorkeeper (5.6.6)
       railties (>= 5)
     email_reply_parser (0.5.11)
-    erubi (1.10.0)
-    event_stream_parser (0.3.0)
+    erubi (1.12.0)
     extended_email_reply_parser (0.5.1)
       activesupport
       charlock_holmes
       email_reply_parser (~> 0.5.9)
       mail
-    factory_bot (6.3.0)
+    factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     faraday (2.7.11)
       base64
@@ -205,7 +212,7 @@ GEM
       multipart-post (~> 2)
     faraday-net_http (3.0.2)
     fastimage (2.2.7)
-    ffi (1.16.3)
+    ffi (1.15.5)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
     globalid (1.2.1)
@@ -216,7 +223,7 @@ GEM
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     http_accept_language (2.1.1)
-    i18n (1.11.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
@@ -230,10 +237,12 @@ GEM
       jbuilder
       method_source
       rails (>= 5.0.0)
-    json (2.6.2)
-    loofah (2.18.0)
+    json (2.6.3)
+    language_server-protocol (3.17.0.3)
+    lint_roller (1.1.0)
+    loofah (2.21.3)
       crass (~> 1.0.2)
-      nokogiri (>= 1.5.9)
+      nokogiri (>= 1.12.0)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
@@ -252,33 +261,32 @@ GEM
     mime-types-data (3.2023.1003)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.1)
-    minitest (5.16.2)
+    minitest (5.20.0)
     multipart-post (2.3.0)
-    net-imap (0.4.5)
+    net-imap (0.3.7)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.2.2)
+    net-protocol (0.2.1)
       timeout
-    net-smtp (0.4.0)
+    net-smtp (0.3.3)
       net-protocol
     netrc (0.11.0)
     nice_partials (0.10.0)
       actionview (>= 4.2.6)
     nio4r (2.5.9)
-    nokogiri (1.13.7)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
     orm_adapter (0.5.0)
-    pagy (6.2.0)
+    pagy (6.0.4)
     pagy_cursor (0.6.1)
       activerecord (>= 5)
       pagy (>= 6, < 7)
-    parallel (1.22.1)
-    parser (3.1.2.0)
+    parallel (1.23.0)
+    parser (3.2.2.3)
       ast (~> 2.4.1)
+      racc
     phonelib (0.8.5)
     possessive (1.0.1)
     premailer (1.21.0)
@@ -292,44 +300,46 @@ GEM
     prism (0.17.1)
     public_suffix (5.0.3)
     pwned (2.0.2)
-    racc (1.6.0)
-    rack (2.2.4)
+    racc (1.7.1)
+    rack (2.2.8)
     rack-cors (2.0.1)
       rack (>= 2.0.0)
-    rack-test (2.0.2)
+    rack-test (2.1.0)
       rack (>= 1.3)
-    rails (7.0.3.1)
-      actioncable (= 7.0.3.1)
-      actionmailbox (= 7.0.3.1)
-      actionmailer (= 7.0.3.1)
-      actionpack (= 7.0.3.1)
-      actiontext (= 7.0.3.1)
-      actionview (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activemodel (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activestorage (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
+    rails (7.0.8)
+      actioncable (= 7.0.8)
+      actionmailbox (= 7.0.8)
+      actionmailer (= 7.0.8)
+      actionpack (= 7.0.8)
+      actiontext (= 7.0.8)
+      actionview (= 7.0.8)
+      activejob (= 7.0.8)
+      activemodel (= 7.0.8)
+      activerecord (= 7.0.8)
+      activestorage (= 7.0.8)
+      activesupport (= 7.0.8)
       bundler (>= 1.15.0)
-      railties (= 7.0.3.1)
-    rails-dom-testing (2.0.3)
-      activesupport (>= 4.2.0)
+      railties (= 7.0.8)
+    rails-dom-testing (2.2.0)
+      activesupport (>= 5.0.0)
+      minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.3)
-      loofah (~> 2.3)
-    railties (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
+    rails-html-sanitizer (1.6.0)
+      loofah (~> 2.21)
+      nokogiri (~> 1.14)
+    railties (7.0.8)
+      actionpack (= 7.0.8)
+      activesupport (= 7.0.8)
       method_source
       rake (>= 12.2)
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
-    rake (13.1.0)
-    redis-client (0.18.0)
+    rake (13.0.6)
+    redis-client (0.17.0)
       connection_pool
-    regexp_parser (2.5.0)
-    responders (3.1.1)
+    regexp_parser (2.8.1)
+    responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
     rest-client (2.1.0)
@@ -337,63 +347,73 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.2.5)
-    rubocop (1.32.0)
+    rexml (3.2.6)
+    rubocop (1.56.3)
+      base64 (~> 0.1.1)
       json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.1.0.0)
+      parser (>= 3.2.2.3)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.19.1, < 2.0)
+      rubocop-ast (>= 1.28.1, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.19.1)
-      parser (>= 3.1.1.0)
-    rubocop-performance (1.14.3)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.29.0)
+      parser (>= 3.2.1.0)
+    rubocop-performance (1.19.0)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
-    ruby-openai (6.2.0)
-      event_stream_parser (>= 0.3.0, < 1.0.0)
+    ruby-openai (5.1.0)
       faraday (>= 1)
       faraday-multipart (>= 1)
-    ruby-progressbar (1.11.0)
-    ruby-vips (2.2.0)
+    ruby-progressbar (1.13.0)
+    ruby-vips (2.1.4)
       ffi (~> 1.12)
     ruby2_keywords (0.0.5)
     showcase-rails (0.4.6)
       rails (>= 6.1.0)
-    sidekiq (7.2.0)
+    sidekiq (7.1.4)
       concurrent-ruby (< 2)
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.14.0)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
-    sprockets (4.1.1)
+    sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
+      rack (>= 2.2.4, < 4)
     sprockets-rails (3.4.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.4)
-    standard (1.14.0)
-      rubocop (= 1.32.0)
-      rubocop-performance (= 1.14.3)
-    thor (1.3.0)
+    sqlite3 (1.6.3-arm64-darwin)
+    standard (1.31.1)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.56.2)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.2)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.2.0)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.19.0)
+    thor (1.2.2)
     thread-local (1.1.0)
-    timeout (0.4.1)
-    tzinfo (2.0.4)
+    timeout (0.4.0)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.9)
-    unicode-display_width (2.2.0)
-    unicode-emoji (3.4.0)
+    unf_ext (0.0.8.2)
+    unicode-display_width (2.4.2)
+    unicode-emoji (3.3.2)
       unicode-version (~> 1.0)
     unicode-version (1.3.0)
-    valid_email (0.2.0)
+    valid_email (0.1.4)
       activemodel
       mail (>= 2.6.1)
       simpleidn
@@ -403,24 +423,20 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     xxhash (0.5.0)
-    zeitwerk (2.6.12)
+    zeitwerk (2.6.11)
 
 PLATFORMS
-  arm64-darwin-20
-  arm64-darwin-21
   arm64-darwin-22
-  ruby
-  x86_64-darwin-21
-  x86_64-darwin-22
-  x86_64-linux
 
 DEPENDENCIES
+  bullet_train!
   bullet_train-api!
   bullet_train-fields!
+  bullet_train-super_load_and_authorize_resource!
   bullet_train-super_scaffolding!
   sprockets-rails
   sqlite3
   standard
 
 BUNDLED WITH
-   2.3.14
+   2.4.18

--- a/bullet_train-api/bullet_train-api.gemspec
+++ b/bullet_train-api/bullet_train-api.gemspec
@@ -24,13 +24,15 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "standard"
 
+  spec.add_dependency "bullet_train-super_scaffolding"
+  spec.add_dependency "bullet_train"
+
   spec.add_dependency "rails", ">= 6.0.0"
   spec.add_dependency "pagy"
   spec.add_dependency "pagy_cursor"
   spec.add_dependency "rack-cors"
   spec.add_dependency "doorkeeper"
   spec.add_dependency "jbuilder-schema", "2.6.2"
+  spec.add_dependency "colorizer"
   spec.add_dependency "factory_bot"
-
-  spec.add_dependency "bullet_train"
 end

--- a/bullet_train-fields/Gemfile
+++ b/bullet_train-fields/Gemfile
@@ -8,5 +8,7 @@ gem "sqlite3"
 
 gem "sprockets-rails"
 
+gem "bullet_train-api", path: "../bullet_train-api"
+gem "bullet_train-super_scaffolding", path: "../bullet_train-super_scaffolding"
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"

--- a/bullet_train-has_uuid/Gemfile.lock
+++ b/bullet_train-has_uuid/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    bullet_train-scope_validator (1.6.13)
-      rails
+    bullet_train-has_uuid (1.6.13)
+      rails (>= 6.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -81,7 +81,6 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
-    ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.4)
     builder (3.2.4)
@@ -110,7 +109,7 @@ GEM
       net-smtp
     marcel (1.0.2)
     mini_mime (1.1.5)
-    minitest (5.15.0)
+    minitest (5.20.0)
     mutex_m (0.2.0)
     net-imap (0.4.5)
       date
@@ -124,11 +123,6 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.4-x86_64-linux)
-      racc (~> 1.4)
-    parallel (1.21.0)
-    parser (3.1.0.0)
-      ast (~> 2.4.1)
     psych (5.1.1.1)
       stringio
     racc (1.7.3)
@@ -169,39 +163,25 @@ GEM
       rake (>= 12.2)
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
-    rainbow (3.1.1)
-    rake (13.0.6)
+    rake (13.1.0)
     rdoc (6.6.0)
       psych (>= 4.0.0)
-    regexp_parser (2.2.0)
     reline (0.4.0)
       io-console (~> 0.5)
-    rexml (3.2.5)
-    rubocop (1.24.1)
-      parallel (~> 1.10)
-      parser (>= 3.0.0.0)
-      rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8, < 3.0)
-      rexml
-      rubocop-ast (>= 1.15.1, < 2.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.15.1)
-      parser (>= 3.0.1.1)
-    rubocop-performance (1.13.1)
-      rubocop (>= 1.7.0, < 2.0)
-      rubocop-ast (>= 0.4.0)
-    ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
-    standard (1.6.0)
-      rubocop (= 1.24.1)
-      rubocop-performance (= 1.13.1)
+    sprockets (4.2.1)
+      concurrent-ruby (~> 1.0)
+      rack (>= 2.2.4, < 4)
+    sprockets-rails (3.4.2)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
+      sprockets (>= 3.0.0)
+    sqlite3 (1.6.8-arm64-darwin)
     stringio (3.0.9)
     thor (1.3.0)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (2.1.0)
     webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -209,16 +189,12 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
-  arm64-darwin-20
-  arm64-darwin-21
   arm64-darwin-22
-  x86_64-linux
 
 DEPENDENCIES
-  bullet_train-scope_validator!
-  minitest (~> 5.0)
-  rake (~> 13.0)
-  standard (~> 1.3)
+  bullet_train-has_uuid!
+  sprockets-rails
+  sqlite3
 
 BUNDLED WITH
-   2.3.4
+   2.4.20

--- a/bullet_train-incoming_webhooks/Gemfile
+++ b/bullet_train-incoming_webhooks/Gemfile
@@ -7,7 +7,12 @@ gemspec
 gem "sqlite3"
 
 gem "sprockets-rails"
-gem "bullet_train"
+
+gem "bullet_train-super_scaffolding", path: "../bullet_train-super_scaffolding"
+gem "bullet_train-super_load_and_authorize_resource", path: "../bullet_train-super_load_and_authorize_resource"
+gem "bullet_train-api", path: "../bullet_train-api"
+gem "bullet_train-fields", path: "../bullet_train-fields"
+gem "bullet_train", path: "../bullet_train"
 
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"

--- a/bullet_train-incoming_webhooks/Gemfile.lock
+++ b/bullet_train-incoming_webhooks/Gemfile.lock
@@ -14,6 +14,22 @@ PATH
       rails (>= 6.0.0)
 
 PATH
+  remote: ../bullet_train-fields
+  specs:
+    bullet_train-fields (1.6.13)
+      chronic
+      cloudinary
+      phonelib
+      rails (>= 6.0.0)
+
+PATH
+  remote: ../bullet_train-super_load_and_authorize_resource
+  specs:
+    bullet_train-super_load_and_authorize_resource (1.6.13)
+      cancancan
+      rails (>= 6.0.0)
+
+PATH
   remote: ../bullet_train-super_scaffolding
   specs:
     bullet_train-super_scaffolding (1.6.13)
@@ -23,92 +39,8 @@ PATH
       rails (>= 6.0.0)
 
 PATH
-  remote: .
+  remote: ../bullet_train
   specs:
-    bullet_train-fields (1.6.13)
-      chronic
-      cloudinary
-      phonelib
-      rails (>= 6.0.0)
-
-GEM
-  remote: https://rubygems.org/
-  specs:
-    actioncable (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      nio4r (~> 2.0)
-      websocket-driver (>= 0.6.1)
-    actionmailbox (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activestorage (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      mail (>= 2.7.1)
-      net-imap
-      net-pop
-      net-smtp
-    actionmailer (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      actionview (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      mail (~> 2.5, >= 2.5.4)
-      net-imap
-      net-pop
-      net-smtp
-      rails-dom-testing (~> 2.0)
-    actionpack (7.0.3.1)
-      actionview (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      rack (~> 2.0, >= 2.2.0)
-      rack-test (>= 0.6.3)
-      rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actiontext (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activestorage (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      globalid (>= 0.6.0)
-      nokogiri (>= 1.8.5)
-    actionview (7.0.3.1)
-      activesupport (= 7.0.3.1)
-      builder (~> 3.1)
-      erubi (~> 1.4)
-      rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    active_hash (3.2.1)
-      activesupport (>= 5.0.0)
-    activejob (7.0.3.1)
-      activesupport (= 7.0.3.1)
-      globalid (>= 0.3.6)
-    activemodel (7.0.3.1)
-      activesupport (= 7.0.3.1)
-    activerecord (7.0.3.1)
-      activemodel (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-    activestorage (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      marcel (~> 1.0)
-      mini_mime (>= 1.1.0)
-    activesupport (7.0.3.1)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      tzinfo (~> 2.0)
-    addressable (2.8.5)
-      public_suffix (>= 2.0.2, < 6.0)
-    ast (2.4.2)
-    awesome_print (1.9.2)
-    aws_cf_signer (0.1.3)
-    base64 (0.2.0)
-    bcrypt (3.1.19)
-    builder (3.2.4)
     bullet_train (1.6.13)
       awesome_print
       bullet_train-fields
@@ -141,6 +73,103 @@ GEM
       unicode-emoji
       valid_email
       xxhash
+
+PATH
+  remote: .
+  specs:
+    bullet_train-incoming_webhooks (1.6.13)
+      bullet_train
+      bullet_train-api
+      bullet_train-super_scaffolding
+      rails (>= 6.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (7.1.2)
+      actionpack (= 7.1.2)
+      activesupport (= 7.1.2)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+      zeitwerk (~> 2.6)
+    actionmailbox (7.1.2)
+      actionpack (= 7.1.2)
+      activejob (= 7.1.2)
+      activerecord (= 7.1.2)
+      activestorage (= 7.1.2)
+      activesupport (= 7.1.2)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.1.2)
+      actionpack (= 7.1.2)
+      actionview (= 7.1.2)
+      activejob (= 7.1.2)
+      activesupport (= 7.1.2)
+      mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
+      rails-dom-testing (~> 2.2)
+    actionpack (7.1.2)
+      actionview (= 7.1.2)
+      activesupport (= 7.1.2)
+      nokogiri (>= 1.8.5)
+      racc
+      rack (>= 2.2.4)
+      rack-session (>= 1.0.1)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    actiontext (7.1.2)
+      actionpack (= 7.1.2)
+      activerecord (= 7.1.2)
+      activestorage (= 7.1.2)
+      activesupport (= 7.1.2)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (7.1.2)
+      activesupport (= 7.1.2)
+      builder (~> 3.1)
+      erubi (~> 1.11)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    active_hash (3.2.1)
+      activesupport (>= 5.0.0)
+    activejob (7.1.2)
+      activesupport (= 7.1.2)
+      globalid (>= 0.3.6)
+    activemodel (7.1.2)
+      activesupport (= 7.1.2)
+    activerecord (7.1.2)
+      activemodel (= 7.1.2)
+      activesupport (= 7.1.2)
+      timeout (>= 0.4.0)
+    activestorage (7.1.2)
+      actionpack (= 7.1.2)
+      activejob (= 7.1.2)
+      activerecord (= 7.1.2)
+      activesupport (= 7.1.2)
+      marcel (~> 1.0)
+    activesupport (7.1.2)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      mutex_m
+      tzinfo (~> 2.0)
+    addressable (2.8.5)
+      public_suffix (>= 2.0.2, < 6.0)
+    awesome_print (1.9.2)
+    aws_cf_signer (0.1.3)
+    base64 (0.2.0)
+    bcrypt (3.1.19)
+    bigdecimal (3.1.4)
+    builder (3.2.4)
     bullet_train-has_uuid (1.6.13)
       rails (>= 6.0.0)
     bullet_train-roles (1.6.13)
@@ -150,9 +179,6 @@ GEM
     bullet_train-routes (1.0.0)
       rails (>= 6.0.0)
     bullet_train-scope_validator (1.6.13)
-    bullet_train-super_load_and_authorize_resource (1.6.13)
-      cancancan
-      rails (>= 6.0.0)
     bullet_train-themes (1.6.13)
       rails (>= 6.0.0)
     cable_ready (5.0.3)
@@ -169,7 +195,7 @@ GEM
       rest-client (>= 2.0.0)
     colorizer (0.0.2)
     commonmarker (0.23.10)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crass (1.0.6)
     css_parser (1.16.0)
@@ -187,16 +213,21 @@ GEM
     domain_name (0.6.20231109)
     doorkeeper (5.6.6)
       railties (>= 5)
+    drb (2.2.0)
+      ruby2_keywords
     email_reply_parser (0.5.11)
-    erubi (1.10.0)
+    erubi (1.12.0)
     event_stream_parser (0.3.0)
     extended_email_reply_parser (0.5.1)
       activesupport
       charlock_holmes
       email_reply_parser (~> 0.5.9)
       mail
-    factory_bot (6.3.0)
+    factory_bot (6.2.1)
       activesupport (>= 5.0.0)
+    factory_bot_rails (6.2.0)
+      factory_bot (~> 6.2.0)
+      railties (>= 5.0.0)
     faraday (2.7.11)
       base64
       faraday-net_http (>= 2.0, < 3.1)
@@ -216,13 +247,17 @@ GEM
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     http_accept_language (2.1.1)
-    i18n (1.11.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
     indefinite_article (0.2.5)
       activesupport
+    io-console (0.6.0)
+    irb (1.9.0)
+      rdoc
+      reline (>= 0.3.8)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -230,10 +265,9 @@ GEM
       jbuilder
       method_source
       rails (>= 5.0.0)
-    json (2.6.2)
-    loofah (2.18.0)
+    loofah (2.22.0)
       crass (~> 1.0.2)
-      nokogiri (>= 1.5.9)
+      nokogiri (>= 1.12.0)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
@@ -252,9 +286,9 @@ GEM
     mime-types-data (3.2023.1003)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.1)
-    minitest (5.16.2)
+    minitest (5.20.0)
     multipart-post (2.3.0)
+    mutex_m (0.2.0)
     net-imap (0.4.5)
       date
       net-protocol
@@ -268,17 +302,14 @@ GEM
     nice_partials (0.10.0)
       actionview (>= 4.2.6)
     nio4r (2.5.9)
-    nokogiri (1.13.7)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     pagy (6.2.0)
     pagy_cursor (0.6.1)
       activerecord (>= 5)
       pagy (>= 6, < 7)
-    parallel (1.22.1)
-    parser (3.1.2.0)
-      ast (~> 2.4.1)
+    pg (1.5.4)
     phonelib (0.8.5)
     possessive (1.0.1)
     premailer (1.21.0)
@@ -290,45 +321,57 @@ GEM
       net-smtp
       premailer (~> 1.7, >= 1.7.9)
     prism (0.17.1)
+    psych (5.1.1.1)
+      stringio
     public_suffix (5.0.3)
     pwned (2.0.2)
-    racc (1.6.0)
-    rack (2.2.4)
+    racc (1.7.3)
+    rack (3.0.8)
     rack-cors (2.0.1)
       rack (>= 2.0.0)
-    rack-test (2.0.2)
+    rack-session (2.0.0)
+      rack (>= 3.0.0)
+    rack-test (2.1.0)
       rack (>= 1.3)
-    rails (7.0.3.1)
-      actioncable (= 7.0.3.1)
-      actionmailbox (= 7.0.3.1)
-      actionmailer (= 7.0.3.1)
-      actionpack (= 7.0.3.1)
-      actiontext (= 7.0.3.1)
-      actionview (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activemodel (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activestorage (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
+    rackup (2.1.0)
+      rack (>= 3)
+      webrick (~> 1.8)
+    rails (7.1.2)
+      actioncable (= 7.1.2)
+      actionmailbox (= 7.1.2)
+      actionmailer (= 7.1.2)
+      actionpack (= 7.1.2)
+      actiontext (= 7.1.2)
+      actionview (= 7.1.2)
+      activejob (= 7.1.2)
+      activemodel (= 7.1.2)
+      activerecord (= 7.1.2)
+      activestorage (= 7.1.2)
+      activesupport (= 7.1.2)
       bundler (>= 1.15.0)
-      railties (= 7.0.3.1)
-    rails-dom-testing (2.0.3)
-      activesupport (>= 4.2.0)
+      railties (= 7.1.2)
+    rails-dom-testing (2.2.0)
+      activesupport (>= 5.0.0)
+      minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.3)
-      loofah (~> 2.3)
-    railties (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      method_source
+    rails-html-sanitizer (1.6.0)
+      loofah (~> 2.21)
+      nokogiri (~> 1.14)
+    railties (7.1.2)
+      actionpack (= 7.1.2)
+      activesupport (= 7.1.2)
+      irb
+      rackup (>= 1.0.0)
       rake (>= 12.2)
-      thor (~> 1.0)
-      zeitwerk (~> 2.5)
-    rainbow (3.1.1)
+      thor (~> 1.0, >= 1.2.2)
+      zeitwerk (~> 2.6)
     rake (13.1.0)
+    rdoc (6.6.0)
+      psych (>= 4.0.0)
     redis-client (0.18.0)
       connection_pool
-    regexp_parser (2.5.0)
+    reline (0.4.0)
+      io-console (~> 0.5)
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
@@ -337,27 +380,10 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.2.5)
-    rubocop (1.32.0)
-      json (~> 2.3)
-      parallel (~> 1.10)
-      parser (>= 3.1.0.0)
-      rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8, < 3.0)
-      rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.19.1, < 2.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.19.1)
-      parser (>= 3.1.1.0)
-    rubocop-performance (1.14.3)
-      rubocop (>= 1.7.0, < 2.0)
-      rubocop-ast (>= 0.4.0)
     ruby-openai (6.2.0)
       event_stream_parser (>= 0.3.0, < 1.0.0)
       faraday (>= 1)
       faraday-multipart (>= 1)
-    ruby-progressbar (1.11.0)
     ruby-vips (2.2.0)
       ffi (~> 1.12)
     ruby2_keywords (0.0.5)
@@ -370,26 +396,23 @@ GEM
       redis-client (>= 0.14.0)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
-    sprockets (4.1.1)
+    sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
+      rack (>= 2.2.4, < 4)
     sprockets-rails (3.4.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.4)
-    standard (1.14.0)
-      rubocop (= 1.32.0)
-      rubocop-performance (= 1.14.3)
+    sqlite3 (1.6.8-arm64-darwin)
+    stringio (3.0.9)
     thor (1.3.0)
     thread-local (1.1.0)
     timeout (0.4.1)
-    tzinfo (2.0.4)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.9)
-    unicode-display_width (2.2.0)
     unicode-emoji (3.4.0)
       unicode-version (~> 1.0)
     unicode-version (1.3.0)
@@ -399,6 +422,7 @@ GEM
       simpleidn
     warden (1.2.9)
       rack (>= 2.0.9)
+    webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -406,21 +430,19 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
-  arm64-darwin-20
-  arm64-darwin-21
   arm64-darwin-22
-  ruby
-  x86_64-darwin-21
-  x86_64-darwin-22
-  x86_64-linux
 
 DEPENDENCIES
+  bullet_train!
   bullet_train-api!
   bullet_train-fields!
+  bullet_train-incoming_webhooks!
+  bullet_train-super_load_and_authorize_resource!
   bullet_train-super_scaffolding!
+  factory_bot_rails
+  pg (~> 1.3)
   sprockets-rails
   sqlite3
-  standard
 
 BUNDLED WITH
-   2.3.14
+   2.4.20

--- a/bullet_train-incoming_webhooks/bullet_train-incoming_webhooks.gemspec
+++ b/bullet_train-incoming_webhooks/bullet_train-incoming_webhooks.gemspec
@@ -24,4 +24,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails", ">= 6.0.0"
   spec.add_dependency "bullet_train-super_scaffolding"
+  spec.add_dependency "bullet_train-api"
+  spec.add_dependency "bullet_train"
+
+  spec.add_development_dependency "factory_bot_rails"
+  spec.add_development_dependency "pg", "~> 1.3"
 end

--- a/bullet_train-integrations-stripe/Gemfile
+++ b/bullet_train-integrations-stripe/Gemfile
@@ -8,5 +8,10 @@ gem "sqlite3"
 
 gem "sprockets-rails"
 
+gem "bullet_train", path: "../bullet_train"
+gem "bullet_train-api", path: "../bullet_train-api"
+gem "bullet_train-fields", path: "../bullet_train-fields"
+gem "bullet_train-super_scaffolding", path: "../bullet_train-super_scaffolding"
+gem "bullet_train-incoming_webhooks", path: "../bullet_train-incoming_webhooks"
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"

--- a/bullet_train-integrations-stripe/Gemfile.lock
+++ b/bullet_train-integrations-stripe/Gemfile.lock
@@ -14,6 +14,24 @@ PATH
       rails (>= 6.0.0)
 
 PATH
+  remote: ../bullet_train-fields
+  specs:
+    bullet_train-fields (1.6.13)
+      chronic
+      cloudinary
+      phonelib
+      rails (>= 6.0.0)
+
+PATH
+  remote: ../bullet_train-incoming_webhooks
+  specs:
+    bullet_train-incoming_webhooks (1.6.13)
+      bullet_train
+      bullet_train-api
+      bullet_train-super_scaffolding
+      rails (>= 6.0.0)
+
+PATH
   remote: ../bullet_train-super_scaffolding
   specs:
     bullet_train-super_scaffolding (1.6.13)
@@ -23,92 +41,8 @@ PATH
       rails (>= 6.0.0)
 
 PATH
-  remote: .
+  remote: ../bullet_train
   specs:
-    bullet_train-fields (1.6.13)
-      chronic
-      cloudinary
-      phonelib
-      rails (>= 6.0.0)
-
-GEM
-  remote: https://rubygems.org/
-  specs:
-    actioncable (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      nio4r (~> 2.0)
-      websocket-driver (>= 0.6.1)
-    actionmailbox (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activestorage (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      mail (>= 2.7.1)
-      net-imap
-      net-pop
-      net-smtp
-    actionmailer (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      actionview (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      mail (~> 2.5, >= 2.5.4)
-      net-imap
-      net-pop
-      net-smtp
-      rails-dom-testing (~> 2.0)
-    actionpack (7.0.3.1)
-      actionview (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      rack (~> 2.0, >= 2.2.0)
-      rack-test (>= 0.6.3)
-      rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actiontext (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activestorage (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      globalid (>= 0.6.0)
-      nokogiri (>= 1.8.5)
-    actionview (7.0.3.1)
-      activesupport (= 7.0.3.1)
-      builder (~> 3.1)
-      erubi (~> 1.4)
-      rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    active_hash (3.2.1)
-      activesupport (>= 5.0.0)
-    activejob (7.0.3.1)
-      activesupport (= 7.0.3.1)
-      globalid (>= 0.3.6)
-    activemodel (7.0.3.1)
-      activesupport (= 7.0.3.1)
-    activerecord (7.0.3.1)
-      activemodel (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-    activestorage (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      marcel (~> 1.0)
-      mini_mime (>= 1.1.0)
-    activesupport (7.0.3.1)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      tzinfo (~> 2.0)
-    addressable (2.8.5)
-      public_suffix (>= 2.0.2, < 6.0)
-    ast (2.4.2)
-    awesome_print (1.9.2)
-    aws_cf_signer (0.1.3)
-    base64 (0.2.0)
-    bcrypt (3.1.19)
-    builder (3.2.4)
     bullet_train (1.6.13)
       awesome_print
       bullet_train-fields
@@ -141,6 +75,104 @@ GEM
       unicode-emoji
       valid_email
       xxhash
+
+PATH
+  remote: .
+  specs:
+    bullet_train-integrations-stripe (1.6.13)
+      omniauth
+      omniauth-rails_csrf_protection
+      omniauth-stripe-connect
+      rails (>= 6.0.0)
+      stripe
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (7.1.2)
+      actionpack (= 7.1.2)
+      activesupport (= 7.1.2)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+      zeitwerk (~> 2.6)
+    actionmailbox (7.1.2)
+      actionpack (= 7.1.2)
+      activejob (= 7.1.2)
+      activerecord (= 7.1.2)
+      activestorage (= 7.1.2)
+      activesupport (= 7.1.2)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.1.2)
+      actionpack (= 7.1.2)
+      actionview (= 7.1.2)
+      activejob (= 7.1.2)
+      activesupport (= 7.1.2)
+      mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
+      rails-dom-testing (~> 2.2)
+    actionpack (7.1.2)
+      actionview (= 7.1.2)
+      activesupport (= 7.1.2)
+      nokogiri (>= 1.8.5)
+      racc
+      rack (>= 2.2.4)
+      rack-session (>= 1.0.1)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    actiontext (7.1.2)
+      actionpack (= 7.1.2)
+      activerecord (= 7.1.2)
+      activestorage (= 7.1.2)
+      activesupport (= 7.1.2)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (7.1.2)
+      activesupport (= 7.1.2)
+      builder (~> 3.1)
+      erubi (~> 1.11)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    active_hash (3.2.1)
+      activesupport (>= 5.0.0)
+    activejob (7.1.2)
+      activesupport (= 7.1.2)
+      globalid (>= 0.3.6)
+    activemodel (7.1.2)
+      activesupport (= 7.1.2)
+    activerecord (7.1.2)
+      activemodel (= 7.1.2)
+      activesupport (= 7.1.2)
+      timeout (>= 0.4.0)
+    activestorage (7.1.2)
+      actionpack (= 7.1.2)
+      activejob (= 7.1.2)
+      activerecord (= 7.1.2)
+      activesupport (= 7.1.2)
+      marcel (~> 1.0)
+    activesupport (7.1.2)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      mutex_m
+      tzinfo (~> 2.0)
+    addressable (2.8.5)
+      public_suffix (>= 2.0.2, < 6.0)
+    awesome_print (1.9.2)
+    aws_cf_signer (0.1.3)
+    base64 (0.2.0)
+    bcrypt (3.1.19)
+    bigdecimal (3.1.4)
+    builder (3.2.4)
     bullet_train-has_uuid (1.6.13)
       rails (>= 6.0.0)
     bullet_train-roles (1.6.13)
@@ -169,7 +201,7 @@ GEM
       rest-client (>= 2.0.0)
     colorizer (0.0.2)
     commonmarker (0.23.10)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crass (1.0.6)
     css_parser (1.16.0)
@@ -187,8 +219,10 @@ GEM
     domain_name (0.6.20231109)
     doorkeeper (5.6.6)
       railties (>= 5)
+    drb (2.2.0)
+      ruby2_keywords
     email_reply_parser (0.5.11)
-    erubi (1.10.0)
+    erubi (1.12.0)
     event_stream_parser (0.3.0)
     extended_email_reply_parser (0.5.1)
       activesupport
@@ -210,19 +244,24 @@ GEM
       thor (>= 0.14.0, < 2)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashie (5.0.0)
     hiredis (0.6.3)
     htmlentities (4.3.4)
     http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     http_accept_language (2.1.1)
-    i18n (1.11.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
     indefinite_article (0.2.5)
       activesupport
+    io-console (0.6.0)
+    irb (1.9.0)
+      rdoc
+      reline (>= 0.3.8)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -230,10 +269,10 @@ GEM
       jbuilder
       method_source
       rails (>= 5.0.0)
-    json (2.6.2)
-    loofah (2.18.0)
+    jwt (2.7.1)
+    loofah (2.22.0)
       crass (~> 1.0.2)
-      nokogiri (>= 1.5.9)
+      nokogiri (>= 1.12.0)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
@@ -252,9 +291,10 @@ GEM
     mime-types-data (3.2023.1003)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.1)
-    minitest (5.16.2)
+    minitest (5.20.0)
+    multi_xml (0.6.0)
     multipart-post (2.3.0)
+    mutex_m (0.2.0)
     net-imap (0.4.5)
       date
       net-protocol
@@ -268,17 +308,32 @@ GEM
     nice_partials (0.10.0)
       actionview (>= 4.2.6)
     nio4r (2.5.9)
-    nokogiri (1.13.7)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
+    oauth2 (2.0.9)
+      faraday (>= 0.17.3, < 3.0)
+      jwt (>= 1.0, < 3.0)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0)
+      version_gem (~> 1.1)
+    omniauth (1.9.2)
+      hashie (>= 3.4.6)
+      rack (>= 1.6.2, < 3)
+    omniauth-oauth2 (1.7.3)
+      oauth2 (>= 1.4, < 3)
+      omniauth (>= 1.9, < 3)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
+    omniauth-stripe-connect (2.10.1)
+      omniauth (~> 1.3)
+      omniauth-oauth2 (~> 1.4)
     orm_adapter (0.5.0)
     pagy (6.2.0)
     pagy_cursor (0.6.1)
       activerecord (>= 5)
       pagy (>= 6, < 7)
-    parallel (1.22.1)
-    parser (3.1.2.0)
-      ast (~> 2.4.1)
     phonelib (0.8.5)
     possessive (1.0.1)
     premailer (1.21.0)
@@ -290,45 +345,57 @@ GEM
       net-smtp
       premailer (~> 1.7, >= 1.7.9)
     prism (0.17.1)
+    psych (5.1.1.1)
+      stringio
     public_suffix (5.0.3)
     pwned (2.0.2)
-    racc (1.6.0)
-    rack (2.2.4)
+    racc (1.7.3)
+    rack (2.2.8)
     rack-cors (2.0.1)
       rack (>= 2.0.0)
-    rack-test (2.0.2)
+    rack-session (1.0.1)
+      rack (< 3)
+    rack-test (2.1.0)
       rack (>= 1.3)
-    rails (7.0.3.1)
-      actioncable (= 7.0.3.1)
-      actionmailbox (= 7.0.3.1)
-      actionmailer (= 7.0.3.1)
-      actionpack (= 7.0.3.1)
-      actiontext (= 7.0.3.1)
-      actionview (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activemodel (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activestorage (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
+    rackup (1.0.0)
+      rack (< 3)
+      webrick
+    rails (7.1.2)
+      actioncable (= 7.1.2)
+      actionmailbox (= 7.1.2)
+      actionmailer (= 7.1.2)
+      actionpack (= 7.1.2)
+      actiontext (= 7.1.2)
+      actionview (= 7.1.2)
+      activejob (= 7.1.2)
+      activemodel (= 7.1.2)
+      activerecord (= 7.1.2)
+      activestorage (= 7.1.2)
+      activesupport (= 7.1.2)
       bundler (>= 1.15.0)
-      railties (= 7.0.3.1)
-    rails-dom-testing (2.0.3)
-      activesupport (>= 4.2.0)
+      railties (= 7.1.2)
+    rails-dom-testing (2.2.0)
+      activesupport (>= 5.0.0)
+      minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.3)
-      loofah (~> 2.3)
-    railties (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      method_source
+    rails-html-sanitizer (1.6.0)
+      loofah (~> 2.21)
+      nokogiri (~> 1.14)
+    railties (7.1.2)
+      actionpack (= 7.1.2)
+      activesupport (= 7.1.2)
+      irb
+      rackup (>= 1.0.0)
       rake (>= 12.2)
-      thor (~> 1.0)
-      zeitwerk (~> 2.5)
-    rainbow (3.1.1)
+      thor (~> 1.0, >= 1.2.2)
+      zeitwerk (~> 2.6)
     rake (13.1.0)
+    rdoc (6.6.0)
+      psych (>= 4.0.0)
     redis-client (0.18.0)
       connection_pool
-    regexp_parser (2.5.0)
+    reline (0.4.0)
+      io-console (~> 0.5)
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
@@ -337,27 +404,10 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.2.5)
-    rubocop (1.32.0)
-      json (~> 2.3)
-      parallel (~> 1.10)
-      parser (>= 3.1.0.0)
-      rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8, < 3.0)
-      rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.19.1, < 2.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.19.1)
-      parser (>= 3.1.1.0)
-    rubocop-performance (1.14.3)
-      rubocop (>= 1.7.0, < 2.0)
-      rubocop-ast (>= 0.4.0)
     ruby-openai (6.2.0)
       event_stream_parser (>= 0.3.0, < 1.0.0)
       faraday (>= 1)
       faraday-multipart (>= 1)
-    ruby-progressbar (1.11.0)
     ruby-vips (2.2.0)
       ffi (~> 1.12)
     ruby2_keywords (0.0.5)
@@ -370,26 +420,27 @@ GEM
       redis-client (>= 0.14.0)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
-    sprockets (4.1.1)
+    snaky_hash (2.0.1)
+      hashie
+      version_gem (~> 1.1, >= 1.1.1)
+    sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
+      rack (>= 2.2.4, < 4)
     sprockets-rails (3.4.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.4)
-    standard (1.14.0)
-      rubocop (= 1.32.0)
-      rubocop-performance (= 1.14.3)
+    sqlite3 (1.6.8-arm64-darwin)
+    stringio (3.0.9)
+    stripe (10.1.0)
     thor (1.3.0)
     thread-local (1.1.0)
     timeout (0.4.1)
-    tzinfo (2.0.4)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.9)
-    unicode-display_width (2.2.0)
     unicode-emoji (3.4.0)
       unicode-version (~> 1.0)
     unicode-version (1.3.0)
@@ -397,8 +448,10 @@ GEM
       activemodel
       mail (>= 2.6.1)
       simpleidn
+    version_gem (1.1.3)
     warden (1.2.9)
       rack (>= 2.0.9)
+    webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -406,21 +459,17 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
-  arm64-darwin-20
-  arm64-darwin-21
   arm64-darwin-22
-  ruby
-  x86_64-darwin-21
-  x86_64-darwin-22
-  x86_64-linux
 
 DEPENDENCIES
+  bullet_train!
   bullet_train-api!
   bullet_train-fields!
+  bullet_train-incoming_webhooks!
+  bullet_train-integrations-stripe!
   bullet_train-super_scaffolding!
   sprockets-rails
   sqlite3
-  standard
 
 BUNDLED WITH
-   2.3.14
+   2.4.20

--- a/bullet_train-integrations/Gemfile.lock
+++ b/bullet_train-integrations/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    bullet_train-scope_validator (1.6.13)
-      rails
+    bullet_train-integrations (1.6.13)
+      rails (>= 6.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -81,7 +81,6 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
-    ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.4)
     builder (3.2.4)
@@ -110,7 +109,7 @@ GEM
       net-smtp
     marcel (1.0.2)
     mini_mime (1.1.5)
-    minitest (5.15.0)
+    minitest (5.20.0)
     mutex_m (0.2.0)
     net-imap (0.4.5)
       date
@@ -124,11 +123,6 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.4-x86_64-linux)
-      racc (~> 1.4)
-    parallel (1.21.0)
-    parser (3.1.0.0)
-      ast (~> 2.4.1)
     psych (5.1.1.1)
       stringio
     racc (1.7.3)
@@ -169,39 +163,25 @@ GEM
       rake (>= 12.2)
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
-    rainbow (3.1.1)
-    rake (13.0.6)
+    rake (13.1.0)
     rdoc (6.6.0)
       psych (>= 4.0.0)
-    regexp_parser (2.2.0)
     reline (0.4.0)
       io-console (~> 0.5)
-    rexml (3.2.5)
-    rubocop (1.24.1)
-      parallel (~> 1.10)
-      parser (>= 3.0.0.0)
-      rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8, < 3.0)
-      rexml
-      rubocop-ast (>= 1.15.1, < 2.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.15.1)
-      parser (>= 3.0.1.1)
-    rubocop-performance (1.13.1)
-      rubocop (>= 1.7.0, < 2.0)
-      rubocop-ast (>= 0.4.0)
-    ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
-    standard (1.6.0)
-      rubocop (= 1.24.1)
-      rubocop-performance (= 1.13.1)
+    sprockets (4.2.1)
+      concurrent-ruby (~> 1.0)
+      rack (>= 2.2.4, < 4)
+    sprockets-rails (3.4.2)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
+      sprockets (>= 3.0.0)
+    sqlite3 (1.6.8-arm64-darwin)
     stringio (3.0.9)
     thor (1.3.0)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (2.1.0)
     webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -209,16 +189,12 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
-  arm64-darwin-20
-  arm64-darwin-21
   arm64-darwin-22
-  x86_64-linux
 
 DEPENDENCIES
-  bullet_train-scope_validator!
-  minitest (~> 5.0)
-  rake (~> 13.0)
-  standard (~> 1.3)
+  bullet_train-integrations!
+  sprockets-rails
+  sqlite3
 
 BUNDLED WITH
-   2.3.4
+   2.4.20

--- a/bullet_train-obfuscates_id/Gemfile.lock
+++ b/bullet_train-obfuscates_id/Gemfile.lock
@@ -1,8 +1,9 @@
 PATH
   remote: .
   specs:
-    bullet_train-scope_validator (1.6.13)
-      rails
+    bullet_train-obfuscates_id (1.6.13)
+      hashids
+      rails (>= 6.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -81,7 +82,6 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
-    ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.4)
     builder (3.2.4)
@@ -94,6 +94,7 @@ GEM
     erubi (1.12.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashids (1.0.6)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
@@ -110,7 +111,7 @@ GEM
       net-smtp
     marcel (1.0.2)
     mini_mime (1.1.5)
-    minitest (5.15.0)
+    minitest (5.20.0)
     mutex_m (0.2.0)
     net-imap (0.4.5)
       date
@@ -124,11 +125,6 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.4-x86_64-linux)
-      racc (~> 1.4)
-    parallel (1.21.0)
-    parser (3.1.0.0)
-      ast (~> 2.4.1)
     psych (5.1.1.1)
       stringio
     racc (1.7.3)
@@ -169,39 +165,25 @@ GEM
       rake (>= 12.2)
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
-    rainbow (3.1.1)
-    rake (13.0.6)
+    rake (13.1.0)
     rdoc (6.6.0)
       psych (>= 4.0.0)
-    regexp_parser (2.2.0)
     reline (0.4.0)
       io-console (~> 0.5)
-    rexml (3.2.5)
-    rubocop (1.24.1)
-      parallel (~> 1.10)
-      parser (>= 3.0.0.0)
-      rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8, < 3.0)
-      rexml
-      rubocop-ast (>= 1.15.1, < 2.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.15.1)
-      parser (>= 3.0.1.1)
-    rubocop-performance (1.13.1)
-      rubocop (>= 1.7.0, < 2.0)
-      rubocop-ast (>= 0.4.0)
-    ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
-    standard (1.6.0)
-      rubocop (= 1.24.1)
-      rubocop-performance (= 1.13.1)
+    sprockets (4.2.1)
+      concurrent-ruby (~> 1.0)
+      rack (>= 2.2.4, < 4)
+    sprockets-rails (3.4.2)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
+      sprockets (>= 3.0.0)
+    sqlite3 (1.6.8-arm64-darwin)
     stringio (3.0.9)
     thor (1.3.0)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (2.1.0)
     webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -209,16 +191,12 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
-  arm64-darwin-20
-  arm64-darwin-21
   arm64-darwin-22
-  x86_64-linux
 
 DEPENDENCIES
-  bullet_train-scope_validator!
-  minitest (~> 5.0)
-  rake (~> 13.0)
-  standard (~> 1.3)
+  bullet_train-obfuscates_id!
+  sprockets-rails
+  sqlite3
 
 BUNDLED WITH
-   2.3.4
+   2.4.20

--- a/bullet_train-outgoing_webhooks/.gitignore
+++ b/bullet_train-outgoing_webhooks/.gitignore
@@ -9,6 +9,5 @@
 /test/dummy/storage/
 /test/dummy/tmp/
 .ruby-version
-Gemfile.lock
 .idea
 /.idea/

--- a/bullet_train-outgoing_webhooks/Gemfile
+++ b/bullet_train-outgoing_webhooks/Gemfile
@@ -9,5 +9,11 @@ gem "sqlite3"
 gem "sprockets-rails"
 
 gem "jbuilder"
+
+gem "bullet_train", path: "../bullet_train"
+gem "bullet_train-api", path: "../bullet_train-api"
+gem "bullet_train-fields", path: "../bullet_train-fields"
+gem "bullet_train-super_scaffolding", path: "../bullet_train-super_scaffolding"
+
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"

--- a/bullet_train-outgoing_webhooks/Gemfile.lock
+++ b/bullet_train-outgoing_webhooks/Gemfile.lock
@@ -14,6 +14,15 @@ PATH
       rails (>= 6.0.0)
 
 PATH
+  remote: ../bullet_train-fields
+  specs:
+    bullet_train-fields (1.6.13)
+      chronic
+      cloudinary
+      phonelib
+      rails (>= 6.0.0)
+
+PATH
   remote: ../bullet_train-super_scaffolding
   specs:
     bullet_train-super_scaffolding (1.6.13)
@@ -23,92 +32,8 @@ PATH
       rails (>= 6.0.0)
 
 PATH
-  remote: .
+  remote: ../bullet_train
   specs:
-    bullet_train-fields (1.6.13)
-      chronic
-      cloudinary
-      phonelib
-      rails (>= 6.0.0)
-
-GEM
-  remote: https://rubygems.org/
-  specs:
-    actioncable (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      nio4r (~> 2.0)
-      websocket-driver (>= 0.6.1)
-    actionmailbox (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activestorage (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      mail (>= 2.7.1)
-      net-imap
-      net-pop
-      net-smtp
-    actionmailer (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      actionview (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      mail (~> 2.5, >= 2.5.4)
-      net-imap
-      net-pop
-      net-smtp
-      rails-dom-testing (~> 2.0)
-    actionpack (7.0.3.1)
-      actionview (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      rack (~> 2.0, >= 2.2.0)
-      rack-test (>= 0.6.3)
-      rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actiontext (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activestorage (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      globalid (>= 0.6.0)
-      nokogiri (>= 1.8.5)
-    actionview (7.0.3.1)
-      activesupport (= 7.0.3.1)
-      builder (~> 3.1)
-      erubi (~> 1.4)
-      rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    active_hash (3.2.1)
-      activesupport (>= 5.0.0)
-    activejob (7.0.3.1)
-      activesupport (= 7.0.3.1)
-      globalid (>= 0.3.6)
-    activemodel (7.0.3.1)
-      activesupport (= 7.0.3.1)
-    activerecord (7.0.3.1)
-      activemodel (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-    activestorage (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      marcel (~> 1.0)
-      mini_mime (>= 1.1.0)
-    activesupport (7.0.3.1)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      tzinfo (~> 2.0)
-    addressable (2.8.5)
-      public_suffix (>= 2.0.2, < 6.0)
-    ast (2.4.2)
-    awesome_print (1.9.2)
-    aws_cf_signer (0.1.3)
-    base64 (0.2.0)
-    bcrypt (3.1.19)
-    builder (3.2.4)
     bullet_train (1.6.13)
       awesome_print
       bullet_train-fields
@@ -141,19 +66,105 @@ GEM
       unicode-emoji
       valid_email
       xxhash
-    bullet_train-has_uuid (1.6.13)
+
+PATH
+  remote: .
+  specs:
+    bullet_train-outgoing_webhooks (1.6.13)
+      public_suffix
       rails (>= 6.0.0)
-    bullet_train-roles (1.6.13)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (7.0.8)
+      actionpack (= 7.0.8)
+      activesupport (= 7.0.8)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+    actionmailbox (7.0.8)
+      actionpack (= 7.0.8)
+      activejob (= 7.0.8)
+      activerecord (= 7.0.8)
+      activestorage (= 7.0.8)
+      activesupport (= 7.0.8)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.0.8)
+      actionpack (= 7.0.8)
+      actionview (= 7.0.8)
+      activejob (= 7.0.8)
+      activesupport (= 7.0.8)
+      mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
+      rails-dom-testing (~> 2.0)
+    actionpack (7.0.8)
+      actionview (= 7.0.8)
+      activesupport (= 7.0.8)
+      rack (~> 2.0, >= 2.2.4)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actiontext (7.0.8)
+      actionpack (= 7.0.8)
+      activerecord (= 7.0.8)
+      activestorage (= 7.0.8)
+      activesupport (= 7.0.8)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (7.0.8)
+      activesupport (= 7.0.8)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_hash (3.2.1)
+      activesupport (>= 5.0.0)
+    activejob (7.0.8)
+      activesupport (= 7.0.8)
+      globalid (>= 0.3.6)
+    activemodel (7.0.8)
+      activesupport (= 7.0.8)
+    activerecord (7.0.8)
+      activemodel (= 7.0.8)
+      activesupport (= 7.0.8)
+    activestorage (7.0.8)
+      actionpack (= 7.0.8)
+      activejob (= 7.0.8)
+      activerecord (= 7.0.8)
+      activesupport (= 7.0.8)
+      marcel (~> 1.0)
+      mini_mime (>= 1.1.0)
+    activesupport (7.0.8)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    addressable (2.8.5)
+      public_suffix (>= 2.0.2, < 6.0)
+    ast (2.4.2)
+    awesome_print (1.9.2)
+    aws_cf_signer (0.1.3)
+    base64 (0.1.1)
+    bcrypt (3.1.19)
+    builder (3.2.4)
+    bullet_train-has_uuid (1.6.11)
+      rails (>= 6.0.0)
+    bullet_train-roles (1.6.11)
       active_hash
       activesupport
       cancancan
     bullet_train-routes (1.0.0)
       rails (>= 6.0.0)
-    bullet_train-scope_validator (1.6.13)
-    bullet_train-super_load_and_authorize_resource (1.6.13)
+    bullet_train-scope_validator (1.6.11)
+    bullet_train-super_load_and_authorize_resource (1.6.11)
       cancancan
       rails (>= 6.0.0)
-    bullet_train-themes (1.6.13)
+    bullet_train-themes (1.6.11)
       rails (>= 6.0.0)
     cable_ready (5.0.3)
       actionpack (>= 5.2)
@@ -169,12 +180,12 @@ GEM
       rest-client (>= 2.0.0)
     colorizer (0.0.2)
     commonmarker (0.23.10)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crass (1.0.6)
     css_parser (1.16.0)
       addressable
-    date (3.3.4)
+    date (3.3.3)
     devise (4.9.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -188,7 +199,7 @@ GEM
     doorkeeper (5.6.6)
       railties (>= 5)
     email_reply_parser (0.5.11)
-    erubi (1.10.0)
+    erubi (1.12.0)
     event_stream_parser (0.3.0)
     extended_email_reply_parser (0.5.1)
       activesupport
@@ -216,7 +227,7 @@ GEM
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     http_accept_language (2.1.1)
-    i18n (1.11.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
@@ -230,10 +241,12 @@ GEM
       jbuilder
       method_source
       rails (>= 5.0.0)
-    json (2.6.2)
-    loofah (2.18.0)
+    json (2.6.3)
+    language_server-protocol (3.17.0.3)
+    lint_roller (1.1.0)
+    loofah (2.21.3)
       crass (~> 1.0.2)
-      nokogiri (>= 1.5.9)
+      nokogiri (>= 1.12.0)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
@@ -252,33 +265,32 @@ GEM
     mime-types-data (3.2023.1003)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.1)
-    minitest (5.16.2)
+    minitest (5.20.0)
     multipart-post (2.3.0)
-    net-imap (0.4.5)
+    net-imap (0.3.7)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.2.2)
+    net-protocol (0.2.1)
       timeout
-    net-smtp (0.4.0)
+    net-smtp (0.3.3)
       net-protocol
     netrc (0.11.0)
     nice_partials (0.10.0)
       actionview (>= 4.2.6)
     nio4r (2.5.9)
-    nokogiri (1.13.7)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     pagy (6.2.0)
     pagy_cursor (0.6.1)
       activerecord (>= 5)
       pagy (>= 6, < 7)
-    parallel (1.22.1)
-    parser (3.1.2.0)
+    parallel (1.23.0)
+    parser (3.2.2.3)
       ast (~> 2.4.1)
+      racc
     phonelib (0.8.5)
     possessive (1.0.1)
     premailer (1.21.0)
@@ -292,43 +304,45 @@ GEM
     prism (0.17.1)
     public_suffix (5.0.3)
     pwned (2.0.2)
-    racc (1.6.0)
-    rack (2.2.4)
+    racc (1.7.1)
+    rack (2.2.8)
     rack-cors (2.0.1)
       rack (>= 2.0.0)
-    rack-test (2.0.2)
+    rack-test (2.1.0)
       rack (>= 1.3)
-    rails (7.0.3.1)
-      actioncable (= 7.0.3.1)
-      actionmailbox (= 7.0.3.1)
-      actionmailer (= 7.0.3.1)
-      actionpack (= 7.0.3.1)
-      actiontext (= 7.0.3.1)
-      actionview (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activemodel (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activestorage (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
+    rails (7.0.8)
+      actioncable (= 7.0.8)
+      actionmailbox (= 7.0.8)
+      actionmailer (= 7.0.8)
+      actionpack (= 7.0.8)
+      actiontext (= 7.0.8)
+      actionview (= 7.0.8)
+      activejob (= 7.0.8)
+      activemodel (= 7.0.8)
+      activerecord (= 7.0.8)
+      activestorage (= 7.0.8)
+      activesupport (= 7.0.8)
       bundler (>= 1.15.0)
-      railties (= 7.0.3.1)
-    rails-dom-testing (2.0.3)
-      activesupport (>= 4.2.0)
+      railties (= 7.0.8)
+    rails-dom-testing (2.2.0)
+      activesupport (>= 5.0.0)
+      minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.3)
-      loofah (~> 2.3)
-    railties (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
+    rails-html-sanitizer (1.6.0)
+      loofah (~> 2.21)
+      nokogiri (~> 1.14)
+    railties (7.0.8)
+      actionpack (= 7.0.8)
+      activesupport (= 7.0.8)
       method_source
       rake (>= 12.2)
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
-    rake (13.1.0)
+    rake (13.0.6)
     redis-client (0.18.0)
       connection_pool
-    regexp_parser (2.5.0)
+    regexp_parser (2.8.1)
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
@@ -337,27 +351,29 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.2.5)
-    rubocop (1.32.0)
+    rexml (3.2.6)
+    rubocop (1.56.3)
+      base64 (~> 0.1.1)
       json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.1.0.0)
+      parser (>= 3.2.2.3)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.19.1, < 2.0)
+      rubocop-ast (>= 1.28.1, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.19.1)
-      parser (>= 3.1.1.0)
-    rubocop-performance (1.14.3)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.29.0)
+      parser (>= 3.2.1.0)
+    rubocop-performance (1.19.0)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
-    ruby-openai (6.2.0)
+    ruby-openai (6.0.1)
       event_stream_parser (>= 0.3.0, < 1.0.0)
       faraday (>= 1)
       faraday-multipart (>= 1)
-    ruby-progressbar (1.11.0)
+    ruby-progressbar (1.13.0)
     ruby-vips (2.2.0)
       ffi (~> 1.12)
     ruby2_keywords (0.0.5)
@@ -370,26 +386,35 @@ GEM
       redis-client (>= 0.14.0)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
-    sprockets (4.1.1)
+    sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
+      rack (>= 2.2.4, < 4)
     sprockets-rails (3.4.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.4)
-    standard (1.14.0)
-      rubocop (= 1.32.0)
-      rubocop-performance (= 1.14.3)
-    thor (1.3.0)
+    sqlite3 (1.6.8-arm64-darwin)
+    standard (1.31.1)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.56.2)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.2)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.2.0)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.19.0)
+    thor (1.2.2)
     thread-local (1.1.0)
-    timeout (0.4.1)
-    tzinfo (2.0.4)
+    timeout (0.4.0)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.9)
-    unicode-display_width (2.2.0)
+    unicode-display_width (2.4.2)
     unicode-emoji (3.4.0)
       unicode-version (~> 1.0)
     unicode-version (1.3.0)
@@ -403,24 +428,21 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     xxhash (0.5.0)
-    zeitwerk (2.6.12)
+    zeitwerk (2.6.11)
 
 PLATFORMS
-  arm64-darwin-20
-  arm64-darwin-21
   arm64-darwin-22
-  ruby
-  x86_64-darwin-21
-  x86_64-darwin-22
-  x86_64-linux
 
 DEPENDENCIES
+  bullet_train!
   bullet_train-api!
   bullet_train-fields!
+  bullet_train-outgoing_webhooks!
   bullet_train-super_scaffolding!
+  jbuilder
   sprockets-rails
   sqlite3
   standard
 
 BUNDLED WITH
-   2.3.14
+   2.4.18

--- a/bullet_train-scope_validator/bullet_train-scope_validator.gemspec
+++ b/bullet_train-scope_validator/bullet_train-scope_validator.gemspec
@@ -28,6 +28,8 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "rails"
+
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"
 

--- a/bullet_train-sortable/Gemfile
+++ b/bullet_train-sortable/Gemfile
@@ -8,5 +8,10 @@ gem "sqlite3"
 
 gem "sprockets-rails"
 
+gem "bullet_train", path: "../bullet_train"
+gem "bullet_train-api", path: "../bullet_train-api"
+gem "bullet_train-fields", path: "../bullet_train-fields"
+gem "bullet_train-super_scaffolding", path: "../bullet_train-super_scaffolding"
+
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"

--- a/bullet_train-sortable/Gemfile.lock
+++ b/bullet_train-sortable/Gemfile.lock
@@ -14,6 +14,15 @@ PATH
       rails (>= 6.0.0)
 
 PATH
+  remote: ../bullet_train-fields
+  specs:
+    bullet_train-fields (1.6.13)
+      chronic
+      cloudinary
+      phonelib
+      rails (>= 6.0.0)
+
+PATH
   remote: ../bullet_train-super_scaffolding
   specs:
     bullet_train-super_scaffolding (1.6.13)
@@ -23,92 +32,8 @@ PATH
       rails (>= 6.0.0)
 
 PATH
-  remote: .
+  remote: ../bullet_train
   specs:
-    bullet_train-fields (1.6.13)
-      chronic
-      cloudinary
-      phonelib
-      rails (>= 6.0.0)
-
-GEM
-  remote: https://rubygems.org/
-  specs:
-    actioncable (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      nio4r (~> 2.0)
-      websocket-driver (>= 0.6.1)
-    actionmailbox (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activestorage (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      mail (>= 2.7.1)
-      net-imap
-      net-pop
-      net-smtp
-    actionmailer (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      actionview (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      mail (~> 2.5, >= 2.5.4)
-      net-imap
-      net-pop
-      net-smtp
-      rails-dom-testing (~> 2.0)
-    actionpack (7.0.3.1)
-      actionview (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      rack (~> 2.0, >= 2.2.0)
-      rack-test (>= 0.6.3)
-      rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actiontext (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activestorage (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      globalid (>= 0.6.0)
-      nokogiri (>= 1.8.5)
-    actionview (7.0.3.1)
-      activesupport (= 7.0.3.1)
-      builder (~> 3.1)
-      erubi (~> 1.4)
-      rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    active_hash (3.2.1)
-      activesupport (>= 5.0.0)
-    activejob (7.0.3.1)
-      activesupport (= 7.0.3.1)
-      globalid (>= 0.3.6)
-    activemodel (7.0.3.1)
-      activesupport (= 7.0.3.1)
-    activerecord (7.0.3.1)
-      activemodel (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-    activestorage (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      marcel (~> 1.0)
-      mini_mime (>= 1.1.0)
-    activesupport (7.0.3.1)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      tzinfo (~> 2.0)
-    addressable (2.8.5)
-      public_suffix (>= 2.0.2, < 6.0)
-    ast (2.4.2)
-    awesome_print (1.9.2)
-    aws_cf_signer (0.1.3)
-    base64 (0.2.0)
-    bcrypt (3.1.19)
-    builder (3.2.4)
     bullet_train (1.6.13)
       awesome_print
       bullet_train-fields
@@ -141,6 +66,101 @@ GEM
       unicode-emoji
       valid_email
       xxhash
+
+PATH
+  remote: .
+  specs:
+    bullet_train-sortable (1.6.13)
+      rails (>= 6.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (7.1.2)
+      actionpack (= 7.1.2)
+      activesupport (= 7.1.2)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+      zeitwerk (~> 2.6)
+    actionmailbox (7.1.2)
+      actionpack (= 7.1.2)
+      activejob (= 7.1.2)
+      activerecord (= 7.1.2)
+      activestorage (= 7.1.2)
+      activesupport (= 7.1.2)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.1.2)
+      actionpack (= 7.1.2)
+      actionview (= 7.1.2)
+      activejob (= 7.1.2)
+      activesupport (= 7.1.2)
+      mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
+      rails-dom-testing (~> 2.2)
+    actionpack (7.1.2)
+      actionview (= 7.1.2)
+      activesupport (= 7.1.2)
+      nokogiri (>= 1.8.5)
+      racc
+      rack (>= 2.2.4)
+      rack-session (>= 1.0.1)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    actiontext (7.1.2)
+      actionpack (= 7.1.2)
+      activerecord (= 7.1.2)
+      activestorage (= 7.1.2)
+      activesupport (= 7.1.2)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (7.1.2)
+      activesupport (= 7.1.2)
+      builder (~> 3.1)
+      erubi (~> 1.11)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    active_hash (3.2.1)
+      activesupport (>= 5.0.0)
+    activejob (7.1.2)
+      activesupport (= 7.1.2)
+      globalid (>= 0.3.6)
+    activemodel (7.1.2)
+      activesupport (= 7.1.2)
+    activerecord (7.1.2)
+      activemodel (= 7.1.2)
+      activesupport (= 7.1.2)
+      timeout (>= 0.4.0)
+    activestorage (7.1.2)
+      actionpack (= 7.1.2)
+      activejob (= 7.1.2)
+      activerecord (= 7.1.2)
+      activesupport (= 7.1.2)
+      marcel (~> 1.0)
+    activesupport (7.1.2)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      mutex_m
+      tzinfo (~> 2.0)
+    addressable (2.8.5)
+      public_suffix (>= 2.0.2, < 6.0)
+    ast (2.4.2)
+    awesome_print (1.9.2)
+    aws_cf_signer (0.1.3)
+    base64 (0.2.0)
+    bcrypt (3.1.19)
+    bigdecimal (3.1.4)
+    builder (3.2.4)
     bullet_train-has_uuid (1.6.13)
       rails (>= 6.0.0)
     bullet_train-roles (1.6.13)
@@ -169,7 +189,7 @@ GEM
       rest-client (>= 2.0.0)
     colorizer (0.0.2)
     commonmarker (0.23.10)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crass (1.0.6)
     css_parser (1.16.0)
@@ -187,8 +207,10 @@ GEM
     domain_name (0.6.20231109)
     doorkeeper (5.6.6)
       railties (>= 5)
+    drb (2.2.0)
+      ruby2_keywords
     email_reply_parser (0.5.11)
-    erubi (1.10.0)
+    erubi (1.12.0)
     event_stream_parser (0.3.0)
     extended_email_reply_parser (0.5.1)
       activesupport
@@ -216,13 +238,17 @@ GEM
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     http_accept_language (2.1.1)
-    i18n (1.11.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
     indefinite_article (0.2.5)
       activesupport
+    io-console (0.6.0)
+    irb (1.9.0)
+      rdoc
+      reline (>= 0.3.8)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -230,10 +256,12 @@ GEM
       jbuilder
       method_source
       rails (>= 5.0.0)
-    json (2.6.2)
-    loofah (2.18.0)
+    json (2.6.3)
+    language_server-protocol (3.17.0.3)
+    lint_roller (1.1.0)
+    loofah (2.22.0)
       crass (~> 1.0.2)
-      nokogiri (>= 1.5.9)
+      nokogiri (>= 1.12.0)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
@@ -252,9 +280,9 @@ GEM
     mime-types-data (3.2023.1003)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.1)
-    minitest (5.16.2)
+    minitest (5.20.0)
     multipart-post (2.3.0)
+    mutex_m (0.2.0)
     net-imap (0.4.5)
       date
       net-protocol
@@ -268,17 +296,17 @@ GEM
     nice_partials (0.10.0)
       actionview (>= 4.2.6)
     nio4r (2.5.9)
-    nokogiri (1.13.7)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     pagy (6.2.0)
     pagy_cursor (0.6.1)
       activerecord (>= 5)
       pagy (>= 6, < 7)
-    parallel (1.22.1)
-    parser (3.1.2.0)
+    parallel (1.23.0)
+    parser (3.2.2.4)
       ast (~> 2.4.1)
+      racc
     phonelib (0.8.5)
     possessive (1.0.1)
     premailer (1.21.0)
@@ -290,45 +318,59 @@ GEM
       net-smtp
       premailer (~> 1.7, >= 1.7.9)
     prism (0.17.1)
+    psych (5.1.1.1)
+      stringio
     public_suffix (5.0.3)
     pwned (2.0.2)
-    racc (1.6.0)
-    rack (2.2.4)
+    racc (1.7.3)
+    rack (3.0.8)
     rack-cors (2.0.1)
       rack (>= 2.0.0)
-    rack-test (2.0.2)
+    rack-session (2.0.0)
+      rack (>= 3.0.0)
+    rack-test (2.1.0)
       rack (>= 1.3)
-    rails (7.0.3.1)
-      actioncable (= 7.0.3.1)
-      actionmailbox (= 7.0.3.1)
-      actionmailer (= 7.0.3.1)
-      actionpack (= 7.0.3.1)
-      actiontext (= 7.0.3.1)
-      actionview (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activemodel (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activestorage (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
+    rackup (2.1.0)
+      rack (>= 3)
+      webrick (~> 1.8)
+    rails (7.1.2)
+      actioncable (= 7.1.2)
+      actionmailbox (= 7.1.2)
+      actionmailer (= 7.1.2)
+      actionpack (= 7.1.2)
+      actiontext (= 7.1.2)
+      actionview (= 7.1.2)
+      activejob (= 7.1.2)
+      activemodel (= 7.1.2)
+      activerecord (= 7.1.2)
+      activestorage (= 7.1.2)
+      activesupport (= 7.1.2)
       bundler (>= 1.15.0)
-      railties (= 7.0.3.1)
-    rails-dom-testing (2.0.3)
-      activesupport (>= 4.2.0)
+      railties (= 7.1.2)
+    rails-dom-testing (2.2.0)
+      activesupport (>= 5.0.0)
+      minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.3)
-      loofah (~> 2.3)
-    railties (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      method_source
+    rails-html-sanitizer (1.6.0)
+      loofah (~> 2.21)
+      nokogiri (~> 1.14)
+    railties (7.1.2)
+      actionpack (= 7.1.2)
+      activesupport (= 7.1.2)
+      irb
+      rackup (>= 1.0.0)
       rake (>= 12.2)
-      thor (~> 1.0)
-      zeitwerk (~> 2.5)
+      thor (~> 1.0, >= 1.2.2)
+      zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.1.0)
+    rdoc (6.6.0)
+      psych (>= 4.0.0)
     redis-client (0.18.0)
       connection_pool
-    regexp_parser (2.5.0)
+    regexp_parser (2.8.2)
+    reline (0.4.0)
+      io-console (~> 0.5)
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
@@ -337,27 +379,28 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.2.5)
-    rubocop (1.32.0)
+    rexml (3.2.6)
+    rubocop (1.57.2)
       json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.1.0.0)
+      parser (>= 3.2.2.4)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.19.1, < 2.0)
+      rubocop-ast (>= 1.28.1, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.19.1)
-      parser (>= 3.1.1.0)
-    rubocop-performance (1.14.3)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    rubocop-performance (1.19.1)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-openai (6.2.0)
       event_stream_parser (>= 0.3.0, < 1.0.0)
       faraday (>= 1)
       faraday-multipart (>= 1)
-    ruby-progressbar (1.11.0)
+    ruby-progressbar (1.13.0)
     ruby-vips (2.2.0)
       ffi (~> 1.12)
     ruby2_keywords (0.0.5)
@@ -370,26 +413,36 @@ GEM
       redis-client (>= 0.14.0)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
-    sprockets (4.1.1)
+    sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
+      rack (>= 2.2.4, < 4)
     sprockets-rails (3.4.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.4)
-    standard (1.14.0)
-      rubocop (= 1.32.0)
-      rubocop-performance (= 1.14.3)
+    sqlite3 (1.6.8-arm64-darwin)
+    standard (1.32.0)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.57.2)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.2)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.2.1)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.19.1)
+    stringio (3.0.9)
     thor (1.3.0)
     thread-local (1.1.0)
     timeout (0.4.1)
-    tzinfo (2.0.4)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.9)
-    unicode-display_width (2.2.0)
+    unicode-display_width (2.5.0)
     unicode-emoji (3.4.0)
       unicode-version (~> 1.0)
     unicode-version (1.3.0)
@@ -399,6 +452,7 @@ GEM
       simpleidn
     warden (1.2.9)
       rack (>= 2.0.9)
+    webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -406,21 +460,17 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
-  arm64-darwin-20
-  arm64-darwin-21
   arm64-darwin-22
-  ruby
-  x86_64-darwin-21
-  x86_64-darwin-22
-  x86_64-linux
 
 DEPENDENCIES
+  bullet_train!
   bullet_train-api!
   bullet_train-fields!
+  bullet_train-sortable!
   bullet_train-super_scaffolding!
   sprockets-rails
   sqlite3
   standard
 
 BUNDLED WITH
-   2.3.14
+   2.4.20

--- a/bullet_train-super_scaffolding/.gitignore
+++ b/bullet_train-super_scaffolding/.gitignore
@@ -8,6 +8,5 @@
 /test/dummy/log/*.log
 /test/dummy/storage/
 /test/dummy/tmp/
-Gemfile.lock
 yarn.lock
 /node_modules

--- a/bullet_train-super_scaffolding/Gemfile
+++ b/bullet_train-super_scaffolding/Gemfile
@@ -8,8 +8,9 @@ gem "sqlite3"
 
 gem "sprockets-rails"
 
-gem "bullet_train"
-gem "bullet_train-api"
+gem "bullet_train", path: "../bullet_train"
+gem "bullet_train-api", path: "../bullet_train-api"
+gem "bullet_train-fields", path: "../bullet_train-fields"
 
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"

--- a/bullet_train-super_scaffolding/Gemfile.lock
+++ b/bullet_train-super_scaffolding/Gemfile.lock
@@ -14,16 +14,7 @@ PATH
       rails (>= 6.0.0)
 
 PATH
-  remote: ../bullet_train-super_scaffolding
-  specs:
-    bullet_train-super_scaffolding (1.6.13)
-      bullet_train
-      indefinite_article
-      masamune-ast (~> 2.0.2)
-      rails (>= 6.0.0)
-
-PATH
-  remote: .
+  remote: ../bullet_train-fields
   specs:
     bullet_train-fields (1.6.13)
       chronic
@@ -31,84 +22,9 @@ PATH
       phonelib
       rails (>= 6.0.0)
 
-GEM
-  remote: https://rubygems.org/
+PATH
+  remote: ../bullet_train
   specs:
-    actioncable (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      nio4r (~> 2.0)
-      websocket-driver (>= 0.6.1)
-    actionmailbox (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activestorage (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      mail (>= 2.7.1)
-      net-imap
-      net-pop
-      net-smtp
-    actionmailer (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      actionview (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      mail (~> 2.5, >= 2.5.4)
-      net-imap
-      net-pop
-      net-smtp
-      rails-dom-testing (~> 2.0)
-    actionpack (7.0.3.1)
-      actionview (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      rack (~> 2.0, >= 2.2.0)
-      rack-test (>= 0.6.3)
-      rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actiontext (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activestorage (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      globalid (>= 0.6.0)
-      nokogiri (>= 1.8.5)
-    actionview (7.0.3.1)
-      activesupport (= 7.0.3.1)
-      builder (~> 3.1)
-      erubi (~> 1.4)
-      rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    active_hash (3.2.1)
-      activesupport (>= 5.0.0)
-    activejob (7.0.3.1)
-      activesupport (= 7.0.3.1)
-      globalid (>= 0.3.6)
-    activemodel (7.0.3.1)
-      activesupport (= 7.0.3.1)
-    activerecord (7.0.3.1)
-      activemodel (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-    activestorage (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      marcel (~> 1.0)
-      mini_mime (>= 1.1.0)
-    activesupport (7.0.3.1)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      tzinfo (~> 2.0)
-    addressable (2.8.5)
-      public_suffix (>= 2.0.2, < 6.0)
-    ast (2.4.2)
-    awesome_print (1.9.2)
-    aws_cf_signer (0.1.3)
-    base64 (0.2.0)
-    bcrypt (3.1.19)
-    builder (3.2.4)
     bullet_train (1.6.13)
       awesome_print
       bullet_train-fields
@@ -141,19 +57,108 @@ GEM
       unicode-emoji
       valid_email
       xxhash
-    bullet_train-has_uuid (1.6.13)
+
+PATH
+  remote: .
+  specs:
+    bullet_train-super_scaffolding (1.6.13)
+      bullet_train
+      colorizer
+      indefinite_article
+      masamune-ast (~> 2.0.2)
       rails (>= 6.0.0)
-    bullet_train-roles (1.6.13)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (7.0.8)
+      actionpack (= 7.0.8)
+      activesupport (= 7.0.8)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+    actionmailbox (7.0.8)
+      actionpack (= 7.0.8)
+      activejob (= 7.0.8)
+      activerecord (= 7.0.8)
+      activestorage (= 7.0.8)
+      activesupport (= 7.0.8)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.0.8)
+      actionpack (= 7.0.8)
+      actionview (= 7.0.8)
+      activejob (= 7.0.8)
+      activesupport (= 7.0.8)
+      mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
+      rails-dom-testing (~> 2.0)
+    actionpack (7.0.8)
+      actionview (= 7.0.8)
+      activesupport (= 7.0.8)
+      rack (~> 2.0, >= 2.2.4)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actiontext (7.0.8)
+      actionpack (= 7.0.8)
+      activerecord (= 7.0.8)
+      activestorage (= 7.0.8)
+      activesupport (= 7.0.8)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (7.0.8)
+      activesupport (= 7.0.8)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_hash (3.2.1)
+      activesupport (>= 5.0.0)
+    activejob (7.0.8)
+      activesupport (= 7.0.8)
+      globalid (>= 0.3.6)
+    activemodel (7.0.8)
+      activesupport (= 7.0.8)
+    activerecord (7.0.8)
+      activemodel (= 7.0.8)
+      activesupport (= 7.0.8)
+    activestorage (7.0.8)
+      actionpack (= 7.0.8)
+      activejob (= 7.0.8)
+      activerecord (= 7.0.8)
+      activesupport (= 7.0.8)
+      marcel (~> 1.0)
+      mini_mime (>= 1.1.0)
+    activesupport (7.0.8)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    addressable (2.8.5)
+      public_suffix (>= 2.0.2, < 6.0)
+    ast (2.4.2)
+    awesome_print (1.9.2)
+    aws_cf_signer (0.1.3)
+    base64 (0.1.1)
+    bcrypt (3.1.19)
+    builder (3.2.4)
+    bullet_train-has_uuid (1.6.11)
+      rails (>= 6.0.0)
+    bullet_train-roles (1.6.11)
       active_hash
       activesupport
       cancancan
     bullet_train-routes (1.0.0)
       rails (>= 6.0.0)
-    bullet_train-scope_validator (1.6.13)
-    bullet_train-super_load_and_authorize_resource (1.6.13)
+    bullet_train-scope_validator (1.6.11)
+    bullet_train-super_load_and_authorize_resource (1.6.11)
       cancancan
       rails (>= 6.0.0)
-    bullet_train-themes (1.6.13)
+    bullet_train-themes (1.6.11)
       rails (>= 6.0.0)
     cable_ready (5.0.3)
       actionpack (>= 5.2)
@@ -169,12 +174,12 @@ GEM
       rest-client (>= 2.0.0)
     colorizer (0.0.2)
     commonmarker (0.23.10)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crass (1.0.6)
     css_parser (1.16.0)
       addressable
-    date (3.3.4)
+    date (3.3.3)
     devise (4.9.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -188,7 +193,7 @@ GEM
     doorkeeper (5.6.6)
       railties (>= 5)
     email_reply_parser (0.5.11)
-    erubi (1.10.0)
+    erubi (1.12.0)
     event_stream_parser (0.3.0)
     extended_email_reply_parser (0.5.1)
       activesupport
@@ -216,7 +221,7 @@ GEM
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     http_accept_language (2.1.1)
-    i18n (1.11.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
@@ -230,10 +235,12 @@ GEM
       jbuilder
       method_source
       rails (>= 5.0.0)
-    json (2.6.2)
-    loofah (2.18.0)
+    json (2.6.3)
+    language_server-protocol (3.17.0.3)
+    lint_roller (1.1.0)
+    loofah (2.21.3)
       crass (~> 1.0.2)
-      nokogiri (>= 1.5.9)
+      nokogiri (>= 1.12.0)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
@@ -252,15 +259,14 @@ GEM
     mime-types-data (3.2023.1003)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.1)
-    minitest (5.16.2)
+    minitest (5.20.0)
     multipart-post (2.3.0)
-    net-imap (0.4.5)
+    net-imap (0.3.7)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.2.2)
+    net-protocol (0.2.1)
       timeout
     net-smtp (0.4.0)
       net-protocol
@@ -268,17 +274,17 @@ GEM
     nice_partials (0.10.0)
       actionview (>= 4.2.6)
     nio4r (2.5.9)
-    nokogiri (1.13.7)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     pagy (6.2.0)
     pagy_cursor (0.6.1)
       activerecord (>= 5)
       pagy (>= 6, < 7)
-    parallel (1.22.1)
-    parser (3.1.2.0)
+    parallel (1.23.0)
+    parser (3.2.2.3)
       ast (~> 2.4.1)
+      racc
     phonelib (0.8.5)
     possessive (1.0.1)
     premailer (1.21.0)
@@ -292,43 +298,45 @@ GEM
     prism (0.17.1)
     public_suffix (5.0.3)
     pwned (2.0.2)
-    racc (1.6.0)
-    rack (2.2.4)
+    racc (1.7.1)
+    rack (2.2.8)
     rack-cors (2.0.1)
       rack (>= 2.0.0)
-    rack-test (2.0.2)
+    rack-test (2.1.0)
       rack (>= 1.3)
-    rails (7.0.3.1)
-      actioncable (= 7.0.3.1)
-      actionmailbox (= 7.0.3.1)
-      actionmailer (= 7.0.3.1)
-      actionpack (= 7.0.3.1)
-      actiontext (= 7.0.3.1)
-      actionview (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activemodel (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activestorage (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
+    rails (7.0.8)
+      actioncable (= 7.0.8)
+      actionmailbox (= 7.0.8)
+      actionmailer (= 7.0.8)
+      actionpack (= 7.0.8)
+      actiontext (= 7.0.8)
+      actionview (= 7.0.8)
+      activejob (= 7.0.8)
+      activemodel (= 7.0.8)
+      activerecord (= 7.0.8)
+      activestorage (= 7.0.8)
+      activesupport (= 7.0.8)
       bundler (>= 1.15.0)
-      railties (= 7.0.3.1)
-    rails-dom-testing (2.0.3)
-      activesupport (>= 4.2.0)
+      railties (= 7.0.8)
+    rails-dom-testing (2.2.0)
+      activesupport (>= 5.0.0)
+      minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.3)
-      loofah (~> 2.3)
-    railties (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
+    rails-html-sanitizer (1.6.0)
+      loofah (~> 2.21)
+      nokogiri (~> 1.14)
+    railties (7.0.8)
+      actionpack (= 7.0.8)
+      activesupport (= 7.0.8)
       method_source
       rake (>= 12.2)
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
-    rake (13.1.0)
+    rake (13.0.6)
     redis-client (0.18.0)
       connection_pool
-    regexp_parser (2.5.0)
+    regexp_parser (2.8.1)
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
@@ -337,27 +345,29 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.2.5)
-    rubocop (1.32.0)
+    rexml (3.2.6)
+    rubocop (1.56.3)
+      base64 (~> 0.1.1)
       json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.1.0.0)
+      parser (>= 3.2.2.3)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.19.1, < 2.0)
+      rubocop-ast (>= 1.28.1, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.19.1)
-      parser (>= 3.1.1.0)
-    rubocop-performance (1.14.3)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.29.0)
+      parser (>= 3.2.1.0)
+    rubocop-performance (1.19.1)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
-    ruby-openai (6.2.0)
+    ruby-openai (6.0.1)
       event_stream_parser (>= 0.3.0, < 1.0.0)
       faraday (>= 1)
       faraday-multipart (>= 1)
-    ruby-progressbar (1.11.0)
+    ruby-progressbar (1.13.0)
     ruby-vips (2.2.0)
       ffi (~> 1.12)
     ruby2_keywords (0.0.5)
@@ -370,26 +380,35 @@ GEM
       redis-client (>= 0.14.0)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
-    sprockets (4.1.1)
+    sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
+      rack (>= 2.2.4, < 4)
     sprockets-rails (3.4.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.4)
-    standard (1.14.0)
-      rubocop (= 1.32.0)
-      rubocop-performance (= 1.14.3)
-    thor (1.3.0)
+    sqlite3 (1.6.6-arm64-darwin)
+    standard (1.31.1)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.56.2)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.2)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.2.0)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.19.0)
+    thor (1.2.2)
     thread-local (1.1.0)
-    timeout (0.4.1)
-    tzinfo (2.0.4)
+    timeout (0.4.0)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.9)
-    unicode-display_width (2.2.0)
+    unicode-display_width (2.4.2)
     unicode-emoji (3.4.0)
       unicode-version (~> 1.0)
     unicode-version (1.3.0)
@@ -403,18 +422,13 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     xxhash (0.5.0)
-    zeitwerk (2.6.12)
+    zeitwerk (2.6.11)
 
 PLATFORMS
-  arm64-darwin-20
-  arm64-darwin-21
   arm64-darwin-22
-  ruby
-  x86_64-darwin-21
-  x86_64-darwin-22
-  x86_64-linux
 
 DEPENDENCIES
+  bullet_train!
   bullet_train-api!
   bullet_train-fields!
   bullet_train-super_scaffolding!
@@ -423,4 +437,4 @@ DEPENDENCIES
   standard
 
 BUNDLED WITH
-   2.3.14
+   2.4.19

--- a/bullet_train-super_scaffolding/bullet_train-super_scaffolding.gemspec
+++ b/bullet_train-super_scaffolding/bullet_train-super_scaffolding.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rails", ">= 6.0.0"
   spec.add_dependency "bullet_train"
   spec.add_dependency "masamune-ast", "~> 2.0.2"
+  spec.add_dependency "colorizer"
 
   # For Super Scaffolding: "select *a* team member" vs. "select *an* option".
   spec.add_dependency "indefinite_article"

--- a/bullet_train-themes-light/Gemfile
+++ b/bullet_train-themes-light/Gemfile
@@ -8,5 +8,10 @@ gem "sqlite3"
 
 gem "sprockets-rails"
 
+gem "bullet_train", path: "../bullet_train"
+gem "bullet_train-api", path: "../bullet_train-api"
+gem "bullet_train-fields", path: "../bullet_train-fields"
+gem "bullet_train-super_scaffolding", path: "../bullet_train-super_scaffolding"
+
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"

--- a/bullet_train-themes-light/Gemfile.lock
+++ b/bullet_train-themes-light/Gemfile.lock
@@ -14,16 +14,7 @@ PATH
       rails (>= 6.0.0)
 
 PATH
-  remote: ../bullet_train-super_scaffolding
-  specs:
-    bullet_train-super_scaffolding (1.6.13)
-      bullet_train
-      indefinite_article
-      masamune-ast (~> 2.0.2)
-      rails (>= 6.0.0)
-
-PATH
-  remote: .
+  remote: ../bullet_train-fields
   specs:
     bullet_train-fields (1.6.13)
       chronic
@@ -31,84 +22,19 @@ PATH
       phonelib
       rails (>= 6.0.0)
 
-GEM
-  remote: https://rubygems.org/
+PATH
+  remote: ../bullet_train-super_scaffolding
   specs:
-    actioncable (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      nio4r (~> 2.0)
-      websocket-driver (>= 0.6.1)
-    actionmailbox (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activestorage (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      mail (>= 2.7.1)
-      net-imap
-      net-pop
-      net-smtp
-    actionmailer (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      actionview (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      mail (~> 2.5, >= 2.5.4)
-      net-imap
-      net-pop
-      net-smtp
-      rails-dom-testing (~> 2.0)
-    actionpack (7.0.3.1)
-      actionview (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      rack (~> 2.0, >= 2.2.0)
-      rack-test (>= 0.6.3)
-      rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actiontext (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activestorage (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      globalid (>= 0.6.0)
-      nokogiri (>= 1.8.5)
-    actionview (7.0.3.1)
-      activesupport (= 7.0.3.1)
-      builder (~> 3.1)
-      erubi (~> 1.4)
-      rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    active_hash (3.2.1)
-      activesupport (>= 5.0.0)
-    activejob (7.0.3.1)
-      activesupport (= 7.0.3.1)
-      globalid (>= 0.3.6)
-    activemodel (7.0.3.1)
-      activesupport (= 7.0.3.1)
-    activerecord (7.0.3.1)
-      activemodel (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-    activestorage (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      marcel (~> 1.0)
-      mini_mime (>= 1.1.0)
-    activesupport (7.0.3.1)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      tzinfo (~> 2.0)
-    addressable (2.8.5)
-      public_suffix (>= 2.0.2, < 6.0)
-    ast (2.4.2)
-    awesome_print (1.9.2)
-    aws_cf_signer (0.1.3)
-    base64 (0.2.0)
-    bcrypt (3.1.19)
-    builder (3.2.4)
+    bullet_train-super_scaffolding (1.6.13)
+      bullet_train
+      colorizer
+      indefinite_article
+      masamune-ast (~> 2.0.2)
+      rails (>= 6.0.0)
+
+PATH
+  remote: ../bullet_train
+  specs:
     bullet_train (1.6.13)
       awesome_print
       bullet_train-fields
@@ -141,6 +67,103 @@ GEM
       unicode-emoji
       valid_email
       xxhash
+
+PATH
+  remote: .
+  specs:
+    bullet_train-themes-light (1.6.13)
+      bullet_train-themes-tailwind_css
+      masamune-ast (~> 2.0.2)
+      rails (>= 6.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (7.1.2)
+      actionpack (= 7.1.2)
+      activesupport (= 7.1.2)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+      zeitwerk (~> 2.6)
+    actionmailbox (7.1.2)
+      actionpack (= 7.1.2)
+      activejob (= 7.1.2)
+      activerecord (= 7.1.2)
+      activestorage (= 7.1.2)
+      activesupport (= 7.1.2)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.1.2)
+      actionpack (= 7.1.2)
+      actionview (= 7.1.2)
+      activejob (= 7.1.2)
+      activesupport (= 7.1.2)
+      mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
+      rails-dom-testing (~> 2.2)
+    actionpack (7.1.2)
+      actionview (= 7.1.2)
+      activesupport (= 7.1.2)
+      nokogiri (>= 1.8.5)
+      racc
+      rack (>= 2.2.4)
+      rack-session (>= 1.0.1)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    actiontext (7.1.2)
+      actionpack (= 7.1.2)
+      activerecord (= 7.1.2)
+      activestorage (= 7.1.2)
+      activesupport (= 7.1.2)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (7.1.2)
+      activesupport (= 7.1.2)
+      builder (~> 3.1)
+      erubi (~> 1.11)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    active_hash (3.2.1)
+      activesupport (>= 5.0.0)
+    activejob (7.1.2)
+      activesupport (= 7.1.2)
+      globalid (>= 0.3.6)
+    activemodel (7.1.2)
+      activesupport (= 7.1.2)
+    activerecord (7.1.2)
+      activemodel (= 7.1.2)
+      activesupport (= 7.1.2)
+      timeout (>= 0.4.0)
+    activestorage (7.1.2)
+      actionpack (= 7.1.2)
+      activejob (= 7.1.2)
+      activerecord (= 7.1.2)
+      activesupport (= 7.1.2)
+      marcel (~> 1.0)
+    activesupport (7.1.2)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      mutex_m
+      tzinfo (~> 2.0)
+    addressable (2.8.5)
+      public_suffix (>= 2.0.2, < 6.0)
+    ast (2.4.2)
+    awesome_print (1.9.2)
+    aws_cf_signer (0.1.3)
+    base64 (0.2.0)
+    bcrypt (3.1.19)
+    bigdecimal (3.1.4)
+    builder (3.2.4)
     bullet_train-has_uuid (1.6.13)
       rails (>= 6.0.0)
     bullet_train-roles (1.6.13)
@@ -154,6 +177,10 @@ GEM
       cancancan
       rails (>= 6.0.0)
     bullet_train-themes (1.6.13)
+      rails (>= 6.0.0)
+    bullet_train-themes-tailwind_css (1.6.13)
+      bullet_train
+      bullet_train-themes
       rails (>= 6.0.0)
     cable_ready (5.0.3)
       actionpack (>= 5.2)
@@ -169,7 +196,7 @@ GEM
       rest-client (>= 2.0.0)
     colorizer (0.0.2)
     commonmarker (0.23.10)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crass (1.0.6)
     css_parser (1.16.0)
@@ -187,8 +214,10 @@ GEM
     domain_name (0.6.20231109)
     doorkeeper (5.6.6)
       railties (>= 5)
+    drb (2.2.0)
+      ruby2_keywords
     email_reply_parser (0.5.11)
-    erubi (1.10.0)
+    erubi (1.12.0)
     event_stream_parser (0.3.0)
     extended_email_reply_parser (0.5.1)
       activesupport
@@ -216,13 +245,17 @@ GEM
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     http_accept_language (2.1.1)
-    i18n (1.11.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
     indefinite_article (0.2.5)
       activesupport
+    io-console (0.6.0)
+    irb (1.9.0)
+      rdoc
+      reline (>= 0.3.8)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -230,10 +263,12 @@ GEM
       jbuilder
       method_source
       rails (>= 5.0.0)
-    json (2.6.2)
-    loofah (2.18.0)
+    json (2.6.3)
+    language_server-protocol (3.17.0.3)
+    lint_roller (1.1.0)
+    loofah (2.22.0)
       crass (~> 1.0.2)
-      nokogiri (>= 1.5.9)
+      nokogiri (>= 1.12.0)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
@@ -252,9 +287,9 @@ GEM
     mime-types-data (3.2023.1003)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.1)
-    minitest (5.16.2)
+    minitest (5.20.0)
     multipart-post (2.3.0)
+    mutex_m (0.2.0)
     net-imap (0.4.5)
       date
       net-protocol
@@ -268,17 +303,17 @@ GEM
     nice_partials (0.10.0)
       actionview (>= 4.2.6)
     nio4r (2.5.9)
-    nokogiri (1.13.7)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     pagy (6.2.0)
     pagy_cursor (0.6.1)
       activerecord (>= 5)
       pagy (>= 6, < 7)
-    parallel (1.22.1)
-    parser (3.1.2.0)
+    parallel (1.23.0)
+    parser (3.2.2.4)
       ast (~> 2.4.1)
+      racc
     phonelib (0.8.5)
     possessive (1.0.1)
     premailer (1.21.0)
@@ -290,45 +325,59 @@ GEM
       net-smtp
       premailer (~> 1.7, >= 1.7.9)
     prism (0.17.1)
+    psych (5.1.1.1)
+      stringio
     public_suffix (5.0.3)
     pwned (2.0.2)
-    racc (1.6.0)
-    rack (2.2.4)
+    racc (1.7.3)
+    rack (3.0.8)
     rack-cors (2.0.1)
       rack (>= 2.0.0)
-    rack-test (2.0.2)
+    rack-session (2.0.0)
+      rack (>= 3.0.0)
+    rack-test (2.1.0)
       rack (>= 1.3)
-    rails (7.0.3.1)
-      actioncable (= 7.0.3.1)
-      actionmailbox (= 7.0.3.1)
-      actionmailer (= 7.0.3.1)
-      actionpack (= 7.0.3.1)
-      actiontext (= 7.0.3.1)
-      actionview (= 7.0.3.1)
-      activejob (= 7.0.3.1)
-      activemodel (= 7.0.3.1)
-      activerecord (= 7.0.3.1)
-      activestorage (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
+    rackup (2.1.0)
+      rack (>= 3)
+      webrick (~> 1.8)
+    rails (7.1.2)
+      actioncable (= 7.1.2)
+      actionmailbox (= 7.1.2)
+      actionmailer (= 7.1.2)
+      actionpack (= 7.1.2)
+      actiontext (= 7.1.2)
+      actionview (= 7.1.2)
+      activejob (= 7.1.2)
+      activemodel (= 7.1.2)
+      activerecord (= 7.1.2)
+      activestorage (= 7.1.2)
+      activesupport (= 7.1.2)
       bundler (>= 1.15.0)
-      railties (= 7.0.3.1)
-    rails-dom-testing (2.0.3)
-      activesupport (>= 4.2.0)
+      railties (= 7.1.2)
+    rails-dom-testing (2.2.0)
+      activesupport (>= 5.0.0)
+      minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.3)
-      loofah (~> 2.3)
-    railties (7.0.3.1)
-      actionpack (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-      method_source
+    rails-html-sanitizer (1.6.0)
+      loofah (~> 2.21)
+      nokogiri (~> 1.14)
+    railties (7.1.2)
+      actionpack (= 7.1.2)
+      activesupport (= 7.1.2)
+      irb
+      rackup (>= 1.0.0)
       rake (>= 12.2)
-      thor (~> 1.0)
-      zeitwerk (~> 2.5)
+      thor (~> 1.0, >= 1.2.2)
+      zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.1.0)
+    rdoc (6.6.0)
+      psych (>= 4.0.0)
     redis-client (0.18.0)
       connection_pool
-    regexp_parser (2.5.0)
+    regexp_parser (2.8.2)
+    reline (0.4.0)
+      io-console (~> 0.5)
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
@@ -337,27 +386,28 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.2.5)
-    rubocop (1.32.0)
+    rexml (3.2.6)
+    rubocop (1.57.2)
       json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.1.0.0)
+      parser (>= 3.2.2.4)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.19.1, < 2.0)
+      rubocop-ast (>= 1.28.1, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.19.1)
-      parser (>= 3.1.1.0)
-    rubocop-performance (1.14.3)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    rubocop-performance (1.19.1)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-openai (6.2.0)
       event_stream_parser (>= 0.3.0, < 1.0.0)
       faraday (>= 1)
       faraday-multipart (>= 1)
-    ruby-progressbar (1.11.0)
+    ruby-progressbar (1.13.0)
     ruby-vips (2.2.0)
       ffi (~> 1.12)
     ruby2_keywords (0.0.5)
@@ -370,26 +420,36 @@ GEM
       redis-client (>= 0.14.0)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
-    sprockets (4.1.1)
+    sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
+      rack (>= 2.2.4, < 4)
     sprockets-rails (3.4.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.4)
-    standard (1.14.0)
-      rubocop (= 1.32.0)
-      rubocop-performance (= 1.14.3)
+    sqlite3 (1.6.8-arm64-darwin)
+    standard (1.32.0)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.57.2)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.2)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.2.1)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.19.1)
+    stringio (3.0.9)
     thor (1.3.0)
     thread-local (1.1.0)
     timeout (0.4.1)
-    tzinfo (2.0.4)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.9)
-    unicode-display_width (2.2.0)
+    unicode-display_width (2.5.0)
     unicode-emoji (3.4.0)
       unicode-version (~> 1.0)
     unicode-version (1.3.0)
@@ -399,6 +459,7 @@ GEM
       simpleidn
     warden (1.2.9)
       rack (>= 2.0.9)
+    webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -406,21 +467,17 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
-  arm64-darwin-20
-  arm64-darwin-21
   arm64-darwin-22
-  ruby
-  x86_64-darwin-21
-  x86_64-darwin-22
-  x86_64-linux
 
 DEPENDENCIES
+  bullet_train!
   bullet_train-api!
   bullet_train-fields!
   bullet_train-super_scaffolding!
+  bullet_train-themes-light!
   sprockets-rails
   sqlite3
   standard
 
 BUNDLED WITH
-   2.3.14
+   2.4.20

--- a/bullet_train-themes-tailwind_css/Gemfile
+++ b/bullet_train-themes-tailwind_css/Gemfile
@@ -8,5 +8,10 @@ gem "sqlite3"
 
 gem "sprockets-rails"
 
+gem "bullet_train", path: "../bullet_train"
+gem "bullet_train-api", path: "../bullet_train-api"
+gem "bullet_train-fields", path: "../bullet_train-fields"
+gem "bullet_train-super_scaffolding", path: "../bullet_train-super_scaffolding"
+
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"

--- a/bullet_train/Gemfile
+++ b/bullet_train/Gemfile
@@ -13,5 +13,15 @@ gem "active_hash", github: "bullet-train-co/active_hash"
 
 gem "commonmarker", ">= 1.0.0.pre10"
 
+gem "bullet_train-api", path: "../bullet_train-api"
+gem "bullet_train-fields", path: "../bullet_train-fields"
+gem "bullet_train-roles", path: "../bullet_train-roles"
+gem "bullet_train-super_scaffolding", path: "../bullet_train-super_scaffolding"
+gem "bullet_train-super_load_and_authorize_resource", path: "../bullet_train-super_load_and_authorize_resource"
+gem "bullet_train-themes-light", path: "../bullet_train-themes-light"
+gem "bullet_train-has_uuid", path: "../bullet_train-has_uuid"
+gem "bullet_train-scope_validator", path: "../bullet_train-scope_validator"
+gem "bullet_train-themes", path: "../bullet_train-themes"
+
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"

--- a/bullet_train/Gemfile.lock
+++ b/bullet_train/Gemfile.lock
@@ -6,6 +6,81 @@ GIT
       activesupport (>= 5.0.0)
 
 PATH
+  remote: ../bullet_train-api
+  specs:
+    bullet_train-api (1.6.13)
+      bullet_train
+      bullet_train-super_scaffolding
+      colorizer
+      doorkeeper
+      factory_bot
+      jbuilder-schema (= 2.6.2)
+      pagy
+      pagy_cursor
+      rack-cors
+      rails (>= 6.0.0)
+
+PATH
+  remote: ../bullet_train-fields
+  specs:
+    bullet_train-fields (1.6.13)
+      chronic
+      cloudinary
+      phonelib
+      rails (>= 6.0.0)
+
+PATH
+  remote: ../bullet_train-has_uuid
+  specs:
+    bullet_train-has_uuid (1.6.13)
+      rails (>= 6.0.0)
+
+PATH
+  remote: ../bullet_train-roles
+  specs:
+    bullet_train-roles (1.6.13)
+      active_hash
+      activesupport
+      cancancan
+
+PATH
+  remote: ../bullet_train-scope_validator
+  specs:
+    bullet_train-scope_validator (1.6.13)
+      rails
+
+PATH
+  remote: ../bullet_train-super_load_and_authorize_resource
+  specs:
+    bullet_train-super_load_and_authorize_resource (1.6.13)
+      cancancan
+      rails (>= 6.0.0)
+
+PATH
+  remote: ../bullet_train-super_scaffolding
+  specs:
+    bullet_train-super_scaffolding (1.6.13)
+      bullet_train
+      colorizer
+      indefinite_article
+      masamune-ast (~> 2.0.2)
+      rails (>= 6.0.0)
+
+PATH
+  remote: ../bullet_train-themes-light
+  specs:
+    bullet_train-themes-light (1.6.13)
+      bullet_train-themes-tailwind_css
+      masamune-ast (~> 2.0.2)
+      rails (>= 6.0.0)
+
+PATH
+  remote: ../bullet_train-themes
+  specs:
+    bullet_train-themes (1.6.13)
+      rails (>= 6.0.0)
+
+PATH
   remote: .
   specs:
     bullet_train (1.6.13)
@@ -19,6 +94,7 @@ PATH
       bullet_train-themes
       cable_ready (~> 5.0.0)
       cancancan
+      colorizer
       commonmarker
       devise
       devise-pwned_password
@@ -30,6 +106,7 @@ PATH
       image_processing
       microscope
       nice_partials (~> 0.9)
+      omniauth
       pagy
       possessive
       premailer-rails
@@ -119,24 +196,11 @@ GEM
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.4)
-    bullet_train-fields (1.5.1)
-      chronic
-      cloudinary
-      phonelib
-      rails (>= 6.0.0)
-    bullet_train-has_uuid (1.5.1)
-      rails (>= 6.0.0)
-    bullet_train-roles (1.5.1)
-      active_hash
-      activesupport
-      cancancan
     bullet_train-routes (1.0.0)
       rails (>= 6.0.0)
-    bullet_train-scope_validator (1.5.1)
-    bullet_train-super_load_and_authorize_resource (1.5.1)
-      cancancan
-      rails (>= 6.0.0)
-    bullet_train-themes (1.5.1)
+    bullet_train-themes-tailwind_css (1.6.13)
+      bullet_train
+      bullet_train-themes
       rails (>= 6.0.0)
     cable_ready (5.0.1)
       actionpack (>= 5.2)
@@ -151,6 +215,7 @@ GEM
       aws_cf_signer
       rest-client (>= 2.0.0)
     coderay (1.1.3)
+    colorizer (0.0.2)
     commonmarker (1.0.0.pre10-arm64-darwin)
     commonmarker (1.0.0.pre10-x86_64-linux)
     concurrent-ruby (1.2.2)
@@ -171,6 +236,8 @@ GEM
       pwned (~> 2.0.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    doorkeeper (5.6.6)
+      railties (>= 5)
     email_reply_parser (0.5.11)
     erubi (1.12.0)
     extended_email_reply_parser (0.5.1)
@@ -178,6 +245,8 @@ GEM
       charlock_holmes
       email_reply_parser (~> 0.5.9)
       mail
+    factory_bot (6.3.0)
+      activesupport (>= 5.0.0)
     faraday (2.7.11)
       base64
       faraday-net_http (>= 2.0, < 3.1)
@@ -191,6 +260,7 @@ GEM
       thor (>= 0.14.0, < 2)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashie (5.0.0)
     hiredis (0.6.3)
     htmlentities (4.3.4)
     http-accept (1.7.0)
@@ -202,6 +272,15 @@ GEM
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
+    indefinite_article (0.2.5)
+      activesupport
+    jbuilder (2.11.5)
+      actionview (>= 5.0.0)
+      activesupport (>= 5.0.0)
+    jbuilder-schema (2.6.2)
+      jbuilder
+      method_source
+      rails (>= 5.0.0)
     json (2.6.3)
     language_server-protocol (3.17.0.2)
     loofah (2.20.0)
@@ -213,6 +292,9 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.2)
+    masamune-ast (2.0.2)
+      activesupport
+      prism (>= 0.14.0)
     method_source (1.0.0)
     microscope (1.1.1)
       activerecord (>= 4.1.0)
@@ -245,8 +327,15 @@ GEM
       racc (~> 1.4)
     nokogiri (1.14.3-x86_64-linux)
       racc (~> 1.4)
+    omniauth (2.1.1)
+      hashie (>= 3.4.6)
+      rack (>= 2.2.3)
+      rack-protection
     orm_adapter (0.5.0)
     pagy (6.1.0)
+    pagy_cursor (0.6.1)
+      activerecord (>= 5)
+      pagy (>= 6, < 7)
     parallel (1.22.1)
     parser (3.1.3.0)
       ast (~> 2.4.1)
@@ -260,6 +349,7 @@ GEM
       actionmailer (>= 3)
       net-smtp
       premailer (~> 1.7, >= 1.7.9)
+    prism (0.17.1)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -270,6 +360,10 @@ GEM
     pwned (2.0.2)
     racc (1.6.2)
     rack (2.2.6.4)
+    rack-cors (2.0.1)
+      rack (>= 2.0.0)
+    rack-protection (3.1.0)
+      rack (~> 2.2, >= 2.2.4)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.3.1)
@@ -387,6 +481,15 @@ PLATFORMS
 DEPENDENCIES
   active_hash!
   bullet_train!
+  bullet_train-api!
+  bullet_train-fields!
+  bullet_train-has_uuid!
+  bullet_train-roles!
+  bullet_train-scope_validator!
+  bullet_train-super_load_and_authorize_resource!
+  bullet_train-super_scaffolding!
+  bullet_train-themes!
+  bullet_train-themes-light!
   commonmarker (>= 1.0.0.pre10)
   pry
   pry-stack_explorer

--- a/bullet_train/bullet_train.gemspec
+++ b/bullet_train/bullet_train.gemspec
@@ -40,8 +40,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bullet_train-scope_validator"
   spec.add_dependency "bullet_train-themes"
   spec.add_dependency "bullet_train-routes"
+  spec.add_dependency "colorizer"
   spec.add_dependency "devise"
   spec.add_dependency "xxhash"
+  spec.add_dependency "omniauth"
 
   spec.add_dependency "image_processing"
 


### PR DESCRIPTION
In the course of [trying to be able to run all of the tests for individual gems in CI](https://github.com/bullet-train-co/bullet_train-core/pull/569) I've discovered that we don't specify all of our dependencies fully.

In the starter repo the problems don't appear because all of the things that we need end up being dependencies of something or other, but when we try to run tests for individual gems we'll get errors about unsatisfied dependencies.

There are only a few gems where we needed to declare a missing dependency in the `.gemspec`. And those are the only things in this PR that could have the chance to impact downsteam apps.

All of the changes to `Gemfile` and `Gemfile.lock` in each gem won't impact gem consumers at all. They just come into play in local development and CI. The changes in each `Gemfile` ensure that when developing or testing these gems that they'll use their peer gems from inside the `core` repo insted of using whatever version happens to be latest.