### PR TITLE
Add comment to method in `ClassNamesTransformer`

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/class_names_transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/class_names_transformer.rb
@@ -37,6 +37,19 @@ class Scaffolding::ClassNamesTransformer
     parts.last
   end
 
+  # "In context" here means all of the parts in a namespace
+  # without reference to the parts that overlap.
+  #
+  # For example:
+  # Returns everything because there is no overlap.
+  #   Parent: Team
+  #   Child: Projects::Site
+  #   Return value: [["Projects", "Site"], ["Team"]]
+  #
+  # Returns the namespaces/classes without the parts that overlap.
+  #   Parent: Projects::Site
+  #   Child:  Projects::Sites::Url
+  #   Return value: [["Url"], ["Site"]]
   def all_parts_in_context
     working_parts = parts
     working_parent_parts = parent_parts


### PR DESCRIPTION
I was looking over the `ClassNamesTransformer` and wasn't quite sure what this method was doing, so I added an explanation so we won't have to dig in the future to find out what's going on.

I also wonder if there is some way to refactor `replacement_for` later on in the file since there are a lot of string literals there, but I think we can do that in another PR.