### PR TITLE
Remove excess event listener for `template` tag in showcase view

### DIFF
--- a/bullet_train-themes-light/app/views/showcase/engine/_head.html.erb
+++ b/bullet_train-themes-light/app/views/showcase/engine/_head.html.erb
@@ -3,6 +3,7 @@
 
 <script>
   const BulletTrain = {}
+  let templateRendered = false
 
   class ___theme {
     start() {
@@ -34,10 +35,14 @@
   BulletTrain.theme.start()
 
   function placeThemeSelector() {
-    const node = document.getElementById("bullet_train_theme_selects").content.cloneNode(true)
-    document.querySelector("main").appendChild(node)
-    const selectorNode = document.getElementById("bt-theme-selector")
-    document.querySelector("main").style.paddingBottom = selectorNode.offsetHeight + "px"
+    if(!templateRendered) {
+      console.log("not rendered")
+      const node = document.getElementById("bullet_train_theme_selects").content.cloneNode(true)
+      document.querySelector("main").appendChild(node)
+      const selectorNode = document.getElementById("bt-theme-selector")
+      document.querySelector("main").style.paddingBottom = selectorNode.offsetHeight + "px"
+      templateRendered = true
+    }
   }
 
   document.addEventListener("DOMContentLoaded", placeThemeSelector);

--- a/bullet_train-themes-light/app/views/showcase/engine/_head.html.erb
+++ b/bullet_train-themes-light/app/views/showcase/engine/_head.html.erb
@@ -3,7 +3,6 @@
 
 <script>
   const BulletTrain = {}
-  let templateRendered = false
 
   class ___theme {
     start() {
@@ -35,17 +34,12 @@
   BulletTrain.theme.start()
 
   function placeThemeSelector() {
-    if(!templateRendered) {
-      console.log("not rendered")
-      const node = document.getElementById("bullet_train_theme_selects").content.cloneNode(true)
-      document.querySelector("main").appendChild(node)
-      const selectorNode = document.getElementById("bt-theme-selector")
-      document.querySelector("main").style.paddingBottom = selectorNode.offsetHeight + "px"
-      templateRendered = true
-    }
+    const node = document.getElementById("bullet_train_theme_selects").content.cloneNode(true)
+    document.querySelector("main").appendChild(node)
+    const selectorNode = document.getElementById("bt-theme-selector")
+    document.querySelector("main").style.paddingBottom = selectorNode.offsetHeight + "px"
   }
 
-  document.addEventListener("DOMContentLoaded", placeThemeSelector);
   document.addEventListener("turbo:load", placeThemeSelector);
 </script>
 


### PR DESCRIPTION
Closes https://github.com/bullet-train-co/showcase/issues/82.

I have the details written there, but basically we don't need a listener for the `DOMContentLoaded` event since `turbo:load` is fired during the initial page load.