### PR TITLE
Update documentation for `rails generate super_scaffold`

### DIFF
--- a/bullet_train/docs/field-partials.md
+++ b/bullet_train/docs/field-partials.md
@@ -149,7 +149,7 @@ For Cloudinary you should use `string`, and for ActiveStorage you should use `at
 ## A Note On Data Types
 When creating a `multiple` option attribute, Bullet Train generates these values as a `jsonb`.
 ```
-bin/super-scaffold crud Project Team multiple_buttons:buttons{multiple}
+rails generate super_scaffold Project Team multiple_buttons:buttons{multiple}
 ```
 
 This will run the following rails command.

--- a/bullet_train/docs/field-partials/file-field.md
+++ b/bullet_train/docs/field-partials/file-field.md
@@ -21,7 +21,7 @@ Note, no database migration is required as ActiveStorage uses its own tables to 
 Run the following command to generate the scaffolding for the `document` field on the `Post` model:
 
 ```bash
-./bin/super-scaffold crud-field Post document:file_field
+rails generate super_scaffold:field Post document:file_field
 ```
 
 ## Multiple Attachment Example
@@ -39,7 +39,7 @@ Note, no database migration is required as ActiveStorage uses its own tables to 
 Run the following command to generate the scaffolding for the `documents` field on the `Post` model:
 
 ```bash
-./bin/super-scaffold crud-field Post documents:file_field{multiple}
+rails generate super_scaffold:field Post documents:file_field{multiple}
 ```
 
 ## Generating a Model & Super Scaffold Example
@@ -47,5 +47,5 @@ Run the following command to generate the scaffolding for the `documents` field 
 If you're starting fresh, and don't have an existing model you can do something like this:
 
 ```
-bin/super-scaffold crud Project Team name:text_field specification:file_field documents:file_field{multiple}
+rails generate super_scaffold Project Team name:text_field specification:file_field documents:file_field{multiple}
 ```

--- a/bullet_train/docs/getting-started.md
+++ b/bullet_train/docs/getting-started.md
@@ -8,18 +8,18 @@ Whether you want to build a new application with Bullet Train or contribute to B
 
 If you're using Bullet Train for the first time, begin by learning these five important techniques:
 
-1. Use `bin/super-scaffold crud` to scaffold a new model:
+1. Use `rails generate super_scaffold` to scaffold a new model:
 
     ```
-    bin/super-scaffold crud Project Team name:text_field
+    rails generate super_scaffold Project Team name:text_field
     ```
 
-    In this example, `Team` refers to the immediate parent of the `Project` resource. For more details, just run `bin/super-scaffold` or [read the documentation](/docs/super-scaffolding.md).
+    In this example, `Team` refers to the immediate parent of the `Project` resource. For more details, just run `rails generate super_scaffold` or [read the documentation](/docs/super-scaffolding.md).
 
-2. Use `bin/super-scaffold crud-field` to add a new field to a model you've already scaffolded:
+2. Use `rails generate super_scaffold:field` to add a new field to a model you've already scaffolded:
 
     ```
-    bin/super-scaffold crud-field Project description:trix_editor
+    rails generate super_scaffold:field Project description:trix_editor
     ```
 
     These first two points about Super Scaffolding are just the tip of the iceberg, so be sure to circle around and [read the full documentation](/docs/super-scaffolding.md).

--- a/bullet_train/docs/modeling.md
+++ b/bullet_train/docs/modeling.md
@@ -44,7 +44,7 @@ In traditional Rails development, it can be so much work to bring your domain mo
 
 ### Focus on the structure and namespacing. Don't worry about every attribute.
 
-One of the unique features of Super Scaffolding is that it allows you to scaffold additional attributes with `bin/super-scaffold crud-field` after the initial scaffolding of a model with `bin/super-scaffold crud`. That means that you don't have to worry about figuring out every single attribute that might exist on a model before running Super Scaffolding. Instead, the really important piece is:
+One of the unique features of Super Scaffolding is that it allows you to scaffold additional attributes with `rails generate super_scaffold:field` after the initial scaffolding of a model with `rails generate super_scaffold`. That means that you don't have to worry about figuring out every single attribute that might exist on a model before running Super Scaffolding. Instead, the really important piece is:
 
 1. Naming the model.
 2. Determining which parent model it primarily belongs to.
@@ -68,7 +68,7 @@ Even if you know there's an attribute or model that you're going to want to poli
 
 ## A Systematic Approach
 
-### 1. Write `bin/super-scaffold` commands in a scratch file.
+### 1. Write `rails generate super_scaffold` commands in a scratch file.
 
 See the [Super Scaffolding documentation](/docs/super-scaffolding.md) for more specific guidance. Leave plenty of comments in your scratch file describing anything that isn't obvious and providing examples of values that might populate attributes.
 

--- a/bullet_train/docs/namespacing.md
+++ b/bullet_train/docs/namespacing.md
@@ -7,5 +7,5 @@ Bullet Train comes preconfigured with an `Account` namespace for controllers and
 In Bullet Train applications with [multiple team types](/docs/teams.md), you may find it helpful to introduce additional controller and view namespaces to represent and organize user interfaces and experiences for certain team types that vary substantially from the `Account` namespace default. In Super Scaffolding, you can specify a namespace other than `Account` with the `--namespace` option, for example:
 
 ```
