### PR TITLE
`bin/resolve` for JavaScript and CSS files

### DIFF
--- a/bullet_train/lib/bullet_train/resolver.rb
+++ b/bullet_train/lib/bullet_train/resolver.rb
@@ -262,23 +262,13 @@ module BulletTrain
 
       # If the file name doesn't include the theme name (i.e. - light.tailwind.css),
       # we append the theme name to the path to match something like "app/assets/javascript/foo/".
-      append_theme_name = !file_name.match?("#{current_theme}.")
-      asset_globs = ["js", "css"].map do |extention|
-        path = "app/assets/"
-        if append_theme_name
-          path += case extention
-          when "js"
-            "javascript/"
-          when "css"
-            "stylesheets/"
-          end
-          path += "#{current_theme}/"
-        end
-        path + "**/*.#{extention}"
-      end
-
-      # Ensure we include JavaScript files that exist under the app's root directory.
-      asset_globs << "*.js"
+      asset_globs = [
+        "*.js", # Include JavaScript files under the app's root directory.
+        "app/assets/javascript/**/*.#{current_theme}.js",
+        "app/assets/javascript/#{current_theme}/**/*.js",
+        "app/assets/stylesheets/**/*.#{current_theme}.css",
+        "app/assets/stylesheets/#{current_theme}/**/*.css",
+      ]
 
       # Search for the file.
       files = Dir.glob(asset_globs).reject { |file| file.match?("/builds/") }

--- a/bullet_train/lib/bullet_train/resolver.rb
+++ b/bullet_train/lib/bullet_train/resolver.rb
@@ -281,14 +281,8 @@ module BulletTrain
         return nil unless gem_path
 
         # At this point we can be more generic since we're inside the gem.
