### PR TITLE
Check if billing_enabled? before enforcing billing requirements

### DIFF
--- a/bullet_train/app/controllers/concerns/account/controllers/base.rb
+++ b/bullet_train/app/controllers/concerns/account/controllers/base.rb
@@ -110,8 +110,7 @@ module Account::Controllers::Base
         end
       end
 
-      # TODO Maybe in this context we should check whether `Billing::ControllerSupport` is included instead of just defined?
-      if defined?(Billing::ControllerSupport)
+      if billing_enabled?
         enforce_billing_requirements
         # See `app/controllers/concerns/billing_support.rb` for details.
       end


### PR DESCRIPTION
instead of looking up `Billing::ControllerSupport`, which lead to false positives: 

when disabling billing in CI (via removing the `STRIPE_SECRET_KEY` or `PADDLE_SECRET_KEY` env variable), this would send me in an infinite redirect loop.

I can't think of any case where it would make sense _not_ to use the `billing_enabled?` helper method here, maybe I'm overlooking something?