### PR TITLE
Move current theme definition to `ApplicationHelper` in light theme gem

### DIFF
--- a/bullet_train-themes-light/app/helpers/application_helper.rb
+++ b/bullet_train-themes-light/app/helpers/application_helper.rb
@@ -1,4 +1,4 @@
-module LightThemeHelper
+module ApplicationHelper
   # override in app/helpers/application_helper.rb
   def current_theme
     :light

--- a/bullet_train-themes-light/app/helpers/theme_helper.rb
+++ b/bullet_train-themes-light/app/helpers/theme_helper.rb
@@ -1,4 +1,4 @@
-module ApplicationHelper
+module ThemeHelper
   # override in app/helpers/application_helper.rb
   def current_theme
     :light

--- a/bullet_train/docs/themes/on-jumpstart-pro-projects.md
+++ b/bullet_train/docs/themes/on-jumpstart-pro-projects.md
@@ -264,6 +264,16 @@ In `package.json`, replace the `build` and `build:css` entries under `scripts` w
 "build:css": "bin/link; THEME=\"light\" tailwindcss --postcss --minify -c ./tailwind.config.js -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.tailwind.css",
 ```
 
+### Define `current_theme` helper
+
+In your `app/helpers/application_helper.rb`, define:
+
+```
+def current_theme
+  :light
+end
+```
+
 ### Add `stylesheet_link_tag` to `<head>`
 
 Make sure you have the following three lines in your `<head>`, which should be defined in `app/views/layouts/application.html.erb`:
@@ -418,13 +428,11 @@ Add the following classes to your `html` tag for your layout:
 
 If you'd like to create your own theme but would still like to build on top of `:light`, you'll need to have both gems installed and you'll be able to switch the current theme this way.
 
-Define `current_theme` in `app/helpers/application_helper.rb`
+Change the `current_theme` value in `app/helpers/application_helper.rb`
 
 ```
-module ApplicationHelper
-  def current_theme
-    :light
-  end
+def current_theme
+  :super_custom_theme
 end
 ```
 

--- a/bullet_train/docs/themes/on-other-rails-projects.md
+++ b/bullet_train/docs/themes/on-other-rails-projects.md
@@ -94,6 +94,16 @@ Remove or comment out the following line from `esbuild.config.js`:
 "intl-tel-input-utils": path.join(process.cwd(), "app/javascript/intl-tel-input-utils.js"),
 ```
 
+### Define `current_theme` helper
+
+In your `app/helpers/application_helper.rb`, define:
+
+```
+def current_theme
+  :light
+end
+```
+
 ### Add `stylesheet_link_tag` to `<head>`
 
 Make sure you have the following three lines in your `<head>`, which should be defined in `app/views/layouts/application.html.erb`:
@@ -231,13 +241,11 @@ Add the following classes to your `html` tag for your layout:
 
 If you'd like to create your own theme but would still like to build on top of `:light`, you'll need to have both gems installed and you'll be able to switch the current theme this way.
 
-Define `current_theme` in `app/helpers/application_helper.rb`
+Change the `current_theme` value in `app/helpers/application_helper.rb`
 
 ```
-module ApplicationHelper
-  def current_theme
-    :light
-  end
+def current_theme
+  :super_custom_theme
 end
 ```
 


### PR DESCRIPTION
Context: https://discord.com/channels/836637622432170028/1214513818093228032

This doesn't account for the use of `BulletTrain::Themes::Light` in the public layout, but it should take care of the `current_theme` definition issue.