### PR TITLE
Resolve `roles.yml` file from `Rails.root`

### DIFF
--- a/bullet_train-roles/test/dummy/config/application.rb
+++ b/bullet_train-roles/test/dummy/config/application.rb
@@ -31,7 +31,7 @@ module Dummy
 
     config.factory_bot.definition_file_paths += [File.expand_path("../../factories", __dir__)] if defined?(FactoryBotRails)
 
-    Role.set_root_path("#{Rails.root}/config/models")
+    Role.set_root_path("config/models")
     Role.set_filename("roles")
   end
 end

--- a/bullet_train-roles/test/dummy/config/application.rb
+++ b/bullet_train-roles/test/dummy/config/application.rb
@@ -31,7 +31,7 @@ module Dummy
 
     config.factory_bot.definition_file_paths += [File.expand_path("../../factories", __dir__)] if defined?(FactoryBotRails)
 
-    Role.set_root_path("config/models")
+    Role.set_root_path("#{Rails.root}/config/models")
     Role.set_filename("roles")
   end
 end

--- a/bullet_train-roles/test/dummy/config/initializers/bullet_train-roles.rb
+++ b/bullet_train-roles/test/dummy/config/initializers/bullet_train-roles.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 Role.class_eval do
-  set_root_path "test/dummy/config/models"
+  set_root_path "#{Rails.root}/config/models"
   set_filename "roles"
 end

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -483,7 +483,7 @@ class Scaffolding::Transformer
 
   def add_ability_line_to_roles_yml(class_names = nil)
     model_names = class_names || [child]
-    role_file = "./config/models/roles.yml"
+    role_file = "#{Rails.root}/config/models/roles.yml"
     roles_hash = YAML.load_file(role_file)
     default_role_placements = [
       [:default, :models],


### PR DESCRIPTION
Closes #688.

As a side note, I didn't add `#{Rails.root}` the following lines because it was throwing an error when trying to run migrations in the starter repository:

https://github.com/bullet-train-co/bullet_train-core/blob/445b8e616199782d4de2de96b1e4e319656b08ff/bullet_train-roles/lib/models/role.rb#L7-L8

https://github.com/bullet-train-co/bullet_train-core/blob/445b8e616199782d4de2de96b1e4e319656b08ff/bullet_train-roles/test/dummy/config/application.rb#L34-L35

`set_root_path` is an ActiveHash method, and it looks like it already looks for a `yml` file based off of the root path. This can be inferred from the following in the [documentation](https://github.com/active-hash/active_hash#activeyaml):

> By default, this class will look for a yml file named "countries.yml" in the same directory as the file. You can either change the directory it looks in, the filename it looks for, or both:
> ```ruby
> class Country < ActiveYaml::Base
>   set_root_path "/u/data"
>   set_filename "sample"
> end
> ```
> The above example will look for the file "/u/data/sample.yml".
