### PR TITLE
Refactor loads and authorize resource part 3

### DIFF
--- a/bullet_train-super_load_and_authorize_resource/app/controllers/concerns/bullet_train/loads_and_authorizes_resource.rb
+++ b/bullet_train-super_load_and_authorize_resource/app/controllers/concerns/bullet_train/loads_and_authorizes_resource.rb
@@ -63,7 +63,6 @@ module BulletTrain::LoadsAndAuthorizesResource
 
       through_as_symbols = Array(through)
 
-      through = []
       through_class_names = []
 
       through_as_symbols.each do |through_as_symbol|
@@ -76,7 +75,6 @@ module BulletTrain::LoadsAndAuthorizesResource
         through_class_name = association.klass.name
 
         begin
-          through << through_class_name.constantize
           through_class_names << through_class_name
         rescue NameError
           raise "Your 'account_load_and_authorize_resource' is broken. We tried to load `#{through_class_name}}` (the class name defined for the `#{through_as_symbol}` association), but couldn't find it."

--- a/bullet_train-super_load_and_authorize_resource/app/controllers/concerns/bullet_train/loads_and_authorizes_resource.rb
+++ b/bullet_train-super_load_and_authorize_resource/app/controllers/concerns/bullet_train/loads_and_authorizes_resource.rb
@@ -72,13 +72,7 @@ module BulletTrain::LoadsAndAuthorizesResource
           raise "Your 'account_load_and_authorize_resource' is broken. Tried to reflect on the `#{through_as_symbol}` association of #{model_class_name}, but didn't find one."
         end
 
-        through_class_name = association.klass.name
-
-        begin
-          through_class_names << through_class_name
-        rescue NameError
-          raise "Your 'account_load_and_authorize_resource' is broken. We tried to load `#{through_class_name}}` (the class name defined for the `#{through_as_symbol}` association), but couldn't find it."
-        end
+        through_class_names << association.klass.name
       end
 
       if through_as_symbols.count > 1 && !options[:polymorphic]

--- a/bullet_train-super_load_and_authorize_resource/app/controllers/concerns/bullet_train/loads_and_authorizes_resource.rb
+++ b/bullet_train-super_load_and_authorize_resource/app/controllers/concerns/bullet_train/loads_and_authorizes_resource.rb
@@ -62,17 +62,14 @@ module BulletTrain::LoadsAndAuthorizesResource
       end
 
       through_as_symbols = Array(through)
-
-      through_class_names = []
-
-      through_as_symbols.each do |through_as_symbol|
+      through_class_names = through_as_symbols.map do |through_as_symbol|
         # reflect on the belongs_to association of the child model to figure out the class names of the parents.
         association = model_class_name.constantize.reflect_on_association(through_as_symbol)
         unless association
           raise "Your 'account_load_and_authorize_resource' is broken. Tried to reflect on the `#{through_as_symbol}` association of #{model_class_name}, but didn't find one."
         end
 
-        through_class_names << association.klass.name
+        association.klass.name
       end
 
       if through_as_symbols.count > 1 && !options[:polymorphic]


### PR DESCRIPTION
Simplifies the process of getting the class name(s) of the `through` association(s).

From #525