### PR TITLE
Fix: Customise existing paths in `openapi.yaml`

### DIFF
--- a/bullet_train-api/app/helpers/api/open_api_helper.rb
+++ b/bullet_train-api/app/helpers/api/open_api_helper.rb
@@ -39,6 +39,8 @@ module Api
 
       if custom_output
         merge = deep_merge(YAML.load(output), YAML.load(custom_output)).to_yaml.html_safe
+        # YAML.load escapes emojis https://github.com/ruby/psych/issues/371
+        # Next line returns emojis back and removes yaml garbage
         output = merge.gsub("---", "").gsub(/\\u[\da-f]{8}/i) { |m| [m[-8..].to_i(16)].pack("U") }
       end
 


### PR DESCRIPTION
Right now whatever users write in their custom `_paths.yaml.erb` files is added at the end of an appropriate
model's `paths:` section. This leads to duplications if they want to customise the existing endpoint. Those duplications are perceived as an error in Redocly parser.

This PR makes contents of those custom _paths files merge with the main generated yaml. This makes it possible not only to add or override the whole endpoint, but also to add or customise only some particular attributes of the schema.

For example, to add new query property to a route users can simply write:
```yaml
"/contacts":
  get:
    parameters:
      - name: filter
        in: query
        required: false
        style: deepObject
        explode: true
        schema:
          type: object
          properties:
            email_address:
              type: array
              items:
                type: string
            id:
              type: array
              items:
                type: string
        example:
          email_address: example@example.com,example2@example.com
        description: Filter used on Contact object to narrow down the results
```

This will merge `filter` with the existing standard query properties such as `after` etc.