### PR TITLE
Don't use `prepend_before_action` when loading/authorizing resources

### DIFF
--- a/bullet_train-super_load_and_authorize_resource/app/controllers/concerns/bullet_train/loads_and_authorizes_resource.rb
+++ b/bullet_train-super_load_and_authorize_resource/app/controllers/concerns/bullet_train/loads_and_authorizes_resource.rb
@@ -210,7 +210,6 @@ module BulletTrain::LoadsAndAuthorizesResource
 
       # 6. finally, load the team and parent resource if we can.
       before_action :load_team
-
     end
   end
 


### PR DESCRIPTION
Using `prepend_before_action` causes problems because developers lose the ability to control the order in which callbacks happen.

Maybe fixes #531? (Hard to be sure since I don't know how to reproduce whatever problem people are running into.)