-bin/super-scaffold crud Event Team name:text_field --namespace=customers
+rails generate super_scaffold Event Team name:text_field --namespace=customers
 ```

--- a/bullet_train/docs/oauth.md
+++ b/bullet_train/docs/oauth.md
@@ -4,7 +4,7 @@ Bullet Train includes [Omniauth](https://github.com/omniauth/omniauth) by defaul
 For specific instructions on adding new OAuth providers, run the following on your shell:
 
 ```
-bin/super-scaffold oauth-provider
+rails generate super_scaffold:oauth_provider
 ```
 
 ## Stripe Connect Example

--- a/bullet_train/docs/super-scaffolding.md
+++ b/bullet_train/docs/super-scaffolding.md
@@ -30,20 +30,20 @@ Before getting started with Super Scaffolding, we recommend reading about [the p
 The Super Scaffolding shell script provides its own documentation. If you're curious about specific scaffolders or parameters, you can run the following in your shell:
 
 ```
-bin/super-scaffold
+rails generate super_scaffold
 ```
 
 ## Examples
 
-### 1. Basic CRUD Scaffolding with `crud`
+### 1. Basic CRUD Scaffolding
 
 Let's implement the following feature:
 
 > An organization has many projects.
 
-First, run the `crud` scaffolder:
+First, run the scaffolder:
 ```
-bin/super-scaffold crud Project Team name:text_field
+rails generate super_scaffold Project Team name:text_field
 rake db:migrate
 ```
 
@@ -60,10 +60,10 @@ rails g model Project team:references name:string
 
 Then you can run the scaffolder with the flag:
 ```
-bin/super-scaffold crud Project Team name:text_field --skip-migration-generation
+rails generate super_scaffold Project Team name:text_field --skip-migration-generation
 ```
 
-### 2. Nested CRUD Scaffolding with `crud`
+### 2. Nested CRUD Scaffolding
 
 Building on that example, let's implement the following feature:
 
@@ -71,40 +71,40 @@ Building on that example, let's implement the following feature:
 A project has many goals.
 ```
 
-First, run the `crud` scaffolder:
+First, run the scaffolder:
 
 ```
-bin/super-scaffold crud Goal Project,Team description:text_field
+rails generate super_scaffold Goal Project,Team description:text_field
 rake db:migrate
 ```
 
 You can see in the example above how we've specified `Project,Team`, because we want to specify the entire chain of ownership back to the `Team`. This allows Super Scaffolding to automatically generate the required permissions. Take note that this generates a foreign key for `Project` and not for `Team`.
 
-### 3. Adding New Fields with `crud-field`
+### 3. Adding New Fields with `field`
 
-One of Bullet Train's most valuable features is the ability to add new fields to existing scaffolded models. When you add new fields with the `crud-field` scaffolder, you don't have to remember to add that same attribute to table views, show views, translation files, API endpoints, serializers, tests, documentation, etc.
+One of Bullet Train's most valuable features is the ability to add new fields to existing scaffolded models. When you add new fields with the `field` scaffolder, you don't have to remember to add that same attribute to table views, show views, translation files, API endpoints, serializers, tests, documentation, etc.
 
 Building on the earlier example, consider the following new requirement:
 
 > In addition to a name, a project can have a description.
 
-Use the `crud-field` scaffolder to add it throughout the application:
+Use the `field` scaffolder to add it throughout the application:
 
 ```
-bin/super-scaffold crud-field Project description:trix_editor
+rails generate super_scaffold:field Project description:trix_editor
 rake db:migrate
 ```
 
