### PR TITLE
Enable support of number formatting in shared/attributes/number

### DIFF
--- a/bullet_train-themes/app/views/themes/base/attributes/_number.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_number.html.erb
@@ -2,12 +2,16 @@
 <% strategy ||= current_attributes_strategy || :none %>
 <% url ||= nil %>
 <% format ||= nil %>
+<% format_helper ||= nil %>
+<% format_helper_args ||= {} %>
 <% options ||= {} %>
 
 <% if object.public_send(attribute).present? %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy do %>
     <% if format %>
       <%= sprintf(format, object.public_send(attribute)) %>
+    <% elsif format_helper %>
+      <%= ActiveSupport::NumberHelper.send(format_helper, object.public_send(attribute), **format_helper_args) %>
     <% else %>
       <%= object.public_send(attribute) %>
     <% end %>


### PR DESCRIPTION
As per https://github.com/bullet-train-co/bullet_train-core/issues/817

This supports both passing the name of the rails helper and giving it additional parameters, as follows:

```
  <%= render 'shared/attributes/number', attribute: :input_tokens, format_helper: "number_to_delimited", format_helper_args: { delimiter: '/' } %>
```