### PR TITLE
Emoji picker: Properly unregister on disconnect()

### DIFF
--- a/bullet_train-fields/app/javascript/controllers/fields/emoji_picker_controller.js
+++ b/bullet_train-fields/app/javascript/controllers/fields/emoji_picker_controller.js
@@ -26,6 +26,11 @@ export default class extends Controller {
     })
   }
 
+  disconnect() {
+    if (this.picker === undefined) { return }
+    this.picker.unregister()
+  }
+
   toggle(event) {
     event.preventDefault()
     if (this.visible) {


### PR DESCRIPTION
Fixes #743 