### PR TITLE
Implement `slug` field partial

### DIFF
--- a/bullet_train-obfuscates_id/app/models/concerns/obfuscates_id.rb
+++ b/bullet_train-obfuscates_id/app/models/concerns/obfuscates_id.rb
@@ -23,8 +23,8 @@ module ObfuscatesId
     end
 
     def find(*ids)
-      if self.respond_to?(:slug_attribute)
-        self.send("find_by_#{slug_attribute}".to_sym, ids.first)
+      if respond_to?(:slug_attribute)
+        send("find_by_#{slug_attribute}".to_sym, ids.first)
       else
         super(*ids.map { |id| decode_id(id) })
       end

--- a/bullet_train-obfuscates_id/app/models/concerns/obfuscates_id.rb
+++ b/bullet_train-obfuscates_id/app/models/concerns/obfuscates_id.rb
@@ -23,7 +23,11 @@ module ObfuscatesId
     end
 
     def find(*ids)
-      super(*ids.map { |id| decode_id(id) })
+      if self.respond_to?(:slug_attribute)
+        self.send("find_by_#{slug_attribute}".to_sym, ids.first)
+      else
+        super(*ids.map { |id| decode_id(id) })
+      end
     end
 
     def relation
@@ -46,6 +50,7 @@ module ObfuscatesId
   end
 
   def to_param
-    obfuscated_id
+    # Even if the `slug` column exists, it might be empty (i.e. - Team).
+    (defined?(slug) && slug.present?) ? slug : obfuscated_id
   end
 end

--- a/bullet_train-obfuscates_id/app/models/concerns/obfuscates_id/sluggable.rb
+++ b/bullet_train-obfuscates_id/app/models/concerns/obfuscates_id/sluggable.rb
@@ -1,5 +1,4 @@
 module ObfuscatesId
-
   # We only want to ensure slugging is possible if a developer
   # can generate a `slug` field partial with our scaffolder.
   if defined?(BulletTrain::SuperScaffolding)
@@ -11,7 +10,7 @@ module ObfuscatesId
         # Alphanumeric downcased URL identifier
         before_validation :downcase_slug
 
-        validates self.slug_attribute,
+        validates slug_attribute,
           uniqueness: true,
           length: {minimum: 2, maximum: 30},
           format: {with: /\A[a-zA-Z0-9|-]+\Z/}
@@ -23,7 +22,7 @@ module ObfuscatesId
         def downcase_slug
           attribute_name = self.class.send(:slug_attribute)
           attribute_name_setter = "#{attribute_name}=".to_sym
-          self.send(attribute_name_setter, self.send(attribute_name).downcase)
+          send(attribute_name_setter, send(attribute_name).downcase)
         end
       end
     end

--- a/bullet_train-obfuscates_id/app/models/concerns/obfuscates_id/sluggable.rb
+++ b/bullet_train-obfuscates_id/app/models/concerns/obfuscates_id/sluggable.rb
@@ -1,0 +1,32 @@
+module ObfuscatesId
+
+  # We only want to ensure slugging is possible if a developer
+  # can generate a `slug` field partial with our scaffolder.
+  if defined?(BulletTrain::SuperScaffolding)
+
+    module Sluggable
+      extend ActiveSupport::Concern
+
+      included do
+        # Alphanumeric downcased URL identifier
+        before_validation :downcase_slug
+
+        validates self.slug_attribute,
+          uniqueness: true,
+          length: {minimum: 2, maximum: 30},
+          format: {with: /\A[a-zA-Z0-9|-]+\Z/}
+
+        validates_with ::RestrictedPathsValidator
+
+        private
+
+        def downcase_slug
+          attribute_name = self.class.send(:slug_attribute)
+          attribute_name_setter = "#{attribute_name}=".to_sym
+          self.send(attribute_name_setter, self.send(attribute_name).downcase)
+        end
+      end
+    end
+
+  end
+end

