### PR TITLE
Don't use _commit callbacks when sending quantity updates

### DIFF
--- a/bullet_train/app/models/concerns/memberships/base.rb
+++ b/bullet_train/app/models/concerns/memberships/base.rb
@@ -30,9 +30,9 @@ module Memberships::Base
       end
     end
 
-    after_create_commit :publish_changed_quantity
-    after_update_commit :publish_changed_quantity
-    after_destroy_commit :publish_changed_quantity
+    after_create :publish_changed_quantity
+    after_update :publish_changed_quantity
+    after_destroy :publish_changed_quantity
 
     after_validation :remove_user_profile_photo, if: :user_profile_photo_removal?
 

--- a/bullet_train/app/models/concerns/memberships/base.rb
+++ b/bullet_train/app/models/concerns/memberships/base.rb
@@ -30,9 +30,7 @@ module Memberships::Base
       end
     end
 
-    after_create :publish_changed_quantity
-    after_update :publish_changed_quantity
-    after_destroy :publish_changed_quantity
+    after_commit :publish_changed_quantity
 
     after_validation :remove_user_profile_photo, if: :user_profile_photo_removal?
 


### PR DESCRIPTION
For whatever reason, I suddenly ran into issues - the transactional versions of the callbacks weren't triggered anymore when adding/removing a team member.

I think we should be fine with the ordinary versions though. Sorry for the hassle!