### PR TITLE
Remove `divergent_namespaces`

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/routes_file_manipulator.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/routes_file_manipulator.rb
@@ -35,22 +35,6 @@ class Scaffolding::RoutesFileManipulator
     @common_namespaces
   end
 
-  # def divergent_namespaces
-  #   unless @divergent_namespaces
-  #     @divergent_namespaces ||= []
-  #     child_parts_copy = child_parts.dup
-  #     parent_parts_copy = parent_parts.dup
-  #     while child_parts_copy.first == parent_parts_copy.first
-  #       child_parts_copy.shift
-  #       parent_parts_copy.shift
-  #     end
-  #     child_parts_copy.pop
-  #     parent_parts_copy.pop
-  #     @divergent_namespaces = [child_parts_copy, parent_parts_copy]
-  #   end
-  #   @divergent_namespaces
-  # end
-
   def divergent_parts
     unless @divergent_namespaces
       @divergent_namespaces ||= []

--- a/bullet_train-super_scaffolding/test/lib/scaffolding/routes_file_manipulator_test.rb
+++ b/bullet_train-super_scaffolding/test/lib/scaffolding/routes_file_manipulator_test.rb
@@ -26,22 +26,6 @@ class Scaffolding::RoutesFileManipulatorTest < ActiveSupport::TestCase
     end
   end
 
-  # {
-  #   ['Scaffolding::Thing', 'Scaffolding::Widget'] =>
-  #     [[], []],
-
-  #   ['Scaffolding::SomethingTogether::Thing', 'Scaffolding::SomethingTogether::Widget'] =>
-  #     [[], []],
-
-  #   ['Scaffolding::SomethingTogether::Thing', 'Scaffolding::SomethingElse::Widget'] =>
-  #     [['something_together'], ['something_else']],
-  # }.each do |inputs, outputs|
-  #   test "divergent_namespaces returns #{outputs.to_s} for `#{inputs.first}` under `#{inputs.last}`" do
-  #     results = subject.new(example_file, *inputs).divergent_namespaces
-  #     assert_equal outputs, results
-  #   end
-  # end
-
   {
     ["Scaffolding::Thing", "Scaffolding::Widget"] =>
       [[], "things", [], "widgets"],


### PR DESCRIPTION
I don't ever remember a time when this was actually being used, so I think we can safely remove this. It is worth noting that this is different from `@divergent_namespaces` which is *not* commented out.