### PR TITLE
[CI] Run starter repo tests in GitHub Actions

### DIFF
--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -46,7 +46,7 @@ jobs:
       BUNDLE_JOBS: 2
       BUNDLE_RETRY: 3
     steps:
-      - name: Checkout This Repo
+      - name: Checkout Core Repo
         uses: actions/checkout@v4
         with:
           path: tmp/core

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -78,25 +78,21 @@ jobs:
 
       - name: 'Setup Super Scaffolding System Test'
         run: bundle exec test/bin/setup-super-scaffolding-system-test
+        working-directory: tmp/starter
         env:
           CIRCLE_NODE_INDEX: ${{ strategy.job-index }}
-        with:
-          working-directory: tmp/starter
 
       - name: 'Run Super Scaffolding Test'
         run: bundle exec rails test test/system/super_scaffolding_test.rb
-        with:
-          working-directory: tmp/starter
+        working-directory: tmp/starter
 
       - name: 'Run Super Scaffolding Partial Test'
         run: bundle exec rails test test/system/super_scaffolding_partial_test.rb
-        with:
-          working-directory: tmp/starter
+        working-directory: tmp/starter
 
       - name: 'Run Super Scaffolding Incoming Webhooks Test'
         run: bundle exec rails test test/controllers/webhooks/incoming/some_provider_webhooks_controller_test.rb
-        with:
-          working-directory: tmp/starter
+        working-directory: tmp/starter
 
       - name: Test Summary
         uses: test-summary/action@v2

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -1,0 +1,105 @@
+# This workflow will run a few super scaffolding commands and then run tests against the generated code.
+#
+# This workflow is pimarily meant to be called by other workflows, but it can be run manually.
+name: 🏗️ ~ Run super scaffolding tests
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: "🏗️"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # For super scaffolding tests we need to have exactly 7 runners.
+        ci_runners: [TestSite, Project, 'Project::Step', Insight, 'Personality::Disposition', 'Personality::Observation', TestFile]
+    services:
+      postgres:
+        image: postgres:11-alpine
+        ports:
+          - "5432:5432"
+        env:
+          POSTGRES_DB: rails_test
+          POSTGRES_USER: rails
+          POSTGRES_PASSWORD: password
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis
+        ports:
+          - "6379:6379"
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
+      BUNDLE_JOBS: 2
+      BUNDLE_RETRY: 3
+    steps:
+      - name: Checkout This Repo
+        uses: actions/checkout@v4
+        with:
+          path: tmp/core
+
+      - name: Checkout Starter Repo
+        uses: bullet-train-co/checkout-repo-with-matching-branch@v1
+        with:
+          target_dir: tmp/starter
+          repository: bullet-train-co/bullet_train
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          working-directory: tmp/starter
+          bundler-cache: true
+
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: tmp/starter/.nvmrc
+          cache: 'yarn'
+          cache-dependency-path: tmp/starter/yarn.lock
+
+      - name: Link Core Repo
+        uses: bullet-train-co/link-core-gems@v1
+        with:
+          application_dir: tmp/starter
+          core_dir: tmp/core
+
+      - name: 'Setup Super Scaffolding System Test'
+        run: bundle exec test/bin/setup-super-scaffolding-system-test
+        env:
+          CIRCLE_NODE_INDEX: ${{ strategy.job-index }}
+        with:
+          working-directory: tmp/starter
+
+      - name: 'Run Super Scaffolding Test'
+        run: bundle exec rails test test/system/super_scaffolding_test.rb
+        with:
+          working-directory: tmp/starter
+
+      - name: 'Run Super Scaffolding Partial Test'
+        run: bundle exec rails test test/system/super_scaffolding_partial_test.rb
+        with:
+          working-directory: tmp/starter
+
+      - name: 'Run Super Scaffolding Incoming Webhooks Test'
+        run: bundle exec rails test test/controllers/webhooks/incoming/some_provider_webhooks_controller_test.rb
+        with:
+          working-directory: tmp/starter
+
+      - name: Test Summary
+        uses: test-summary/action@v2
+        with:
+          paths: "tmp/starter/test/reports/**/TEST-*.xml"
+        if: always()

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -76,6 +76,15 @@ jobs:
           application_dir: tmp/starter
           core_dir: tmp/core
 
