### PR TITLE
Enable bulk action select when one record is present to perform Action Model actions

### DIFF
--- a/bullet_train-super_scaffolding/app/views/account/scaffolding/absolutely_abstract/creative_concepts/_index.html.erb
+++ b/bullet_train-super_scaffolding/app/views/account/scaffolding/absolutely_abstract/creative_concepts/_index.html.erb
@@ -40,7 +40,7 @@
 
         <%# 🚅 super scaffolding will insert new targets one parent action model buttons above this line. %>
         <%# 🚅 super scaffolding will insert new bulk action model buttons above this line. %>
-        <%= render "shared/bulk_action_select" if creative_concepts.many? %>
+        <%= render "shared/bulk_action_select" if creative_concepts.any? %>
 
         <%= link_to t('global.buttons.back'), [:account, context], class: "#{first_button_primary(:absolutely_abstract_creative_concept)} back" unless hide_back %>
       <% end %>

--- a/bullet_train-super_scaffolding/app/views/account/scaffolding/completely_concrete/tangible_things/_index.html.erb
+++ b/bullet_train-super_scaffolding/app/views/account/scaffolding/completely_concrete/tangible_things/_index.html.erb
@@ -51,7 +51,7 @@
 
           <%# 🚅 super scaffolding will insert new targets one parent action model buttons above this line. %>
           <%# 🚅 super scaffolding will insert new bulk action model buttons above this line. %>
-          <%= render "shared/bulk_action_select" if tangible_things.many? %>
+          <%= render "shared/bulk_action_select" if tangible_things.any? %>
 
           <% unless hide_back %>
             <%= link_to t('global.buttons.back'), [:account, context], class: "#{first_button_primary(:completely_concrete_tangible_thing)} back" %>


### PR DESCRIPTION
Whenever Action Models is enabled, we give the user the option to select multiple records of the same model if two or more exist. This happens regardless if the model has an action model that performs actions on it, but I think we should only scaffold the following if the action model requires it:

```erb
<%= render 'shared/bulk_action_select' %>
```

I think that's a separate issue that would require more work, but for now with this PR, I just simply changed `many?` to `any?` because I think the `TargetsMany` action should target records >=1, but we currently have it set so `Select Multiple` is only visible when two or more records exist. Even if user intends to create many records in the future, this means that we can't perform the action at all when just one record is present. Currently if we wanted to target one record, we'd either have to create a new record to fulfill the `tangible_things.many?` requirement, or scaffold a `TargetsOne` action.