### PR TITLE
Don't render all teams in showcase

### DIFF
--- a/bullet_train-themes-light/app/views/showcase/previews/partials/_team.html.erb
+++ b/bullet_train-themes-light/app/views/showcase/previews/partials/_team.html.erb
@@ -6,10 +6,10 @@
   </ul>
 <% end %>
 
-<% if defined?(Membership.all) %>
+<% if defined?(Membership) %>
   <% showcase.sample "With Memberships" do %>
     <ol>
-      <%= render "shared/team", memberships: Membership.all do |cell| %>
+      <%= render "shared/team", memberships: Membership.limit(10) do |cell| %>
         <% cell.name "Title" %>
       <% end %>
     </ol>


### PR DESCRIPTION
On the demo site this page takes more than 15 seconds to load becuase there are over 17k `Membership` records in the database. This PR limits it to showing just 10.

![CleanShot 2024-03-29 at 12 58 47@2x](https://github.com/bullet-train-co/bullet_train-core/assets/58702/2983d86f-d5bc-44ad-a283-0a4793aec158)