+      # TODO: This might be a bad idea. Maybe we should just have spring in the Gemfile all the time.
+      - name: Allow adding of spring
+        run: bundle config unset deployment
+        working-directory: tmp/starter
+
+      - name: Add spring
+        run: bundle add spring
+        working-directory: tmp/starter
+
       - name: 'Setup Super Scaffolding System Test'
         run: bundle exec test/bin/setup-super-scaffolding-system-test
         working-directory: tmp/starter

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -92,15 +92,7 @@ jobs:
           CIRCLE_NODE_INDEX: ${{ strategy.job-index }}
 
       - name: 'Run Super Scaffolding Test'
-        run: bundle exec rails test test/system/super_scaffolding_test.rb
-        working-directory: tmp/starter
-
-      - name: 'Run Super Scaffolding Partial Test'
-        run: bundle exec rails test test/system/super_scaffolding_partial_test.rb
-        working-directory: tmp/starter
-
-      - name: 'Run Super Scaffolding Incoming Webhooks Test'
-        run: bundle exec rails test test/controllers/webhooks/incoming/some_provider_webhooks_controller_test.rb
+        run: bundle exec rails test test/system/super_scaffolding_test.rb test/system/super_scaffolding_partial_test.rb test/controllers/webhooks/incoming/some_provider_webhooks_controller_test.rb
         working-directory: tmp/starter
 
       - name: Test Summary

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -62,7 +62,8 @@ jobs:
         working-directory: ${{ matrix.gem }}
 
     steps:
-      - uses: "actions/checkout@v4"
+      - name: Checkout Core Repo
+        uses: "actions/checkout@v4"
 
       - uses: "ruby/setup-ruby@v1"
         with:

--- a/.github/workflows/_starter_repo_tests.yml
+++ b/.github/workflows/_starter_repo_tests.yml
@@ -7,90 +7,98 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  starter_repo:
     runs-on: ubuntu-latest
+    name: Bullet Train Starter Repo Minitest
     strategy:
       fail-fast: false
       matrix:
-        ruby-version:
-          - "3.2"
-        gem:
-          - "bullet_train"
-          - "bullet_train-api"
-          - "bullet_train-fields"
-          - "bullet_train-has_uuid"
-          - "bullet_train-incoming_webhooks"
-          - "bullet_train-integrations"
-          - "bullet_train-integrations-stripe"
-          - "bullet_train-obfuscates_id"
-          - "bullet_train-outgoing_webhooks"
-          - "bullet_train-roles"
-          - "bullet_train-scope_questions"
-          - "bullet_train-scope_validator"
-          - "bullet_train-sortable"
-          - "bullet_train-super_load_and_authorize_resource"
-          - "bullet_train-super_scaffolding"
-          - "bullet_train-themes"
-          - "bullet_train-themes-light"
-          - "bullet_train-themes-tailwind_css"
-
-    name: ${{ format('{0}:{1}', matrix.gem, matrix.ruby-version) }}
-
+        # Set identifiers for parallel jobs. These can be anything.
+        # For instance if you want a Three Amigos themed pipeline you could use:
+        # ci_node_index: [Dusty, Ned, Lucky]
+        ci_node_index: [1,2,3,4]
     services:
       postgres:
-        image: postgres
+        image: postgres:11-alpine
+        ports:
+          - "5432:5432"
         env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: rails_test
+          POSTGRES_USER: rails
+          POSTGRES_PASSWORD: password
+        # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
-          --health-interval 2s
-          --health-timeout 2s
+          --health-interval 10s
+          --health-timeout 5s
           --health-retries 5
+      redis:
+        image: redis
         ports:
-          - 5432:5432
-
+          - "6379:6379"
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     env:
-      PGHOST: localhost
-      PGUSER: postgres
-      PGPASSWORD: postgres
       RAILS_ENV: test
-      CI: 1
-
-    defaults:
-      run:
-        working-directory: ${{ matrix.gem }}
-
+      DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
+      BUNDLE_JOBS: 2
+      BUNDLE_RETRY: 3
     steps:
-      - uses: "actions/checkout@v4"
+      - name: Checkout This Repo
+        uses: actions/checkout@v4
 
-      - uses: "ruby/setup-ruby@v1"
+      - name: Checkout Starter Repo
+        uses: bullet-train-co/checkout-repo-with-matching-branch@v1
         with:
