### PR TITLE
Feature: Allow custom properties for components

### DIFF
--- a/bullet_train-api/app/helpers/api/open_api_helper.rb
+++ b/bullet_train-api/app/helpers/api/open_api_helper.rb
@@ -176,8 +176,8 @@ module Api
     def customize_component!(original, custom)
       custom = custom.deep_stringify_keys.deep_transform_values { |v| v.is_a?(Symbol) ? v.to_s : v }
 
-      if custom.key?("add")
-        custom["add"].each do |property, details|
+      if custom.key?("include")
+        custom["include"].each do |property, details|
           if details["required"]
             original["required"] << property
             details.delete("required")
@@ -190,8 +190,8 @@ module Api
         end
       end
 
-      if custom.key?("remove")
-        Array(custom["remove"]).each do |property|
+      if custom.key?("except")
+        Array(custom["except"]).each do |property|
           original["required"].delete(property)
           original["properties"].delete(property)
           original["example"].delete(property)

--- a/bullet_train-api/app/helpers/api/open_api_helper.rb
+++ b/bullet_train-api/app/helpers/api/open_api_helper.rb
@@ -176,25 +176,29 @@ module Api
     def customize_component!(original, custom)
       custom = custom.deep_stringify_keys.deep_transform_values { |v| v.is_a?(Symbol) ? v.to_s : v }
 
-      if custom.key?("add")
-        custom["add"].each do |property, details|
-          if details["required"]
-            original["required"] << property
-            details.delete("required")
-          end
-          original["properties"][property] = details
-          if details["example"]
-            original["example"][property] = details["example"]
-            details.delete("example")
+      %w[add include append].each do |add_key|
+        if custom.key?(add_key)
+          custom[add_key].each do |property, details|
+            if details["required"]
+              original["required"] << property
+              details.delete("required")
+            end
+            original["properties"][property] = details
+            if details["example"]
+              original["example"][property] = details["example"]
+              details.delete("example")
+            end
           end
         end
       end
 
-      if custom.key?("remove")
-        Array(custom["remove"]).each do |property|
-          original["required"].delete(property)
-          original["properties"].delete(property)
-          original["example"].delete(property)
+      %w[remove exclude except].each do |remove_key|
+        if custom.key?(remove_key)
+          Array(custom[remove_key]).each do |property|
+            original["required"].delete(property)
+            original["properties"].delete(property)
+            original["example"].delete(property)
+          end
         end
       end
     end

--- a/bullet_train-api/app/helpers/api/open_api_helper.rb
+++ b/bullet_train-api/app/helpers/api/open_api_helper.rb
@@ -177,22 +177,21 @@ module Api
       custom = custom.deep_stringify_keys.deep_transform_values { |v| v.is_a?(Symbol) ? v.to_s : v }
 
       if custom.key?("add")
-        custom["add"].keys.each do |property|
-          if custom["add"][property]["required"]
+        custom["add"].each do |property, details|
+          if details["required"]
             original["required"] << property
-            custom["add"][property].delete("required")
+            details.delete("required")
           end
-          original["properties"][property] = custom["add"][property]
-          if custom["add"][property]["example"]
-            original["example"][property] = custom["add"][property]["example"]
-            custom["add"][property].delete("example")
+          original["properties"][property] = details
+          if details["example"]
+            original["example"][property] = details["example"]
+            details.delete("example")
           end
         end
       end
 
       if custom.key?("remove")
-        custom["remove"] = [custom["remove"]] unless custom["remove"].is_a?(Array)
-        custom["remove"].each do |property|
+        Array(custom["remove"]).each do |property|
           original["required"].delete(property)
           original["properties"].delete(property)
           original["example"].delete(property)

--- a/bullet_train-api/app/helpers/api/open_api_helper.rb
+++ b/bullet_train-api/app/helpers/api/open_api_helper.rb
@@ -201,6 +201,16 @@ module Api
           end
         end
       end
+
+      if custom.key?("only")
+        original["properties"].keys.each do |property|
+          unless Array(custom["only"]).include?(property)
+            original["properties"].delete(property)
+            original["required"].delete(property)
+            original["example"].delete(property)
+          end
+        end
+      end
     end
   end
 end

--- a/bullet_train-api/app/helpers/api/open_api_helper.rb
+++ b/bullet_train-api/app/helpers/api/open_api_helper.rb
@@ -176,8 +176,8 @@ module Api
     def customize_component!(original, custom)
       custom = custom.deep_stringify_keys.deep_transform_values { |v| v.is_a?(Symbol) ? v.to_s : v }
 
-      if custom.key?("include")
-        custom["include"].each do |property, details|
+      if custom.key?("add")
+        custom["add"].each do |property, details|
           if details["required"]
             original["required"] << property
             details.delete("required")
@@ -190,8 +190,8 @@ module Api
         end
       end
 
