### PR TITLE
Fix CI for super scaffolding tests

### DIFF
--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -92,7 +92,7 @@ jobs:
           CIRCLE_NODE_INDEX: ${{ strategy.job-index }}
 
       - name: 'Run Super Scaffolding Test'
-        run: bundle exec rails test test/system/super_scaffolding/super_scaffolding_test.rb test/system/super_scaffolding/super_scaffolding_partial_test.rb test/controllers/webhooks/incoming/some_provider_webhooks_controller_test.rb
+        run: bundle exec rails test test/system/super_scaffolding/super_scaffolding_test.rb test/system/super_scaffolding/partial_test.rb test/controllers/webhooks/incoming/some_provider_webhooks_controller_test.rb
         working-directory: tmp/starter
 
       - name: Test Summary

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -92,7 +92,7 @@ jobs:
           CIRCLE_NODE_INDEX: ${{ strategy.job-index }}
 
       - name: 'Run Super Scaffolding Test'
-        run: bundle exec rails test test/system/super_scaffolding_test.rb test/system/super_scaffolding_partial_test.rb test/controllers/webhooks/incoming/some_provider_webhooks_controller_test.rb
+        run: bundle exec rails test test/system/super_scaffolding/super_scaffolding_test.rb test/system/super_scaffolding/super_scaffolding_partial_test.rb test/controllers/webhooks/incoming/some_provider_webhooks_controller_test.rb
         working-directory: tmp/starter
 
       - name: Test Summary


### PR DESCRIPTION
The location of the super scaffolding tests in the starter repo changed with this PR: https://github.com/bullet-train-co/bullet_train/pull/1311

This updates the GitHub workflow to point to the new location.