-          rubygems: latest
-          bundler: latest
+          target_dir: tmp/starter
+          repository: bullet-train-co/bullet_train
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          working-directory: tmp/starter
           bundler-cache: true
-          ruby-version: ${{ matrix.ruby-version }}
-          working-directory: ${{ matrix.gem }} # setup-ruby does't pick up the job default.
 
-      # TODO: Sometimes the step above complains about the lockfile being fronzen.
-      # When that happens you can get things moving again by chaning the bundler-cache
-      # option above to false. Then _must_ uncomment the line for `bundle install` and
-      # you can also uncomment the following lines to find out what changed unexpectedly.
-      # I _think_ I've got things set up so that this shouldn't be an issue any more, but
-      # I'm leaving this stuff here in case it comes in handy in the near future.
-      #
-      #- run: bundle install
-      #- run: cat Gemfile.lock
-      #- run: git diff Gemfile.lock
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: tmp/starter/.nvmrc
+          cache: 'yarn'
+          cache-dependency-path: tmp/starter/yarn.lock
 
-      - run: bin/rails db:setup
-        if: ${{ hashFiles(format('{0}/test/dummy/db/schema.rb', matrix.gem)) != '' }}
+      - name: Link Core Repo
+        uses: bullet-train-co/link-core-gems@v1
+        with:
+          application_dir: tmp/starter
+          core_dir: .
+
+      - name: Set up database schema
+        run: bin/rails db:schema:load
+        working-directory: ./tmp/starter
 
       - name: Run Tests
-        run: bin/rails test
+        id: run-tests
+        env:
+          # Specifies how many jobs you would like to run in parallel,
+          # used for partitioning
+          CI_NODE_TOTAL: ${{ strategy.job-total }}
+          # Use the index from matrix as an environment variable
+          CI_NODE_INDEX: ${{ strategy.job-index }}
+        continue-on-error: false
+        run : bin/parallel-ci
+        working-directory: ./tmp/starter
 
       - name: Test Summary
         uses: test-summary/action@v2
         with:
-          paths: ${{ format('{0}/test/reports/**/TEST-*.xml', matrix.gem) }}
+          paths: "tmp/starter/test/reports/**/TEST-*.xml"
+          #output: test-summary.md
         if: always()
+
+
+
+

--- a/.github/workflows/_starter_repo_tests.yml
+++ b/.github/workflows/_starter_repo_tests.yml
@@ -74,7 +74,7 @@ jobs:
         uses: bullet-train-co/link-core-gems@v1
         with:
           application_dir: tmp/starter
-          core_dir: .
+          core_dir: ../..
 
       - name: Set up database schema
         run: bin/rails db:schema:load

--- a/.github/workflows/_starter_repo_tests.yml
+++ b/.github/workflows/_starter_repo_tests.yml
@@ -74,7 +74,7 @@ jobs:
         uses: bullet-train-co/link-core-gems@v1
         with:
           application_dir: tmp/starter
-          core_dir: ../..
+          core_dir: ..
 
       - name: Set up database schema
         run: bin/rails db:schema:load

--- a/.github/workflows/_starter_repo_tests.yml
+++ b/.github/workflows/_starter_repo_tests.yml
@@ -48,7 +48,7 @@ jobs:
       BUNDLE_JOBS: 2
       BUNDLE_RETRY: 3
     steps:
-      - name: Checkout This Repo
+      - name: Checkout Core Repo
         uses: actions/checkout@v4
         with:
           path: tmp/core

--- a/.github/workflows/_starter_repo_tests.yml
+++ b/.github/workflows/_starter_repo_tests.yml
@@ -50,6 +50,8 @@ jobs:
     steps:
       - name: Checkout This Repo
         uses: actions/checkout@v4
+        with:
+          path: tmp/core
 
       - name: Checkout Starter Repo
         uses: bullet-train-co/checkout-repo-with-matching-branch@v1
@@ -74,7 +76,7 @@ jobs:
         uses: bullet-train-co/link-core-gems@v1
         with:
           application_dir: tmp/starter
-          core_dir: ./
+          core_dir: tmp/core
 
       - name: Set up database schema
         run: bin/rails db:schema:load

