### PR TITLE
Update `bullet_train` for fields gem

### DIFF
--- a/bullet_train-fields/Gemfile.lock
+++ b/bullet_train-fields/Gemfile.lock
@@ -147,20 +147,20 @@ GEM
     base64 (0.2.0)
     bcrypt (3.1.20)
     builder (3.2.4)
-    bullet_train-has_uuid (1.6.27)
+    bullet_train-has_uuid (1.6.28)
       rails (>= 6.0.0)
-    bullet_train-roles (1.6.27)
+    bullet_train-roles (1.6.28)
       active_hash
       activesupport
       cancancan
     bullet_train-routes (1.0.0)
       rails (>= 6.0.0)
-    bullet_train-scope_validator (1.6.27)
+    bullet_train-scope_validator (1.6.28)
       rails
-    bullet_train-super_load_and_authorize_resource (1.6.27)
+    bullet_train-super_load_and_authorize_resource (1.6.28)
       cancancan
       rails (>= 6.0.0)
-    bullet_train-themes (1.6.27)
+    bullet_train-themes (1.6.28)
       rails (>= 6.0.0)
     cable_ready (5.0.3)
       actionpack (>= 5.2)


### PR DESCRIPTION
Closes #752.

According to the [comment](https://github.com/bullet-train-co/bullet_train-core/issues/752#issuecomment-1914053850) I left there, the dependencies for `bullet_train` needed to be updated so I ran the following in `bullet_train-fields` to account for what was skipped in the process of merging #675 and its surrounding PRs:

```
bundle update --source bullet_train
```
