### PR TITLE
Add Action Model generators

### DIFF
--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding.rb
@@ -17,7 +17,8 @@ module BulletTrain
       "crud" => "BulletTrain::SuperScaffolding::Scaffolders::CrudScaffolder",
       "crud-field" => "BulletTrain::SuperScaffolding::Scaffolders::CrudFieldScaffolder",
       "join-model" => "BulletTrain::SuperScaffolding::Scaffolders::JoinModelScaffolder",
-      "oauth-provider" => "BulletTrain::SuperScaffolding::Scaffolders::OauthProviderScaffolder"
+      "oauth-provider" => "BulletTrain::SuperScaffolding::Scaffolders::OauthProviderScaffolder",
+      "action-models:targets-many" => "BulletTrain::ActionModels::Scaffolders::TargetsManyScaffolder"
     }
 
     class Runner

--- a/bullet_train-super_scaffolding/lib/generators/super_scaffold/action_models/targets_many/USAGE
+++ b/bullet_train-super_scaffolding/lib/generators/super_scaffold/action_models/targets_many/USAGE
@@ -1,0 +1,30 @@
+Description:
+  Generate an action that targets many models.
+
+Example:
+  E.g. Perform an Archive action that targets many Projects on a Team.
+    rails g super_scaffold:action_models:targets_many Archive Project Team
+
+  This will create:
+    app/avo/resources/projects_archive_action.rb
+    app/controllers/account/projects/
+    app/controllers/api/v1/projects/
+    app/controllers/avo/projects_archive_actions_controller.rb
+    app/models/projects.rb
+    app/models/projects/
+    app/views/account/projects/archive_actions/
+    app/views/api/v1/projects/archive_actions/
+    config/locales/en/projects/
+    db/migrate/20240109055956_create_projects_archive_actions.rb
+    test/controllers/api/v1/projects/
+    test/factories/projects/
+    test/models/projects/
+  And update:
+    app/models/team.rb
+    app/views/account/projects/_index.html.erb
+    config/models/roles.yml
+    config/routes.rb
+    config/routes/api/v1.rb
+
+🏆 Protip: Commit your other changes before running Super Scaffolding so it's easy to undo if you (or we) make any mistakes.
+If you do that, you can reset to your last commit state by using `git checkout .` and `git clean -d -f`.

--- a/bullet_train-super_scaffolding/lib/generators/super_scaffold/action_models/targets_many/targets_many_generator.rb
+++ b/bullet_train-super_scaffolding/lib/generators/super_scaffold/action_models/targets_many/targets_many_generator.rb
@@ -1,0 +1,36 @@
+require_relative "../../super_scaffold_base"
+require "scaffolding/routes_file_manipulator"
+
+module ActionModels
+  class TargetsManyGenerator < Rails::Generators::Base
+    include SuperScaffoldBase
+
+    source_root File.expand_path("templates", __dir__)
+
+    namespace "super_scaffold:action_models:targets_many"
+
+    argument :action_model
+    argument :target_model
+    argument :parent_model
+
+    class_option :skip_migration_generation, type: :boolean, default: false, desc: "Don't generate the model migration"
+    class_option :skip_form, type: :boolean, default: false, desc: "Don't alter the new/edit form"
+    class_option :skip_show, type: :boolean, default: false, desc: "Don't alter the show view"
+    class_option :skip_table, type: :boolean, default: false, desc: "Only add to the new/edit form and show view."
+    class_option :skip_locales, type: :boolean, default: false, desc: "Don't alter locale files"
+    class_option :skip_api, type: :boolean, default: false, desc: "Don't alter the api payloads"
+    class_option :skip_model, type: :boolean, default: false, desc: "Don't alter the model file"
+
+    def generate
+      if defined?(BulletTrain::ActionModels)
+        # We add the name of the specific super_scaffolding command that we want to
+        # invoke to the beginning of the argument string.
+        ARGV.unshift "action-models:targets-many"
+        BulletTrain::SuperScaffolding::Runner.new.run
+      else
+        puts "You must have Action Models installed if you want to use this generator.".red
+        puts "Please refer to the documentation for more information: https://bullettrain.co/docs/action-models"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #735.

This initial commit is just for targets-many. I'm leaving it as a draft for now in case we want to close this and move the logic to the Action Models repository. I'm okay with keeping it here though because we include some files here like the `SuperScaffoldBase` generator module which we don't have available in Action Models. We also don't have `bullet_train-super-scaffolding` as a dependency over there, so although I'm sure it's possible to move everything over, I'm not sure if it's worth it for the scope of this PR.

If we're okay with putting everything here, I'll go ahead and add the generators for the other types of actions.

As a side note, we'll also have to update https://github.com/bullet-train-co/bullet_train/blob/main/bin/super-scaffold.