--- a/.github/workflows/_starter_repo_tests.yml
+++ b/.github/workflows/_starter_repo_tests.yml
@@ -1,0 +1,96 @@
+# This workflow runs the main test suite.
+#
+# This workflow is pimarily meant to be called by other workflows, but it can be run manually.
+name: "🧪 ~ Run gem tests"
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version:
+          - "3.2"
+        gem:
+          - "bullet_train"
+          - "bullet_train-api"
+          - "bullet_train-fields"
+          - "bullet_train-has_uuid"
+          - "bullet_train-incoming_webhooks"
+          - "bullet_train-integrations"
+          - "bullet_train-integrations-stripe"
+          - "bullet_train-obfuscates_id"
+          - "bullet_train-outgoing_webhooks"
+          - "bullet_train-roles"
+          - "bullet_train-scope_questions"
+          - "bullet_train-scope_validator"
+          - "bullet_train-sortable"
+          - "bullet_train-super_load_and_authorize_resource"
+          - "bullet_train-super_scaffolding"
+          - "bullet_train-themes"
+          - "bullet_train-themes-light"
+          - "bullet_train-themes-tailwind_css"
+
+    name: ${{ format('{0}:{1}', matrix.gem, matrix.ruby-version) }}
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 2s
+          --health-timeout 2s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    env:
+      PGHOST: localhost
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      RAILS_ENV: test
+      CI: 1
+
+    defaults:
+      run:
+        working-directory: ${{ matrix.gem }}
+
+    steps:
+      - uses: "actions/checkout@v4"
+
+      - uses: "ruby/setup-ruby@v1"
+        with:
+          rubygems: latest
+          bundler: latest
+          bundler-cache: true
+          ruby-version: ${{ matrix.ruby-version }}
+          working-directory: ${{ matrix.gem }} # setup-ruby does't pick up the job default.
+
+      # TODO: Sometimes the step above complains about the lockfile being fronzen.
+      # When that happens you can get things moving again by chaning the bundler-cache
+      # option above to false. Then _must_ uncomment the line for `bundle install` and
+      # you can also uncomment the following lines to find out what changed unexpectedly.
+      # I _think_ I've got things set up so that this shouldn't be an issue any more, but
+      # I'm leaving this stuff here in case it comes in handy in the near future.
+      #
+      #- run: bundle install
+      #- run: cat Gemfile.lock
+      #- run: git diff Gemfile.lock
+
+      - run: bin/rails db:setup
+        if: ${{ hashFiles(format('{0}/test/dummy/db/schema.rb', matrix.gem)) != '' }}
+
+      - name: Run Tests
+        run: bin/rails test
+
+      - name: Test Summary
+        uses: test-summary/action@v2
+        with:
+          paths: ${{ format('{0}/test/reports/**/TEST-*.xml', matrix.gem) }}
+        if: always()

--- a/.github/workflows/_starter_repo_tests.yml
+++ b/.github/workflows/_starter_repo_tests.yml
@@ -74,7 +74,7 @@ jobs:
         uses: bullet-train-co/link-core-gems@v1
         with:
           application_dir: tmp/starter
-          core_dir: ..
+          core_dir: ./
 
       - name: Set up database schema
         run: bin/rails db:schema:load

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ jobs:
     name: 🧪 Starter Repo Tests
     uses: ./.github/workflows/_starter_repo_tests.yml
     secrets: inherit
+  super_scaffolding:
+    name: 🧪 Starter Repo Super Scaffolding Tests
+    uses: ./.github/workflows/_run_super_scaffolding_tests.yml
+    secrets: inherit
   gem_tests:
     name: 🧪 Gem Tests
     uses: ./.github/workflows/_run_tests.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
     branches: [ "main" ]
 
 jobs:
+  minitest:
+    name: 🧪 Starter Repo Tests
+    uses: ./.github/workflows/_starter_repo_tests.yml
+    secrets: inherit
   gem_tests:
     name: 🧪 Gem Tests
     uses: ./.github/workflows/_run_tests.yml


### PR DESCRIPTION
This makes it so that we run the test suites from the starter repo in GitHub Actions.

CircleCI is giving us trouble (again!), so it may be time to ditch it for this repo.

![CleanShot 2023-11-28 at 11 22 47](https://github.com/bullet-train-co/bullet_train-core/assets/58702/563332ed-ce35-4c53-aff7-303f7925c1f5)
