### PR TITLE
Bug fix for passing options to the `buttons` field partial

### DIFF
--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_buttons.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_buttons.html.erb
@@ -26,7 +26,7 @@ if defined?(html_options)
   )
 end
 
-button_field_options = options_for(form, method) if button_field_options.empty?
+button_field_options ||= options_for(form, method)
 
 options[:data] ||= {}
 options[:data]["#{stimulus_controller}-target"] = 'shadowField'

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_buttons.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_buttons.html.erb
@@ -5,16 +5,15 @@ form ||= current_fields_form
 # TODO: We need to do this because `options` is currently an array of strings.
 # i.e. - ["One", "Two", "Three"]
 if defined?(options) && options.is_a?(Array)
-  button_field_buttons = options
+  button_field_options = options
   options = defined?(html_options) ? html_options : {}
   ActiveSupport::Deprecation.new.warn(
     "`options` will be replaced with `button_field_options` in a later version. " \
-    "Please pass all of the strings you want to appear in your buttons to `button_field_buttons`."
+    "Please pass all of the strings you want to appear in your buttons to `button_field_options`."
   )
 end
 
 options ||= {}
-button_field_buttons ||= {}
 other_options ||= {}
 
 if defined?(html_options)
@@ -27,7 +26,7 @@ if defined?(html_options)
   )
 end
 
-button_field_options = options_for(form, method) if button_field_buttons.empty?
+button_field_options = options_for(form, method) if button_field_options.empty?
 
 options[:data] ||= {}
 options[:data]["#{stimulus_controller}-target"] = 'shadowField'

--- a/bullet_train/docs/field-partials/buttons.md
+++ b/bullet_train/docs/field-partials/buttons.md
@@ -38,7 +38,7 @@ You can allow multiple buttons to be selected using the `multiple` option, like 
 
 ```erb
 <%= render 'shared/fields/buttons', form: form, method: :category_ids,
-  options: Category.all.map { |category| [category.id, category.label_string] }, options: {multiple: true} %>
+  button_field_options: Category.all.map { |category| [category.id, category.label_string] }, options: {multiple: true} %>
 ```
 
 ## Dynamically Updating Form Fields

--- a/bullet_train/docs/field-partials/buttons.md
+++ b/bullet_train/docs/field-partials/buttons.md
@@ -25,11 +25,11 @@ en:
 
 ## Generate Buttons Programmatically
 
-You can generate the available buttons using a collection of database objects by passing the `options` option like so:
+You can generate the available buttons using a collection of database objects by passing the `button_field_options` option like so:
 
 ```erb
 <%= render 'shared/fields/buttons', form: form, method: :category_id,
-  options: Category.all.map { |category| [category.id, category.label_string] } %>
+  button_field_options: Category.all.map { |category| [category.id, category.label_string] } %>
 ```
 
 ## Allow Multiple Button Selections


### PR DESCRIPTION
In https://github.com/bullet-train-co/bullet_train-core/pull/633 we standardized the way that we pass various options to various field partials. It looks like we had some confusion about whether we were using `buttion_field_options` or `button_field_buttons` as the new variable name. We were using both in difference spots, but they didn't agree so it just didn't work.

This PR standardizes on `button_field_options` to match the pattern that we're using in other field partials. It removes `button_field_buttons`. Also updates the docs to use `button_field_options` instead of just `options`.

Fixes https://github.com/bullet-train-co/bullet_train-core/issues/815