### PR TITLE
Find namespaces in the `RoutesFileManipulator` with Prism nodes

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/routes_file_manipulator.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/routes_file_manipulator.rb
@@ -54,17 +54,23 @@ class Scaffolding::RoutesFileManipulator
   def find_namespaces(namespaces, within = nil)
     namespaces = namespaces.dup
     results = {}
-    block_end = Scaffolding::BlockManipulator.find_block_end(starting_from: within, lines: lines) if within
-    lines.each_with_index do |line, line_number|
-      if within
-        next unless line_number > within
-        return results if line_number >= block_end
-      end
-      if line.include?("namespace :#{namespaces.first} do")
-        results[namespaces.shift] = line_number
-      end
-      return results unless namespaces.any?
+    reinstatiate_masamune_object
+
+    # `within` can refer to either a `resources`, `namespace`, `scope`, or `shallow` block.
+    blocks = @msmn.method_calls.select {|node| node.token_value.match?(/resources|namespace|scope|shallow/)}
+    namespace_nodes = blocks.select{|node| node.token_value.match?(/namespace/)}
+
+    if within
+      starting_block = blocks.find {|block| block.line_number - 1 == within}
+      block_range = (starting_block.location.start_line - 1)..(starting_block.location.end_line - 1)
+      namespace_nodes.select! {|node| block_range.cover?(node.line_number)}
     end
+
+    namespace_nodes.each do |node|
+      name = node.arguments.child_nodes.first.unescaped
+      results[namespaces.shift] = node.line_number - 1 if namespaces.first.to_s == name
+    end
+
     results
   end
 
@@ -223,7 +229,8 @@ class Scaffolding::RoutesFileManipulator
       # all other namespace blocks INSIDE the top-level namespace blocks are skipped
       if namespace_line_numbers.include?(line_index)
         # Grab the first symbol token on the same line as the namespace.
-        namespace_name = @msmn.symbols.find { |sym| sym.line_number == line_index }.token_value
+        reinstatiate_masamune_object
+        namespace_name = @msmn.symbols.find { |sym| (sym.line_number) == line_index }.token_value
         local_namespace = find_namespaces([namespace_name], within)
         starting_line_number = local_namespace[namespace_name]
         local_namespace_block = ((starting_line_number + 1)..(Scaffolding::BlockManipulator.find_block_end(starting_from: starting_line_number, lines: lines) + 1))
@@ -417,5 +424,9 @@ class Scaffolding::RoutesFileManipulator
     else
       lines[line_number].gsub!(/resources :(.*)$/, "resources :\\1, concerns: [#{existing_concerns.map { |e| ":#{e}" }.join(", ")}]")
     end
+  end
+
+  def reinstatiate_masamune_object
+    @msmn = Masamune::AbstractSyntaxTree.new(lines.join)
   end
 end

--- a/bullet_train-super_scaffolding/lib/scaffolding/routes_file_manipulator.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/routes_file_manipulator.rb
@@ -54,7 +54,7 @@ class Scaffolding::RoutesFileManipulator
   def find_namespaces(namespaces, within = nil)
     namespaces = namespaces.dup
     results = {}
-    reinstatiate_masamune_object
+    reinstantiate_masamune_object
 
     # `within` can refer to either a `resources`, `namespace`, `scope`, or `shallow` block.
     blocks = @msmn.method_calls.select { |node| node.token_value.match?(/resources|namespace|scope|shallow/) }
@@ -229,7 +229,7 @@ class Scaffolding::RoutesFileManipulator
       # all other namespace blocks INSIDE the top-level namespace blocks are skipped
       if namespace_line_numbers.include?(line_index)
         # Grab the first symbol token on the same line as the namespace.
-        reinstatiate_masamune_object
+        reinstantiate_masamune_object
         namespace_name = @msmn.symbols.find { |sym| sym.line_number == line_index }.token_value
         local_namespace = find_namespaces([namespace_name], within)
         starting_line_number = local_namespace[namespace_name]
@@ -426,7 +426,7 @@ class Scaffolding::RoutesFileManipulator
     end
   end
 
-  def reinstatiate_masamune_object
+  def reinstantiate_masamune_object
     @msmn = Masamune::AbstractSyntaxTree.new(lines.join)
   end
 end

--- a/bullet_train-super_scaffolding/lib/scaffolding/routes_file_manipulator.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/routes_file_manipulator.rb
@@ -57,13 +57,13 @@ class Scaffolding::RoutesFileManipulator
     reinstatiate_masamune_object
 
     # `within` can refer to either a `resources`, `namespace`, `scope`, or `shallow` block.
-    blocks = @msmn.method_calls.select {|node| node.token_value.match?(/resources|namespace|scope|shallow/)}
-    namespace_nodes = blocks.select{|node| node.token_value.match?(/namespace/)}
+    blocks = @msmn.method_calls.select { |node| node.token_value.match?(/resources|namespace|scope|shallow/) }
+    namespace_nodes = blocks.select { |node| node.token_value.match?(/namespace/) }
 
     if within
-      starting_block = blocks.find {|block| block.line_number - 1 == within}
+      starting_block = blocks.find { |block| block.line_number - 1 == within }
       block_range = (starting_block.location.start_line - 1)..(starting_block.location.end_line - 1)
-      namespace_nodes.select! {|node| block_range.cover?(node.line_number)}
+      namespace_nodes.select! { |node| block_range.cover?(node.line_number) }
     end
 
     namespace_nodes.each do |node|
@@ -230,7 +230,7 @@ class Scaffolding::RoutesFileManipulator
       if namespace_line_numbers.include?(line_index)
         # Grab the first symbol token on the same line as the namespace.
         reinstatiate_masamune_object
-        namespace_name = @msmn.symbols.find { |sym| (sym.line_number) == line_index }.token_value
+        namespace_name = @msmn.symbols.find { |sym| sym.line_number == line_index }.token_value
         local_namespace = find_namespaces([namespace_name], within)
         starting_line_number = local_namespace[namespace_name]
         local_namespace_block = ((starting_line_number + 1)..(Scaffolding::BlockManipulator.find_block_end(starting_from: starting_line_number, lines: lines) + 1))

--- a/bullet_train-super_scaffolding/lib/scaffolding/routes_file_manipulator.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/routes_file_manipulator.rb
@@ -62,7 +62,7 @@ class Scaffolding::RoutesFileManipulator
 
     if within
       starting_block = blocks.find { |block| block.line_number - 1 == within }
-      block_range = (starting_block.location.start_line - 1)..(starting_block.location.end_line - 1)
+      block_range = (starting_block.location.start_line)..(starting_block.location.end_line)
       namespace_nodes.select! { |node| block_range.cover?(node.line_number) }
     end
 


### PR DESCRIPTION
Closes #690.

The code looks simple now, but this was a really difficult one for me to figure out. One of the most important parts is how we shift elements off of the `namespaces` array to populate the `results` hash.

The new code is the same as the original in that it shifts the first element to `results`, and then leaves any leftover elements in `namespaces` if they don't match any namespaces in the routes file's lines.

I can't say I'm entirely sure *why* we need to shift off lines like this. I want to look over this file as a whole and apply Prism nodes where possible, so I hope to sit down with this file longer to get a better grasp of it.