### PR TITLE
[CI] Handle HIDE_THINGS differently in tests

### DIFF
--- a/bullet_train/app/models/concerns/teams/base.rb
+++ b/bullet_train/app/models/concerns/teams/base.rb
@@ -3,9 +3,9 @@ module Teams::Base
 
   included do
     # super scaffolding
-    #unless scaffolding_things_disabled?
-      has_many :scaffolding_absolutely_abstract_creative_concepts, class_name: "Scaffolding::AbsolutelyAbstract::CreativeConcept", dependent: :destroy, enable_cable_ready_updates: true
-    #end
+    # unless scaffolding_things_disabled?
+    has_many :scaffolding_absolutely_abstract_creative_concepts, class_name: "Scaffolding::AbsolutelyAbstract::CreativeConcept", dependent: :destroy, enable_cable_ready_updates: true
+    # end
 
     # added_by_id is a foreign_key to other Memberships on the same team,
     # so we nullify this to remove the constraint to delete the team.

--- a/bullet_train/app/models/concerns/teams/base.rb
+++ b/bullet_train/app/models/concerns/teams/base.rb
@@ -3,9 +3,9 @@ module Teams::Base
 
   included do
     # super scaffolding
-    unless scaffolding_things_disabled?
+    #unless scaffolding_things_disabled?
       has_many :scaffolding_absolutely_abstract_creative_concepts, class_name: "Scaffolding::AbsolutelyAbstract::CreativeConcept", dependent: :destroy, enable_cable_ready_updates: true
-    end
+    #end
 
     # added_by_id is a foreign_key to other Memberships on the same team,
     # so we nullify this to remove the constraint to delete the team.

--- a/bullet_train/app/models/concerns/teams/base.rb
+++ b/bullet_train/app/models/concerns/teams/base.rb
@@ -3,9 +3,7 @@ module Teams::Base
 
   included do
     # super scaffolding
-    # unless scaffolding_things_disabled?
     has_many :scaffolding_absolutely_abstract_creative_concepts, class_name: "Scaffolding::AbsolutelyAbstract::CreativeConcept", dependent: :destroy, enable_cable_ready_updates: true
-    # end
 
     # added_by_id is a foreign_key to other Memberships on the same team,
     # so we nullify this to remove the constraint to delete the team.


### PR DESCRIPTION
Joint PR: https://github.com/bullet-train-co/bullet_train/pull/1207

Since models are evaluated once at the beginning of a test run this conditional was making it impossible to toggle the value for `HIDE_THINGS` during testing. I think that removing the conditional should be safe since the `Scaffolding::AbsolutelyAbstract::CreativeConcept` model and table are always present.