-        asset_globs = ["**/*.js", "**/*.css"]
-
-        # Read the globs from the home directory.
-        Dir.chdir
-        asset_globs.map! { |glob| "#{gem_path}/#{glob}".gsub("/#{Dir.home}", "") }
-        files = Dir.glob(asset_globs)
-
-        absolute_file_path = files.find { |file| file.match?(/#{file_name}$/) }
+        files = Dir.glob(["#{gem_path}/**/*.js", "#{gem_path}/**/*.css"])
+        absolute_file_path = files.find { |file| file.end_with?(file_name) }
       end
 
       absolute_file_path

--- a/bullet_train/lib/bullet_train/resolver.rb
+++ b/bullet_train/lib/bullet_train/resolver.rb
@@ -251,12 +251,12 @@ module BulletTrain
       nil
     end
 
-    # In this search, we prioritize files in local themes,
+    # In this search, we prioritize files in local themes
     # and then look in theme gems if nothing is found.
     def js_or_stylesheet_path
       file_name = @needle.split("/").last
 
-      # Prioritize the current theme, and fall back to
+      # Prioritize the current theme and fall back to
       # the default `light` theme if nothing is found locally.
       puts "Searching under current theme: #{current_theme.blue}"
 
@@ -268,14 +268,13 @@ module BulletTrain
         "app/assets/stylesheets/#{current_theme}/**/*.css",
       ]
 
-      # Search for the file.
       files = Dir.glob(asset_globs).reject { |file| file.match?("/builds/") }
       absolute_file_path = files.find { |file| file.match?(/#{file_name}$/) }
 
       if absolute_file_path
         absolute_file_path
       else
-        # Search for the file in its respective gem. Fall back to `light` theme if no gem is available.
+        # Search for the file in its respective gem. Fall back to the `light` theme if no gem is available.
         gem_path = [`bundle show bullet_train-themes-#{current_theme}`, `bundle show bullet_train-themes-light`].map(&:chomp).find(&:present?)
         return nil unless gem_path
 

--- a/bullet_train/lib/bullet_train/resolver.rb
+++ b/bullet_train/lib/bullet_train/resolver.rb
@@ -269,7 +269,7 @@ module BulletTrain
       ]
 
       files = Dir.glob(asset_globs).reject { |file| file.match?("/builds/") }
-      absolute_file_path = files.find { |file| file.match?(/#{file_name}$/) }
+      absolute_file_path = files.find { |file| file.end_with?(file_name) }
 
       if absolute_file_path
         absolute_file_path

--- a/bullet_train/lib/bullet_train/resolver.rb
+++ b/bullet_train/lib/bullet_train/resolver.rb
@@ -275,14 +275,10 @@ module BulletTrain
       absolute_file_path = files.find { |file| file.match?(/#{file_name}$/) }
 
       if absolute_file_path.nil? # then search for it in its respective gem.
-        gem_path = `bundle show bullet_train-themes-#{current_theme}`.chomp
-
         # Fall back to `light` theme if no gem is available.
         # (The developer might just be trying to find stylesheets that exist in `light`.)
-        if gem_path.empty?
-          gem_path = `bundle show bullet_train-themes-light`.chomp
-          return nil if gem_path.empty?
-        end
+        gem_path = [`bundle show bullet_train-themes-#{current_theme}`, `bundle show bullet_train-themes-light`].map(&:chomp).find(&:present?)
+        return nil unless gem_path
 
         # At this point we can be more generic since we're inside the gem.
         asset_globs = ["**/*.js", "**/*.css"]

--- a/bullet_train/lib/bullet_train/resolver.rb
+++ b/bullet_train/lib/bullet_train/resolver.rb
@@ -260,8 +260,6 @@ module BulletTrain
       # the default `light` theme if nothing is found locally.
       puts "Searching under current theme: #{current_theme.blue}"
 
-      # If the file name doesn't include the theme name (i.e. - light.tailwind.css),
-      # we append the theme name to the path to match something like "app/assets/javascript/foo/".
       asset_globs = [
         "*.js", # Include JavaScript files under the app's root directory.
         "app/assets/javascript/**/*.#{current_theme}.js",
@@ -274,18 +272,17 @@ module BulletTrain
       files = Dir.glob(asset_globs).reject { |file| file.match?("/builds/") }
       absolute_file_path = files.find { |file| file.match?(/#{file_name}$/) }
 
-      if absolute_file_path.nil? # then search for it in its respective gem.
-        # Fall back to `light` theme if no gem is available.
-        # (The developer might just be trying to find stylesheets that exist in `light`.)
+      if absolute_file_path
+        absolute_file_path
+      else
+        # Search for the file in its respective gem. Fall back to `light` theme if no gem is available.
         gem_path = [`bundle show bullet_train-themes-#{current_theme}`, `bundle show bullet_train-themes-light`].map(&:chomp).find(&:present?)
         return nil unless gem_path
 
         # At this point we can be more generic since we're inside the gem.
         files = Dir.glob(["#{gem_path}/**/*.js", "#{gem_path}/**/*.css"])
-        absolute_file_path = files.find { |file| file.end_with?(file_name) }
+        files.find { |file| file.end_with?(file_name) }
       end
-
-      absolute_file_path
     end
 
     def ejected_theme?

--- a/bullet_train/lib/bullet_train/resolver.rb
+++ b/bullet_train/lib/bullet_train/resolver.rb
@@ -274,7 +274,7 @@ module BulletTrain
           end
           path += "#{current_theme}/"
         end
-        path += "**/*.#{extention}"
+        path + "**/*.#{extention}"
       end
 
       # Ensure we include JavaScript files that exist under the app's root directory.

--- a/bullet_train/lib/bullet_train/resolver.rb
+++ b/bullet_train/lib/bullet_train/resolver.rb
@@ -281,8 +281,8 @@ module BulletTrain
       asset_globs << "*.js"
 
       # Search for the file.
-      files = Dir.glob(asset_globs).reject{|file| file.match?("/builds/")}
-      absolute_file_path = files.find{|file| file.match?(/#{file_name}$/)}
+      files = Dir.glob(asset_globs).reject { |file| file.match?("/builds/") }
+      absolute_file_path = files.find { |file| file.match?(/#{file_name}$/) }
 
       if absolute_file_path.nil? # then search for it in its respective gem.
         gem_path = `bundle show bullet_train-themes-#{current_theme}`.chomp
@@ -299,10 +299,10 @@ module BulletTrain
 
         # Read the globs from the home directory.
         Dir.chdir
-        asset_globs.map! {|glob| "#{gem_path}/#{glob}".gsub("/#{Dir.home}", "")}
+        asset_globs.map! { |glob| "#{gem_path}/#{glob}".gsub("/#{Dir.home}", "") }
         files = Dir.glob(asset_globs)
 
-        absolute_file_path = files.find{|file| file.match?(/#{file_name}$/)}
+        absolute_file_path = files.find { |file| file.match?(/#{file_name}$/) }
       end
 
       absolute_file_path
@@ -314,8 +314,8 @@ module BulletTrain
 
     def current_theme
       msmn = Masamune::AbstractSyntaxTree.new(File.read("#{Rails.root}/app/helpers/application_helper.rb"))
-      current_theme_def = msmn.method_definitions.find{|node| node.token_value == "current_theme"}
-      msmn.symbols.find{|sym| sym.line_number == current_theme_def.line_number + 1}.token_value
+      current_theme_def = msmn.method_definitions.find { |node| node.token_value == "current_theme" }
+      msmn.symbols.find { |sym| sym.line_number == current_theme_def.line_number + 1 }.token_value
     end
   end
 end

--- a/bullet_train/lib/bullet_train/resolver.rb
+++ b/bullet_train/lib/bullet_train/resolver.rb
@@ -313,7 +313,7 @@ module BulletTrain
     end
 
     def current_theme
-      msmn = Masamune::AbstractSyntaxTree.new(File.read("#{Rails.root}/app/helpers/application_helper.rb"))
+      msmn = Masamune::AbstractSyntaxTree.new(Rails.root.join("app/helpers/application_helper.rb").read)
       current_theme_def = msmn.method_definitions.find { |node| node.token_value == "current_theme" }
       msmn.symbols.find { |sym| sym.line_number == current_theme_def.line_number + 1 }.token_value
     end


### PR DESCRIPTION
Closes #727.

This one is a little tricky because these assets can exist in ejected themes, or in `bullet_train-themes-#{theme_name}` gems. I set things up so all the developer has to do is pass the file name. If we're okay with this, I can add some documentation and mark the PR as ready for review.

<img width="1297" alt="resolve js and css" src="https://github.com/bullet-train-co/bullet_train-core/assets/10546292/c9249505-323c-4867-83dc-f2609be52d31">
