### PR TITLE
Add description to generated api paths

### DIFF
--- a/bullet_train-api/app/helpers/api/open_api_helper.rb
+++ b/bullet_train-api/app/helpers/api/open_api_helper.rb
@@ -24,7 +24,7 @@ module Api
     end
 
     def automatic_paths_for(model, parent, except: [])
-      output = render("api/#{@version}/open_api/shared/paths", model_name: model.name.underscore.pluralize, except: except)
+      output = render("api/#{@version}/open_api/shared/paths", model_name: model.model_name.collection, except: except)
       output = Scaffolding::Transformer.new(model.name, [parent&.name]).transform_string(output).html_safe
 
       custom_actions_file_path = "api/#{@version}/open_api/#{model.model_name.collection}/paths"

--- a/bullet_train-api/app/helpers/api/open_api_helper.rb
+++ b/bullet_train-api/app/helpers/api/open_api_helper.rb
@@ -24,7 +24,7 @@ module Api
     end
 
     def automatic_paths_for(model, parent, except: [])
-      output = render("api/#{@version}/open_api/shared/paths", except: except)
+      output = render("api/#{@version}/open_api/shared/paths", model_name: model.name.underscore.pluralize, except: except)
       output = Scaffolding::Transformer.new(model.name, [parent&.name]).transform_string(output).html_safe
 
       custom_actions_file_path = "api/#{@version}/open_api/#{model.model_name.collection}/paths"

--- a/bullet_train-api/app/views/api/v1/open_api/invitations/_paths.yaml.erb
+++ b/bullet_train-api/app/views/api/v1/open_api/invitations/_paths.yaml.erb
@@ -3,6 +3,7 @@
     tags:
       - Invitation
     summary: "Resend Invitation"
+    description: "Resend an Invitation"
     operationId: resendInvitation
     parameters:
       - $ref: "#/components/parameters/id"

--- a/bullet_train-api/app/views/api/v1/open_api/shared/_paths.yaml.erb
+++ b/bullet_train-api/app/views/api/v1/open_api/shared/_paths.yaml.erb
@@ -5,7 +5,8 @@
   get:
     tags:
       - Scaffolding::CompletelyConcrete::TangibleThing
-    summary: "List Tangible Things"
+    summary: <%= I18n.t("#{model_name}.api.paths.index.summary", default: "List Tangible Things") %>
+    description: <%= I18n.t("#{model_name}.api.paths.index.description", default: "List Tangible Things") %>
     operationId: listScaffoldingCompletelyConcreteTangibleThings
     parameters:
       - name: absolutely_abstract_creative_concept_id
@@ -37,7 +38,8 @@
   post:
     tags:
       - Scaffolding::CompletelyConcrete::TangibleThing
-    summary: "Create Tangible Thing"
+    summary: <%= I18n.t("#{model_name}.api.paths.create.summary", default: "Create Tangible Thing") %>
+    description: <%= I18n.t("#{model_name}.api.paths.create.description", default: "Create Tangible Thing") %>
     operationId: createScaffoldingCompletelyConcreteTangibleThings
     parameters:
       - name: absolutely_abstract_creative_concept_id
@@ -77,7 +79,8 @@
   get:
     tags:
       - Scaffolding::CompletelyConcrete::TangibleThing
-    summary: "Fetch Tangible Thing"
+    summary: <%= I18n.t("#{model_name}.api.paths.show.summary", default: "Fetch Tangible Thing") %>
+    description: <%= I18n.t("#{model_name}.api.paths.show.description", default: "Fetch Tangible Thing") %>
     operationId: getScaffoldingCompletelyConcreteTangibleThings
     parameters:
       - $ref: "#/components/parameters/id"
@@ -97,7 +100,8 @@
   put:
     tags:
       - Scaffolding::CompletelyConcrete::TangibleThing
-    summary: "Update Tangible Thing"
+    summary: <%= I18n.t("#{model_name}.api.paths.update.summary", default: "Update Tangible Thing") %>
+    description: <%= I18n.t("#{model_name}.api.paths.update.description", default: "Update Tangible Thing") %>
     operationId: updateScaffoldingCompletelyConcreteTangibleThings
     parameters:
       - $ref: "#/components/parameters/id"
@@ -130,7 +134,8 @@
   delete:
     tags:
       - Scaffolding::CompletelyConcrete::TangibleThing
-    summary: "Remove Tangible Thing"
+    summary: <%= I18n.t("#{model_name}.api.paths.index.summary", default: "List Tangible Things") %>
+    description: <%= I18n.t("#{model_name}.api.paths.index.description", default: "List Tangible Things") %>
     operationId: removeScaffoldingCompletelyConcreteTangibleThings
     parameters:
       - $ref: "#/components/parameters/id"

--- a/bullet_train-api/app/views/api/v1/open_api/teams/_paths.yaml.erb
+++ b/bullet_train-api/app/views/api/v1/open_api/teams/_paths.yaml.erb
@@ -3,6 +3,7 @@
     tags:
       - Team
     summary: "List Teams"
+    description: "List all Teams"
     operationId: listTeams
     parameters:
       - $ref: "#/components/parameters/after"
@@ -30,6 +31,7 @@
     tags:
       - Team
     summary: "Fetch Team"
+    description: "Fetch a single Team"
     operationId: fetchTeam
     parameters:
       - $ref: "#/components/parameters/id"
@@ -48,6 +50,7 @@
     tags:
       - Team
     summary: "Update Team"
+    description: "Update a single Team"
     operationId: updateTeam
     parameters:
       - $ref: "#/components/parameters/id"

--- a/bullet_train-api/app/views/api/v1/open_api/users/_paths.yaml.erb
+++ b/bullet_train-api/app/views/api/v1/open_api/users/_paths.yaml.erb
@@ -3,6 +3,7 @@
     tags:
       - User
     summary: "List Users"
+    description: "List all Users"
     operationId: listUsers
     parameters:
       - $ref: "#/components/parameters/after"
@@ -29,6 +30,7 @@
     tags:
       - User
     summary: "Fetch User"
+    description: "Fetch a single User"
     operationId: fetchUser
     parameters:
       - $ref: "#/components/parameters/id"
@@ -47,6 +49,7 @@
     tags:
       - User
     summary: "Update User"
+    description: "Update a single User"
     operationId: updateUser
     parameters:
       - $ref: "#/components/parameters/id"


### PR DESCRIPTION
We need to add descriptions to the generated yaml for `automatic_paths_for` sections.

I've added translation keys, falling back to the default text. By doing this in the template, the super-scaffold transformer will correctly pick up the default text to change the correct text for the model if nothing is defined in the l10n files.

I've used the keys `<model_name>.api.paths.<action>.description` to let us define the desired text.

While here, I've changed the summary text to use `<model_name>.api.paths.<action>.summary` so this can be modified in the same way if desired.

Happy to hear suggested alternative ways of doing this, but this works well for our app.

I've also added basic `description`s to the user & team paths too.