### PR TITLE
Remove obsolete code in main Super Scaffolding script

### DIFF
--- a/bullet_train-incoming_webhooks/lib/bullet_train/incoming_webhooks/scaffolders/incoming_webhooks_scaffolder.rb
+++ b/bullet_train-incoming_webhooks/lib/bullet_train/incoming_webhooks/scaffolders/incoming_webhooks_scaffolder.rb
@@ -13,7 +13,8 @@ module BulletTrain
             puts "E.g. prepare to receive system-level webhooks from ClickFunnels"
             puts "  bin/super-scaffold incoming-webhooks ClickFunnels"
             puts ""
-            standard_protip
+            puts "🏆 Protip: Commit your other changes before running Super Scaffolding so it's easy to undo if you (or we) make any mistakes."
+            puts "If you do that, you can reset to your last commit state by using `git checkout .` and `git clean -d -f` ."
             puts ""
             return
           end

--- a/bullet_train-super_scaffolding/lib/generators/super_scaffold/field/USAGE
+++ b/bullet_train-super_scaffolding/lib/generators/super_scaffold/field/USAGE
@@ -13,3 +13,24 @@ Example:
     config/locales/en/projects.en.yml
     app/controllers/account/projects_controller.rb
     app/controllers/api/v1/projects_controller.rb
+
+Field Partial Types:
+  address_field:       nil
+  boolean:             boolean
+  buttons:             string
+  cloudinary_image:    string
+  color_picker:        string
+  date_and_time_field: datetime
+  date_field:          date
+  email_field:         string
+  emoji_field:         string
+  file_field:          attachment
+  image:               attachment
+  options:             string
+  password_field:      string
+  phone_field:         string
+  super_select:        string
+  text_area:           text
+  text_field:          string
+  number_field:        integer
+  trix_editor:         text

--- a/bullet_train-super_scaffolding/lib/scaffolding/script.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/script.rb
@@ -45,11 +45,6 @@ ARGV.each do |arg|
   end
 end
 
-def standard_protip
-  puts "🏆 Protip: Commit your other changes before running Super Scaffolding so it's easy to undo if you (or we) make any mistakes."
-  puts "If you do that, you can reset to your last commit state by using `git checkout .` and `git clean -d -f` ."
-end
-
 def get_untracked_files
   `git ls-files --other --exclude-standard`.split("\n")
 end
@@ -208,58 +203,10 @@ def check_required_options_for_attributes(scaffolding_type, attributes, child, p
   end
 end
 
-def show_usage
-  puts ""
-  puts "🚅  usage: bin/super-scaffold [type] (... | --help | --field-partials)"
-  puts ""
-  puts "Supported types of scaffolding:"
-  puts ""
-  BulletTrain::SuperScaffolding.scaffolders.each do |key, _|
-    puts "  #{key}"
-  end
-  puts ""
-  puts "Try `bin/super-scaffold [type]` for usage examples.".blue
-  puts ""
-end
-
 # grab the _type_ of scaffold we're doing.
 scaffolding_type = argv.shift
 
 if BulletTrain::SuperScaffolding.scaffolders.include?(scaffolding_type)
   scaffolder = BulletTrain::SuperScaffolding.scaffolders[scaffolding_type].constantize
   scaffolder.new(argv, @options).run
-elsif argv.empty? || !BulletTrain::SuperScaffolding.scaffolders.include?(scaffolding_type)
-  show_usage
-elsif argv.count > 1
-  puts ""
-  puts "👋"
-  puts "The command line options for Super Scaffolding have changed slightly:".yellow
-  puts "To use the original Super Scaffolding that you know and love, use the `crud` option.".yellow
-
-  show_usage
-elsif ARGV.first.present?
-  case ARGV.first
-  when "--field-partials"
-    puts "Bullet Train uses the following field partials for Super Scaffolding".blue
-    puts ""
-
-    max_name_length = 0
-    FIELD_PARTIALS.each do |key, value|
-      if key.to_s.length > max_name_length
-        max_name_length = key.to_s.length
-      end
-    end
-
-    printf "\t%#{max_name_length}s:Data Type\n".bold, "Field Partial Name"
-    FIELD_PARTIALS.each { |key, value| printf "\t%#{max_name_length}s:#{value}\n", key }
-
-    puts ""
-    puts "For more details, check out the documentation:"
-    puts "https://bullettrain.co/docs/field-partials"
-  when "--help"
-    show_usage
-  else
-    puts "Invalid scaffolding type \"#{ARGV.first}\".".red
-    show_usage
-  end
 end


### PR DESCRIPTION
Completes this task in #662:
> Remove usage/documentation from the main scaffolding script

The `--field-partials` option toward the bottom simply listed out the field partials available, so I wrote this information in the USAGE page for `rails generate super_scaffold:field`.