### PR TITLE
Run migrations automatically for the `oauth_provider` scaffolder

### DIFF
--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/oauth_provider_scaffolder.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/oauth_provider_scaffolder.rb
@@ -59,18 +59,19 @@ module BulletTrain
             end
 
             if @options["skip-migration-generation"]
-              transformed_data.each do |klass, _|
-                if klass.safe_constantize.nil?
-                  puts ""
-                  puts "We could not find `#{klass}`.".red
-                  puts "🚨 Before doing the actual Super Scaffolding, you'll need to generate the models like so:".red
-                  puts ""
-                  transformed_data.each {|_, migration| puts "  #{migration}".red}
-                  puts ""
-                  puts "However, don't do the `rake db:migrate` until after you re-run Super Scaffolding, as it will need to update some settings in those migrations.".red
-                  puts ""
-                  return
-                end
+              undefined_models = transformed_data.keys.each {|key| key.safe_constantize.nil?}
+              if undefined_models.any?
+                puts ""
+                puts "We could not find the following models:".red
+                undefined_models.each {|model| puts "  #{model}".red}
+                puts ""
+                puts "🚨 Before doing the actual Super Scaffolding, you'll need to generate the models like so:".red
+                puts ""
+                transformed_data.each { |_, migration| puts "  #{migration}".red }
+                puts ""
+                puts "However, don't do the `rake db:migrate` until after you re-run Super Scaffolding, as it will need to update some settings in those migrations.".red
+                puts ""
+                return
               end
             else
               transformed_data.each do |klass, generation_command|

--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/oauth_provider_scaffolder.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/oauth_provider_scaffolder.rb
@@ -59,11 +59,11 @@ module BulletTrain
             end
 
             if @options["skip-migration-generation"]
-              undefined_models = transformed_data.keys.each {|key| key.safe_constantize.nil?}
+              undefined_models = transformed_data.keys.each { |key| key.safe_constantize.nil? }
               if undefined_models.any?
                 puts ""
                 puts "We could not find the following models:".red
-                undefined_models.each {|model| puts "  #{model}".red}
+                undefined_models.each { |model| puts "  #{model}".red }
                 puts ""
                 puts "🚨 Before doing the actual Super Scaffolding, you'll need to generate the models like so:".red
                 puts ""

--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/oauth_provider_scaffolder.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/oauth_provider_scaffolder.rb
@@ -45,16 +45,40 @@ module BulletTrain
           unless File.exist?(oauth_transform_string("./app/models/oauth/stripe_account.rb", options)) &&
               File.exist?(oauth_transform_string("./app/models/integrations/stripe_installation.rb", options)) &&
               File.exist?(oauth_transform_string("./app/models/webhooks/incoming/oauth/stripe_account_webhook.rb", options))
-            puts ""
-            puts oauth_transform_string("🚨 Before doing the actual Super Scaffolding, you'll need to generate the models like so:", options).red
-            puts ""
-            puts oauth_transform_string("  rails g model Oauth::StripeAccount uid:string data:jsonb user:references", options).red
-            puts oauth_transform_string("  rails g model Integrations::StripeInstallation team:references oauth_stripe_account:references name:string", options).red
-            puts oauth_transform_string("  rails g model Webhooks::Incoming::Oauth::StripeAccountWebhook data:jsonb processed_at:datetime verified_at:datetime oauth_stripe_account:references", options).red
-            puts ""
-            puts "However, don't do the `rake db:migrate` until after you re-run Super Scaffolding, as it will need to update some settings in those migrations.".red
-            puts ""
-            return
+
+            oauth_model_data = {
+              "Oauth::StripeAccount": "rails generate model Oauth::StripeAccount uid:string data:jsonb user:references",
+              "Integrations::StripeInstallation": "rails generate model Integrations::StripeInstallation team:references oauth_stripe_account:references name:string",
+              "Webhooks::Incoming::Oauth::StripeAccountWebhook": "rails generate model Webhooks::Incoming::Oauth::StripeAccountWebhook data:jsonb processed_at:datetime verified_at:datetime oauth_stripe_account:references"
+            }
+
+            # Transform class names and model migrations.
+            transformed_data = {}
+            oauth_model_data.each do |key, value|
+              transformed_data[oauth_transform_string(key.to_s, options)] = oauth_transform_string(value, options)
+            end
+
+            if @options["skip-migration-generation"]
+              transformed_data.each do |klass, _|
+                if klass.safe_constantize.nil?
+                  puts ""
+                  puts "We could not find `#{klass}`.".red
+                  puts "🚨 Before doing the actual Super Scaffolding, you'll need to generate the models like so:".red
+                  puts ""
+                  transformed_data.each {|_, migration| puts "  #{migration}".red}
+                  puts ""
+                  puts "However, don't do the `rake db:migrate` until after you re-run Super Scaffolding, as it will need to update some settings in those migrations.".red
+                  puts ""
+                  return
+                end
+              end
+            else
+              transformed_data.each do |klass, generation_command|
+                puts "Generating #{klass} model with '#{generation_command}'".green
+                generation_thread = Thread.new { `#{generation_command}` }
+                generation_thread.join # Wait for the process to finish.
+              end
+            end
           end
 
           icon_name = nil

--- a/bullet_train-super_scaffolding/lib/scaffolding/script.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/script.rb
@@ -174,7 +174,8 @@ def check_required_options_for_attributes(scaffolding_type, attributes, child, p
   # Generate the models/migrations with the attributes passed.
   if attributes_to_generate.any?
     case scaffolding_type
-    # "join-model" is not here because the `rails g` command is written inline in its own scaffolder.
+    # "join-model" and "oauth-provider" are not here because the
+    # `rails g` command is written inline in their own respective scaffolders.
     when "crud"
       puts "Generating #{child} model with '#{generation_command}'".green
     when "crud-field"


### PR DESCRIPTION
Closes #626.

I've set things up so the command will exit if the `--skip-migration-generation` flag is passed but the models haven't been defined:

```
We could not find the following models:
  Oauth::SpotifyAccount
  Integrations::SpotifyInstallation
  Webhooks::Incoming::Oauth::SpotifyAccountWebhook

🚨 Before doing the actual Super Scaffolding, you'll need to generate the models like so:

  rails generate model Oauth::SpotifyAccount uid:string data:jsonb user:references
  rails generate model Integrations::SpotifyInstallation team:references oauth_spotify_account:references name:string
  rails generate model Webhooks::Incoming::Oauth::SpotifyAccountWebhook data:jsonb processed_at:datetime verified_at:datetime oauth_spotify_account:references

However, don't do the `rake db:migrate` until after you re-run Super Scaffolding, as it will need to update some settings in those migrations.
```

However, if it's more desirable to simply continue with the scaffolding regardless if the migrations are present or not, I can edit the file to reflect that. I'm okay with this current setup though because I think it is in step with the `omakase` style of Bullet Train.