### PR TITLE
Feature: Auto-include external markdown files in OpenAPI `index.yaml.erb`

### DIFF
--- a/bullet_train-api/app/helpers/api/open_api_helper.rb
+++ b/bullet_train-api/app/helpers/api/open_api_helper.rb
@@ -131,6 +131,33 @@ module Api
       end
     end
 
+    def markdown_description(filename)
+      # Extract the caller info to get file path and line number
+      caller_info = caller.first
+      caller_path, line_number = caller_info.split(":")
+      line_number = line_number.to_i
+
+      # Read the ERB file and find the specific line
+      file_lines = File.readlines(caller_path)
+      caller_line = file_lines[line_number - 1] # Adjust for array index starting at 0
+
+      # Determine indentation by counting leading spaces
+      indentation = caller_line.match(/^(\s*)/)[1]
+
+      path = Rails.root.join("app", "views", "api", @version, "open_api", "docs", filename)
+      if File.exist?(path)
+        # Read the Markdown file content
+        markdown_content = File.read(path)
+
+        # Apply the indentation to each line of the Markdown content
+        markdown_content.lines.map { |line| "  #{indentation}#{line}".rstrip }.join("\n").prepend("|\n").html_safe
+      else
+        "Markdown file not found: #{path}"
+      end
+    # rescue StandardError => e
+    #   "Error loading markdown description: #{e.message}"
+    end
+
     private
 
     def has_strong_parameters?(controller)

--- a/bullet_train-api/app/helpers/api/open_api_helper.rb
+++ b/bullet_train-api/app/helpers/api/open_api_helper.rb
@@ -132,7 +132,7 @@ module Api
     end
 
     def external_doc(filename)
-      caller_path, line_number = caller.find { |line| line.include?('.yaml.erb:') }.split(":")
+      caller_path, line_number = caller.find { |line| line.include?(".yaml.erb:") }.split(":")
       indentation = File.readlines(caller_path)[line_number.to_i - 1].match(/^(\s*)/)[1]
       path = "app/views/api/#{@version}/open_api/docs/#{filename}.md"
 


### PR DESCRIPTION
Closes #763 

This PR introduces 2 new methods in `OpenApiHelper`:
- `external_doc "<file_name>"`: Includes external markdown file found in `app/views/api/<version>/open_api/docs`
- `documentation_for <Model>`: Includes external markdown found in file `app/views/api/<version>/open_api/docs/<Model.name.underscore>_description.md`

This allows including external markdown files in OpenAPI schema like in this example:
````yaml
openapi: 3.1.0
info:
  ...
  description: <%= external_doc "info_description" %>
  ...
tags:
  - name: Team
    description: <%= description_for Team %>
  - name: Addresses::Country
    description: <%= description_for Addresses::Country %>
  ...
````
supposing the following files exist:
````
app/views/api/v1/open_api/docs/info_description.md
app/views/api/v1/open_api/docs/team_description.md
app/views/api/v1/open_api/docs/addresses/country_description.md
````
---

Detailed documentation on these methods will be added in #749 