### PR TITLE
Update shared/box view

### DIFF
--- a/bullet_train-themes-light/app/views/themes/light/_box.html.erb
+++ b/bullet_train-themes-light/app/views/themes/light/_box.html.erb
@@ -36,7 +36,7 @@
       </div>
     <% end %>
 
-    <% if partial.actions? || pagy %>
+    <% if partial.actions? || (pagy && pagy.pages > 1) %>
       <div class="pb-7 px-8 space-y-7">
         <div class="sm:flex">
           <div class="flex-1 space-x">


### PR DESCRIPTION
Only add the extra div if pagy object exists and we're actually going to show the pagy nav.

Currently if we pass is a pagy object but there's only 1 page of objects, we end up with extra blank space at the bottom of the box.