-      if custom.key?("except")
-        Array(custom["except"]).each do |property|
+      if custom.key?("remove")
+        Array(custom["remove"]).each do |property|
           original["required"].delete(property)
           original["properties"].delete(property)
           original["example"].delete(property)

--- a/bullet_train-api/app/helpers/api/open_api_helper.rb
+++ b/bullet_train-api/app/helpers/api/open_api_helper.rb
@@ -47,7 +47,9 @@ module Api
       indent(output, 1)
     end
 
-    def automatic_components_for(model, locals: {})
+    def automatic_components_for(model, **options)
+      locals = options.delete(:locals) || {}
+
       path = "app/views/api/#{@version}"
       paths = [path, "app/views"] + gem_paths.product(%W[/#{path} /app/views]).map(&:join)
 
@@ -75,6 +77,9 @@ module Api
       )
 
       attributes_output = JSON.parse(schema_json)
+
+      # Allow customization of Attributes
+      customize_component!(attributes_output, options[:attributes]) if options[:attributes]
 
       # Add "Attributes" part to $ref's
       update_ref_values!(attributes_output)
@@ -105,6 +110,9 @@ module Api
         parameters_output["required"].select! { |key| strong_parameter_keys.include?(key.to_sym) }
         parameters_output["properties"].select! { |key| strong_parameter_keys.include?(key.to_sym) }
         parameters_output["example"]&.select! { |key, value| strong_parameter_keys.include?(key.to_sym) && value.present? }
+
+        # Allow customization of Parameters
+        customize_component!(parameters_output, options[:parameters]) if options[:parameters]
 
         (
           indent(attributes_output.to_yaml.gsub("---", "#{model.name.gsub("::", "")}Attributes:"), 3) +
@@ -161,6 +169,33 @@ module Api
           (old_val + new_val).uniq
         else
           new_val
+        end
+      end
+    end
+
+    def customize_component!(original, custom)
+      custom = custom.deep_stringify_keys.deep_transform_values { |v| v.is_a?(Symbol) ? v.to_s : v }
+
+      if custom.key?("add")
+        custom["add"].keys.each do |property|
+          if custom["add"][property]["required"]
+            original["required"] << property
+            custom["add"][property].delete("required")
+          end
+          original["properties"][property] = custom["add"][property]
+          if custom["add"][property]["example"]
+            original["example"][property] = custom["add"][property]["example"]
+            custom["add"][property].delete("example")
+          end
+        end
+      end
+
+      if custom.key?("remove")
+        custom["remove"] = [custom["remove"]] unless custom["remove"].is_a?(Array)
+        custom["remove"].each do |property|
+          original["required"].delete(property)
+          original["properties"].delete(property)
+          original["example"].delete(property)
         end
       end
     end

--- a/bullet_train-api/app/helpers/api/open_api_helper.rb
+++ b/bullet_train-api/app/helpers/api/open_api_helper.rb
@@ -176,29 +176,25 @@ module Api
     def customize_component!(original, custom)
       custom = custom.deep_stringify_keys.deep_transform_values { |v| v.is_a?(Symbol) ? v.to_s : v }
 
-      %w[add include append].each do |add_key|
-        if custom.key?(add_key)
-          custom[add_key].each do |property, details|
-            if details["required"]
-              original["required"] << property
-              details.delete("required")
-            end
-            original["properties"][property] = details
-            if details["example"]
-              original["example"][property] = details["example"]
-              details.delete("example")
-            end
+      if custom.key?("add")
+        custom["add"].each do |property, details|
+          if details["required"]
+            original["required"] << property
+            details.delete("required")
+          end
+          original["properties"][property] = details
+          if details["example"]
+            original["example"][property] = details["example"]
+            details.delete("example")
           end
         end
       end
 
-      %w[remove exclude except].each do |remove_key|
-        if custom.key?(remove_key)
-          Array(custom[remove_key]).each do |property|
-            original["required"].delete(property)
-            original["properties"].delete(property)
-            original["example"].delete(property)
-          end
+      if custom.key?("remove")
+        Array(custom["remove"]).each do |property|
+          original["required"].delete(property)
+          original["properties"].delete(property)
+          original["example"].delete(property)
         end
       end
 


### PR DESCRIPTION
This PR allows custom properties for components in Open-API schema:

```ruby
<%= automatic_components_for Team, attributes: {add: {password: {type: :string, description: "Test", required: true, example: "password-ABC"}}, remove: :time_zone}, parameters: {add: {password: {type: :string, description: "Test", required: true, example: "password-ABC"}}, remove: :time_zone} %>
<%= automatic_components_for User, attributes: {remove: [:email, :time_zone]}, parameters: {remove: [:email, :time_zone, :locale]} %>
<%= automatic_components_for Membership, attributes: {remove: :team_id}, parameters: {remove: :user_first_name} %>
<%= automatic_components_for Webhooks::Outgoing::Endpoint, attributes: {only: [:id, :team_id]}, parameters: {only: :url} %>
```

Acceptable keys: `add`, `remove` and `only` inside `attributes` and/or `parameters`