### PR TITLE
Fix: Handle internationalized git in superscaffolding script

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/script.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/script.rb
@@ -50,16 +50,7 @@ def standard_protip
   puts "If you do that, you can reset to your last commit state by using `git checkout .` and `git clean -d -f` ."
 end
 
-def git_status
-  `git status`.split("\n")
-end
-
-def has_untracked_files?(status_lines)
-  status_lines.include?("Untracked files:")
-end
-
-# All untracked files begin with a tab (i.e. - "\tapp/models/model.rb").
-def get_untracked_files(status_lines)
+def get_untracked_files
   `git ls-files --other --exclude-standard`.split("\n")
 end
 
@@ -198,11 +189,11 @@ def check_required_options_for_attributes(scaffolding_type, attributes, child, p
     puts ""
 
     unless @options["skip-migration-generation"]
-      untracked_files = has_untracked_files?(git_status) ? get_untracked_files(git_status) : []
+      untracked_files = get_untracked_files
       generation_thread = Thread.new { `#{generation_command}` }
       generation_thread.join # Wait for the process to finish.
 
-      newly_untracked_files = has_untracked_files?(git_status) ? get_untracked_files(git_status) : []
+      newly_untracked_files = get_untracked_files
       if (newly_untracked_files - untracked_files).size.zero?
         error_message = <<~MESSAGE
           Since you have already created the #{child} model, Super Scaffolding won't allow you to re-create it.


### PR DESCRIPTION
Git commands can be internationalized and superscaffolding untracked file detection will fail because the labels don't match (eg, on my machine, git displays "Fichiers non suivis" instead of "Untracked files"), which causes the script to stop right after model generation.

I initially modified `git_status`and `has_untracked_files` to use the `--porcelain` option of `git status` which, according to the docs, is intended to be used by scripts and as such is not internationalized. but digging deeper, it seems these are not needed, as `get_untracked_files` already manages the "no untracked files" scenario by returning an empty array.

As a workaround until this or a better solution is merged, one can re-run the superscaffolding command with `--skip-migration-generation` and the script will successfully run this time