-As you can see, when we're using `crud-field`, we don't need to supply the chain of ownership back to `Team`.
+As you can see, when we're using `field`, we don't need to supply the chain of ownership back to `Team`.
 
 If you want to scaffold a new field to use for read-only purposes, add the following option to omit the field from the form and all other files that apply:
 ```
-bin/super-scaffold crud-field Project description:trix_editor{readonly}
+rails generate super_scaffold:field Project description:trix_editor{readonly}
 ```
 
 Again, if you would like to automatically generate the migration on your own, pass the `--skip-migration-generation` flag:
 ```
-bin/super-scaffold crud-field Project description:trix_editor --skip-migration-generation
+rails generate super_scaffold:field Project description:trix_editor --skip-migration-generation
 ```
 
 ### 4. Adding Option Fields with Fixed, Translatable Options
@@ -118,7 +118,7 @@ We have multiple [field partials](/docs/field-partials.md) that we could use for
 In this example, let's add a status attribute and present it as buttons:
 
 ```
-bin/super-scaffold crud-field Project status:buttons
+rails generate super_scaffold:field Project status:buttons
 ```
 
 By default, Super Scaffolding configures the buttons as "One", "Two", and "Three", but in this example you can edit those options in the `fields` section of `config/locales/en/projects.en.yml`. For example, you could specify the following options:
@@ -146,7 +146,7 @@ Although you might think this calls for a reference to `User`, we've learned the
 We can accomplish this like so:
 
 ```
-bin/super-scaffold crud-field Project lead_id:super_select{class_name=Membership}
+rails generate super_scaffold:field Project lead_id:super_select{class_name=Membership}
 rake db:migrate
 ```
 
@@ -166,7 +166,7 @@ end
 
 (The `current_and_invited` scope just filters out people that have already been removed from the team.)
 
-### 6. Scaffolding Has-Many-Through Associations with `join-model`
+### 6. Scaffolding Has-Many-Through Associations with `join_model`
 
 Finally, working from the same example, imagine the following requirement:
 
@@ -177,31 +177,31 @@ We can accomplish this with a new model, a new join model, and a `super_select` 
 First, let's create the tag model:
 
 ```
-bin/super-scaffold crud Projects::Tag Team name:text_field
+rails generate super_scaffold Projects::Tag Team name:text_field
 ```
 
 Note that project tags are specifically defined at the `Team` level. The same tag can be applied to multiple `Project` models.
 
 Now, let's create a join model for the has-many-through association.
 
-We're not going to scaffold this model with the typical `crud` scaffolder, but some preparation is needed before we can use it with the `crud-field` scaffolder, so we need to do the following:
+We're not going to scaffold this model with the typical `rails generate super_scaffold` scaffolder, but some preparation is needed before we can use it with the `field` scaffolder, so we need to do the following:
 
 ```
-bin/super-scaffold join-model Projects::AppliedTag project_id{class_name=Project} tag_id{class_name=Projects::Tag}
+rails generate super_scaffold:join_model Projects::AppliedTag project_id{class_name=Project} tag_id{class_name=Projects::Tag}
 ```
 
 All we're doing here is specifying the name of the join model, and the two attributes and class names of the models it joins. Note again that we specify the `_id` suffix on both of the attributes.
 
-Now that the join model has been prepared, we can use the `crud-field` scaffolder to create the multi-select field:
+Now that the join model has been prepared, we can use the `field` scaffolder to create the multi-select field:
 
 ```
-bin/super-scaffold crud-field Project tag_ids:super_select{class_name=Projects::Tag}
+rails generate super_scaffold:field Project tag_ids:super_select{class_name=Projects::Tag}
 rake db:migrate
 ```
 
 Just note that the suffix of the field is `_ids` plural, and this is an attribute provided by Rails to interact with the `has_many :tags, through: :applied_tags` association.
 
-The `crud-field` step will ask you to define the logic for the `valid_tags` method in `app/models/project.rb`. You can define it like so:
+The `field` step will ask you to define the logic for the `valid_tags` method in `app/models/project.rb`. You can define it like so:
 
 ```ruby
 def valid_tags
@@ -228,13 +228,13 @@ For instance to scaffold a `Project` model with a `logo` image upload.
 Use `image` as a field type for super scaffolding:
 
 ```
-bin/super-scaffold crud Project Team name:text_field logo:image
+rails generate super_scaffold Project Team name:text_field logo:image
 rake db:migrate
 ```
 
 Under the hood, Bullet Train will generate your model with the following command:
 ```