--- a/bullet_train-obfuscates_id/app/validators/restricted_paths_validator.rb
+++ b/bullet_train-obfuscates_id/app/validators/restricted_paths_validator.rb
@@ -1,0 +1,7 @@
+class RestrictedPathsValidator < ActiveModel::Validator
+  def validate(record)
+    if record.class.restricted_paths.include?(record.slug)
+      record.errors.add record.class.slug_attribute.to_sym, :restricted_path
+    end
+  end
+end

--- a/bullet_train-obfuscates_id/config/locales/en/errors.en.yml
+++ b/bullet_train-obfuscates_id/config/locales/en/errors.en.yml
@@ -1,0 +1,4 @@
+en:
+  errors:
+    messages:
+      restricted_path: "This slug is prohibited"

--- a/bullet_train-super_scaffolding/lib/scaffolding.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding.rb
@@ -24,6 +24,7 @@ module Scaffolding
       "options",
       "password_field",
       "phone_field",
+      "slug",
       "super_select",
       "text_area",
       "text_field",

--- a/bullet_train-super_scaffolding/lib/scaffolding/attribute.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/attribute.rb
@@ -126,6 +126,7 @@ class Scaffolding::Attribute
   def partial_name
     return options[:attribute] if options[:attribute]
 
+    # TODO: We should put these in alphabetical order.
     case type
     when "trix_editor", "ckeditor"
       "html"
@@ -169,6 +170,8 @@ class Scaffolding::Attribute
       "number"
     when "address_field"
       "address"
+    when "slug"
+      "text"
     else
       raise "Invalid field type: #{type}."
     end

--- a/bullet_train-super_scaffolding/lib/scaffolding/script.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/script.rb
@@ -22,6 +22,7 @@ FIELD_PARTIALS = {
   options: "string",
   password_field: "string",
   phone_field: "string",
+  slug: "string",
   super_select: "string",
   text_area: "text",
   text_field: "string",

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -623,7 +623,7 @@ class Scaffolding::Transformer
       # 'primary_key' => '',
       # 'references' => '',
       "string" => "text_field",
-      "text" => "text_area"
+      "text" => "text_area",
       # 'time' => '',
       # 'timestamp' => '',
     }
@@ -1294,6 +1294,34 @@ class Scaffolding::Transformer
           if attribute.is_boolean?
             scaffold_add_line_to_file("./app/models/scaffolding/completely_concrete/tangible_thing.rb", "validates :#{attribute.name}, inclusion: [true, false]", VALIDATIONS_HOOK, prepend: true)
           end
+        when "slug"
+          # TODO: We should really be including Sluggable at the top
+          # above the concerns hook, not here below the methods.
+          slug_methods = <<~RUBY
+            def slug
+              #{attribute.name}
+            end
+
+            def self.slug_attribute
+              :#{attribute.name}
+            end
+
+            def self.restricted_paths
+              [
+                "admin",
+                "admins"
+              ]
+            end
+
+            include Sluggable
+          RUBY
+
+          scaffold_add_line_to_file(
+            "./app/models/scaffolding/completely_concrete/tangible_thing.rb",
+            slug_methods,
+            METHODS_HOOK,
+            prepend: true
+          )
         end
 
       end

--- a/bullet_train-themes/app/views/themes/base/fields/_slug.html.erb
+++ b/bullet_train-themes/app/views/themes/base/fields/_slug.html.erb
@@ -1,0 +1,8 @@
+<!-- This is the same content as text_field -->
+<%
+form ||= current_fields_form
+options ||= {}
+other_options ||= {}
+%>
+
+<%= render 'shared/fields/field', form: form, method: method, helper: :text_field, options: options, other_options: other_options %>


### PR DESCRIPTION
Closes https://github.com/bullet-train-co/bullet_train/issues/1232

```
rails generate super_scaffold Site Team name:text_field foo:slug
```

![image](https://github.com/bullet-train-co/bullet_train-core/assets/10546292/191757f3-4bfc-434c-87f5-3e81f85fd2d6)

## TODO
- [ ] Write Super Scaffolding tests in the starter repository
- [ ] Fix a bug related to nil object when an error is raised on an invalid slug, and then trying to save a valid slug.