### PR TITLE
Remove CommonMarker 0.x fallback

### DIFF
--- a/bullet_train-api/Gemfile.lock
+++ b/bullet_train-api/Gemfile.lock
@@ -37,7 +37,7 @@ PATH
       cable_ready (~> 5.0.0)
       cancancan
       colorizer
-      commonmarker
+      commonmarker (>= 1.0.0)
       devise
       devise-pwned_password
       extended_email_reply_parser
@@ -178,7 +178,8 @@ GEM
       aws_cf_signer
       rest-client (>= 2.0.0)
     colorizer (0.0.2)
-    commonmarker (0.23.10)
+    commonmarker (1.0.4-arm64-darwin)
+    commonmarker (1.0.4-x86_64-linux)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crass (1.0.6)

--- a/bullet_train-fields/Gemfile.lock
+++ b/bullet_train-fields/Gemfile.lock
@@ -36,7 +36,7 @@ PATH
       cable_ready (~> 5.0.0)
       cancancan
       colorizer
-      commonmarker
+      commonmarker (>= 1.0.0)
       devise
       devise-pwned_password
       extended_email_reply_parser

--- a/bullet_train-incoming_webhooks/Gemfile.lock
+++ b/bullet_train-incoming_webhooks/Gemfile.lock
@@ -52,7 +52,7 @@ PATH
       cable_ready (~> 5.0.0)
       cancancan
       colorizer
-      commonmarker
+      commonmarker (>= 1.0.0)
       devise
       devise-pwned_password
       extended_email_reply_parser
@@ -196,7 +196,8 @@ GEM
       aws_cf_signer
       rest-client (>= 2.0.0)
     colorizer (0.0.2)
-    commonmarker (0.23.10)
+    commonmarker (1.0.4-arm64-darwin)
+    commonmarker (1.0.4-x86_64-linux)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crass (1.0.6)

--- a/bullet_train-integrations-stripe/Gemfile.lock
+++ b/bullet_train-integrations-stripe/Gemfile.lock
@@ -54,7 +54,7 @@ PATH
       cable_ready (~> 5.0.0)
       cancancan
       colorizer
-      commonmarker
+      commonmarker (>= 1.0.0)
       devise
       devise-pwned_password
       extended_email_reply_parser
@@ -202,7 +202,8 @@ GEM
       aws_cf_signer
       rest-client (>= 2.0.0)
     colorizer (0.0.2)
-    commonmarker (0.23.10)
+    commonmarker (1.0.4-arm64-darwin)
+    commonmarker (1.0.4-x86_64-linux)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crass (1.0.6)

--- a/bullet_train-outgoing_webhooks/Gemfile.lock
+++ b/bullet_train-outgoing_webhooks/Gemfile.lock
@@ -45,7 +45,7 @@ PATH
       cable_ready (~> 5.0.0)
       cancancan
       colorizer
-      commonmarker
+      commonmarker (>= 1.0.0)
       devise
       devise-pwned_password
       extended_email_reply_parser
@@ -181,7 +181,8 @@ GEM
       aws_cf_signer
       rest-client (>= 2.0.0)
     colorizer (0.0.2)
-    commonmarker (0.23.10)
+    commonmarker (1.0.4-arm64-darwin)
+    commonmarker (1.0.4-x86_64-linux)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crass (1.0.6)

--- a/bullet_train-sortable/Gemfile.lock
+++ b/bullet_train-sortable/Gemfile.lock
@@ -45,7 +45,7 @@ PATH
       cable_ready (~> 5.0.0)
       cancancan
       colorizer
-      commonmarker
+      commonmarker (>= 1.0.0)
       devise
       devise-pwned_password
       extended_email_reply_parser
@@ -190,7 +190,8 @@ GEM
       aws_cf_signer
       rest-client (>= 2.0.0)
     colorizer (0.0.2)
-    commonmarker (0.23.10)
+    commonmarker (1.0.4-arm64-darwin)
+    commonmarker (1.0.4-x86_64-linux)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crass (1.0.6)

--- a/bullet_train-super_scaffolding/Gemfile.lock
+++ b/bullet_train-super_scaffolding/Gemfile.lock
@@ -36,7 +36,7 @@ PATH
       cable_ready (~> 5.0.0)
       cancancan
       colorizer
-      commonmarker
+      commonmarker (>= 1.0.0)
       devise
       devise-pwned_password
       extended_email_reply_parser
@@ -174,7 +174,8 @@ GEM
       aws_cf_signer
       rest-client (>= 2.0.0)
     colorizer (0.0.2)
-    commonmarker (0.23.10)
+    commonmarker (1.0.4-arm64-darwin)
+    commonmarker (1.0.4-x86_64-linux)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crass (1.0.6)

--- a/bullet_train-themes-light/Gemfile.lock
+++ b/bullet_train-themes-light/Gemfile.lock
@@ -45,7 +45,7 @@ PATH
       cable_ready (~> 5.0.0)
       cancancan
       colorizer
