### PR TITLE
Use Prism nodes to find namespaces in RoutesFileManipulator

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/routes_file_manipulator.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/routes_file_manipulator.rb
@@ -73,13 +73,20 @@ class Scaffolding::RoutesFileManipulator
     namespace_nodes.map do |node|
       # Get the first argument (a Symbol) without the colon from the list of arguments.
       name = node.arguments.child_nodes.first.unescaped
-      results[name] = node.line_number if namespaces.include?(name)
+
+      # TODO: For some reason we use both strings and symbols for namespaces.
+      # i.e. - ["account"] and [:v1].
+      if namespaces.include?(name.to_sym)
+        results[name.to_sym] = node.line_number - 1
+      elsif namespaces.include?(name)
+        results[name] = node.line_number - 1
+      end
     end
 
     # `within` uses an Array index whereas Masamune nodes use the actual line number, so we write `within + 1` here.
     if within
-      block_end = @msmn.method_calls.find {|node| node.line_number == within + 1}.location.end_line
-      results.reject {|name, line_number| line_number >= block_end}
+      block_end = @msmn.method_calls.find { |node| node.line_number == within + 1 }.location.end_line
+      results.reject { |name, line_number| line_number >= block_end }
     end
 
     results

--- a/bullet_train-super_scaffolding/lib/scaffolding/routes_file_manipulator.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/routes_file_manipulator.rb
@@ -68,19 +68,20 @@ class Scaffolding::RoutesFileManipulator
   end
 
   def find_namespaces(namespaces, within = nil)
-    namespaces = namespaces.dup
     results = {}
-    block_end = Scaffolding::BlockManipulator.find_block_end(starting_from: within, lines: lines) if within
-    lines.each_with_index do |line, line_number|
-      if within
-        next unless line_number > within
-        return results if line_number >= block_end
-      end
-      if line.include?("namespace :#{namespaces.first} do")
-        results[namespaces.shift] = line_number
-      end
-      return results unless namespaces.any?
+    namespace_nodes = @msmn.method_calls(token_value: "namespace")
+    namespace_nodes.map do |node|
+      # Get the first argument (a Symbol) without the colon from the list of arguments.
+      name = node.arguments.child_nodes.first.unescaped
+      results[name] = node.line_number if namespaces.include?(name)
     end
+
+    # `within` uses an Array index whereas Masamune nodes use the actual line number, so we write `within + 1` here.
+    if within
+      block_end = @msmn.method_calls.find {|node| node.line_number == within + 1}.location.end_line
+      results.reject {|name, line_number| line_number >= block_end}
+    end
+
     results
   end
 


### PR DESCRIPTION
Trying piece by piece to migrate to Masamune, and I'm really liking that we can find block ends with Prism nodes. There's one model whose routes are not being properly scaffolded though, so I'll keep trying to debug this one.

I added a TODO, but I also noticed we use both strings and symbols in the `namespaces` array we're passing to this method, which is having an affect on the keys for the hash we're returning. We don't have to do it in this PR, but it might be beneficial to standardize on one or the other.