### PR TITLE
Change hashids to sqids

### DIFF
--- a/bullet_train-obfuscates_id/Gemfile.lock
+++ b/bullet_train-obfuscates_id/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     bullet_train-obfuscates_id (1.6.24)
-      hashids
       rails (>= 6.0.0)
+      sqids
 
 GEM
   remote: https://rubygems.org/
@@ -95,7 +95,6 @@ GEM
     erubi (1.12.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    hashids (1.0.6)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
@@ -130,6 +129,8 @@ GEM
       net-protocol
     nio4r (2.5.9)
     nokogiri (1.15.4-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.15.4-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
@@ -187,7 +188,9 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqids (0.2.0)
     sqlite3 (1.6.8-arm64-darwin)
+    sqlite3 (1.6.8-x86_64-darwin)
     sqlite3 (1.6.8-x86_64-linux)
     stringio (3.0.9)
     thor (1.3.0)
@@ -202,6 +205,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/bullet_train-obfuscates_id/app/models/concerns/obfuscates_id.rb
+++ b/bullet_train-obfuscates_id/app/models/concerns/obfuscates_id.rb
@@ -2,24 +2,24 @@ module ObfuscatesId
   extend ActiveSupport::Concern
 
   class_methods do
-    def hashids
+    def sqids
       # ⚠️ Changing anything in this method will invalidate any URLs with obfuscated IDs that are in the wild.
       # You should not change any of these settings after going live unless you're OK breaking links in sent emails,
-      # breaking bookmarks to pages within your application, etc. For this reason, we don't want the Hashids salt
+      # breaking bookmarks to pages within your application, etc. For this reason, we don't want the Sqids salt
       # configurable via an ENV value.
 
       # We don't include digits in our alphabet because it sometimes results in fully numeric strings being generated,
       # and we can't differentiate those from normal IDs that we still need to be able to deal with.
-      @hashids ||= Hashids.new "Default ID Obfuscation Salt for #{name}", 6, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      @sqids ||= Sqids.new(alphabet: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", min_length: 6)
     end
 
     def encode_id(id)
-      hashids.encode(id)
+      sqids.encode(id)
     end
 
     def decode_id(id)
       return id if id.to_i > 0
-      hashids.decode(id).first
+      sqids.decode(id).first
     end
 
     def find(*ids)

--- a/bullet_train-obfuscates_id/bullet_train-obfuscates_id.gemspec
+++ b/bullet_train-obfuscates_id/bullet_train-obfuscates_id.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "rails", ">= 6.0.0"
-  spec.add_dependency "hashids"
+  spec.add_dependency "sqids"
 end

--- a/bullet_train-obfuscates_id/lib/bullet_train/obfuscates_id.rb
+++ b/bullet_train-obfuscates_id/lib/bullet_train/obfuscates_id.rb
@@ -1,7 +1,7 @@
 require "bullet_train/obfuscates_id/version"
 require "bullet_train/obfuscates_id/engine"
 
-require "hashids"
+require "sqids"
 
 module BulletTrain
   module ObfuscatesId


### PR DESCRIPTION
I looked into https://github.com/bullet-train-co/bullet_train/issues/1232 a little bit and came across an update concerning hashids. According to the [documentation](https://github.com/peterhellberg/hashids.rb), hashids has been rebranded to `sqids`, so I used the new gem. The code itself was the same for the most part, but the object constructor was just a little different.

I think I'll try to implement the slug logic with `obfuscates_id` next.