### PR TITLE
Feature: pass html_option for using user time_zone or browser time_zone in onboarding

### DIFF
--- a/bullet_train/app/views/account/onboarding/user_details/edit.html.erb
+++ b/bullet_train/app/views/account/onboarding/user_details/edit.html.erb
@@ -30,7 +30,8 @@
           <div class="sm:col-span-2">
             <%= render 'shared/fields/super_select', form: f, method: :time_zone,
               choices: time_zone_options_for_select(@user.time_zone, nil, ActiveSupport::TimeZone),
-              other_options: {search: true, required: true} %>
+              other_options: {search: true, required: true},
+              html_options: {use_browser_time_zone: true} %>
           </div>
         </div>
 
@@ -60,14 +61,18 @@
     // figure out the rails timezone value.
     var railsValue = jsTimezoneMapping[jstz.determine().name()];
 
-    // set the form accordingly.
-    var $option = $("#user_time_zone option[value=\"" + railsValue + "\"]")
-    $option.prop('selected', true);
+    var useBrowserTimeZone = $("#user_time_zone").attr('use_browser_time_zone');
 
-    // update the select2 as well. is there a better way to handle this?
-    // why don't _they_ handle this for us?
-    $("#select2-user_time_zone-container").attr('title', $option.text());
-    $("#select2-user_time_zone-container").text($option.text());
+    if (useBrowserTimeZone == "true") {
+      // set the form accordingly.
+      var $option = $("#user_time_zone option[value=\"" + railsValue + "\"]")
+      $option.prop('selected', true);
+
+      // update the select2 as well. is there a better way to handle this?
+      // why don't _they_ handle this for us?
+      $("#select2-user_time_zone-container").attr('title', $option.text());
+      $("#select2-user_time_zone-container").text($option.text());
+    }
 
   });
 </script>


### PR DESCRIPTION
The current User detail onboarding form is passing in `@user.time_zone` as the selected value but the script at the bottom is overriding that value with the result of `jstz.determine().name()`

I think for most cases, that's a good default but with overriding that value, it doesn't allow for something like setting the User's time_zone from OAuth response data.

I'm guessing there's a reason for doing this within the script block on the page so I didn't try to move that to a stimulus controller, but if that's not the case, I'm happy to try to refactor to a stimulus controller.