-      commonmarker
+      commonmarker (>= 1.0.0)
       devise
       devise-pwned_password
       extended_email_reply_parser
@@ -196,7 +196,8 @@ GEM
       aws_cf_signer
       rest-client (>= 2.0.0)
     colorizer (0.0.2)
-    commonmarker (0.23.10)
+    commonmarker (1.0.4-arm64-darwin)
+    commonmarker (1.0.4-x86_64-linux)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crass (1.0.6)

--- a/bullet_train-themes-tailwind_css/Gemfile.lock
+++ b/bullet_train-themes-tailwind_css/Gemfile.lock
@@ -45,7 +45,7 @@ PATH
       cable_ready (~> 5.0.0)
       cancancan
       colorizer
-      commonmarker
+      commonmarker (>= 1.0.0)
       devise
       devise-pwned_password
       extended_email_reply_parser
@@ -192,7 +192,8 @@ GEM
       aws_cf_signer
       rest-client (>= 2.0.0)
     colorizer (0.0.2)
-    commonmarker (0.23.10)
+    commonmarker (1.0.4-arm64-darwin)
+    commonmarker (1.0.4-x86_64-linux)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crass (1.0.6)

--- a/bullet_train/Gemfile
+++ b/bullet_train/Gemfile
@@ -11,8 +11,6 @@ gem "sprockets-rails"
 # TODO Have to specify this dependency here until our changes are in the original package.
 gem "active_hash", github: "bullet-train-co/active_hash"
 
-gem "commonmarker", ">= 1.0.0.pre10"
-
 gem "bullet_train-api", path: "../bullet_train-api"
 gem "bullet_train-fields", path: "../bullet_train-fields"
 gem "bullet_train-roles", path: "../bullet_train-roles"

--- a/bullet_train/Gemfile.lock
+++ b/bullet_train/Gemfile.lock
@@ -93,7 +93,7 @@ PATH
       cable_ready (~> 5.0.0)
       cancancan
       colorizer
-      commonmarker
+      commonmarker (>= 1.0.0)
       devise
       devise-pwned_password
       extended_email_reply_parser
@@ -215,8 +215,10 @@ GEM
       rest-client (>= 2.0.0)
     coderay (1.1.3)
     colorizer (0.0.2)
-    commonmarker (1.0.0.pre10-arm64-darwin)
-    commonmarker (1.0.0.pre10-x86_64-linux)
+    commonmarker (1.0.4)
+      rb_sys (~> 0.9)
+    commonmarker (1.0.4-arm64-darwin)
+    commonmarker (1.0.4-x86_64-linux)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -398,6 +400,7 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
+    rb_sys (0.9.86)
     redis-client (0.17.0)
       connection_pool
     regexp_parser (2.6.1)
@@ -494,7 +497,6 @@ DEPENDENCIES
   bullet_train-super_scaffolding!
   bullet_train-themes!
   bullet_train-themes-light!
-  commonmarker (>= 1.0.0.pre10)
   minitest-reporters
   pry
   pry-stack_explorer

--- a/bullet_train/app/helpers/account/markdown_helper.rb
+++ b/bullet_train/app/helpers/account/markdown_helper.rb
@@ -1,13 +1,9 @@
 module Account::MarkdownHelper
   def markdown(string)
-    if defined?(Commonmarker.to_html)
-      Commonmarker.to_html(string, options: {
-        extensions: {header_ids: true},
-        plugins: {syntax_highlighter: {theme: "InspiredGitHub"}},
-        render: {width: 120, unsafe: true}
-      }).html_safe
-    else
-      CommonMarker.render_html(string, :UNSAFE, [:table]).html_safe
-    end
+    Commonmarker.to_html(string, options: {
+      extensions: {header_ids: true},
+      plugins: {syntax_highlighter: {theme: "InspiredGitHub"}},
+      render: {width: 120, unsafe: true}
+    }).html_safe
   end
 end

--- a/bullet_train/bullet_train.gemspec
+++ b/bullet_train/bullet_train.gemspec
@@ -87,7 +87,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "valid_email"
 
   # Allow users to supply content with markdown formatting. Powers our markdown() view helper.
-  spec.add_dependency "commonmarker"
+  spec.add_dependency "commonmarker", ">= 1.0.0"
 
   # Extract the body from emails received using action inbox.
   spec.add_dependency "extended_email_reply_parser" # TODO ➡️ `bullet_train-conversations`


### PR DESCRIPTION
Follow up to https://github.com/bullet-train-co/bullet_train-core/pull/398#issuecomment-1675575807

CommonMarker has shipped 1.0 and are on 1.0.4, Dependabot has already updated the starter repo: https://github.com/bullet-train-co/bullet_train/pull/1261

So we can require >= 1.0 and remove our fallback now.