-bin/super-scaffold crud Project Team name:text_field
+rails generate super_scaffold Project Team name:text_field
 rake db:migrate
 ```
 
@@ -246,13 +246,13 @@ For instance to scaffold a `Project` model with a `logo` image upload.
 Use `image` as a field type for super scaffolding:
 
 ```
-bin/super-scaffold crud Project Team name:text_field logo:image
+rails generate super_scaffold Project Team name:text_field logo:image
 rake db:migrate
 ```
 
 Under the hood, Bullet Train will generate your model with the following command:
 ```
-bin/super-scaffold crud Project Team name:text_field
+rails generate super_scaffold Project Team name:text_field
 rake db:migrate
 ```
 

--- a/bullet_train/docs/super-scaffolding.md
+++ b/bullet_train/docs/super-scaffolding.md
@@ -33,6 +33,16 @@ The Super Scaffolding shell script provides its own documentation. If you're cur
 rails generate super_scaffold
 ```
 
+## Available Scaffolding Types
+
+| `rails generate` Command | Scaffolding Type |
+|--------------------------|------------------|
+| `rails generate super_scaffold` | Basic CRUD scaffolder |
+| `rails generate super_scaffold:field` | Adds a field to an existing model |
+| `rails generate super_scaffold:incoming_webhook` | Scaffolds an incoming webhook |
+| `rails generate super_scaffold:join_model` | Scaffolds a join model (must have two existing models to join before scaffolding) |
+| `rails generate super_scaffold:oauth_provider` | Scaffolds logic to use OAuth2 with the provider of your choice |
+
 ## Examples
 
 ### 1. Basic CRUD Scaffolding

--- a/bullet_train/docs/super-scaffolding/delegated-types.md
+++ b/bullet_train/docs/super-scaffolding/delegated-types.md
@@ -39,7 +39,7 @@ Note that in this specific approach we don't need a `team:references` on `Messag
 ### 2. Super Scaffolding for `Entry`
 
 ```
-bin/super-scaffold crud Entry Team entryable_type:buttons --skip-migration-generation
+rails generate super_scaffold Entry Team entryable_type:buttons --skip-migration-generation
 ```
 
 We use `entryable_type:buttons` because we're going to allow people to choose which type of `Entry` they're creating with a list of buttons. This isn't the only option available to us, but it's the easiest to implement for now.

--- a/bullet_train/docs/super-scaffolding/options.md
+++ b/bullet_train/docs/super-scaffolding/options.md
@@ -2,7 +2,7 @@
 
 There are different flags you can pass to the Super Scaffolding command which gives you more flexibility over creating your model. Add the flag of your choice to **the end** of the command for the option to take effect.
 ```
-bin/super-scaffold crud Project Team description:text_field --sortable
+rails generate super_scaffold Project Team description:text_field --sortable
 ```
 
 Most of these include skipping particular functionalities, so take a look at what's available here and pass the flag that applies to your use-case.

--- a/bullet_train/docs/super-scaffolding/sortable.md
+++ b/bullet_train/docs/super-scaffolding/sortable.md
@@ -1,10 +1,10 @@
 # Super Scaffolding with the `--sortable` option
 
-When issuing a `bin/super-scaffold crud` command, you can pass the `--sortable` option like this:
+When issuing a `rails generate super_scaffold` command, you can pass the `--sortable` option like this:
 
 ```
 # E.g. Pages belong to a Site and are sortable via drag-and-drop:
-bin/super-scaffold crud Page Site,Team name:text_field path:text_area --sortable
+rails generate super_scaffold Page Site,Team name:text_field path:text_area --sortable
 ```
 
 The `--sortable` option:

--- a/bullet_train/docs/webhooks/incoming.md
+++ b/bullet_train/docs/webhooks/incoming.md
@@ -3,5 +3,5 @@
 Bullet Train makes it trivial to scaffold new endpoints where external systems can send you webhooks and they can be processed asyncronously in a background job. For more information, run:
 
 ```
-bin/super-scaffold incoming-webhooks
+rails generate super_scaffold:incoming_webhooks
 ```


### PR DESCRIPTION
Takes care of the documentation task in #662.

I decided to leave the usage text in the old scaffolders as-is because I figured we could just delete it altogether when we get rid of `bin/super-scaffold` (I added a deprecation warning in https://github.com/bullet-train-co/bullet_train/pull/1203).