### PR TITLE
date_and_time_field partial handles no timezone set on team

### DIFF
--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_date_and_time_field.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_date_and_time_field.html.erb
@@ -4,7 +4,7 @@ form ||= current_fields_form
 
 user_tz = defined?(current_user.time_zone) ? ActiveSupport::TimeZone.find_tzinfo(current_user.time_zone).name : nil
 
-current_team_time_zone = if current_user&.respond_to?(:current_team)
+current_team_time_zone = if current_user&.respond_to?(:current_team) && current_team.time_zone
   current_team.time_zone
 else
   "UTC"


### PR DESCRIPTION
This started happening when I updated to tag v1.7.4

If there is no timezone set on a Team (my `db:reset` did not set one by default) then checking `ActiveSupport::TimeZone.find_tzinfo(current_team_time_zone)` fails with
```
TZInfo::InvalidTimezoneIdentifier at /account/model/:id/new 
Invalid identifier: nil
```

Trace:
<img width="495" alt="image" src="https://github.com/bullet-train-co/bullet_train-core/assets/7661/40a4fb98-b865-4423-82f7-146b822cd72e">

Also, I don't see where `user_tz` is being used, but we do things like `<% if current_user&.time_zone != current_team_time_zone %>` when that should maybe be the `user_tz` calculated above. (I didn't know if that's part of this issue or not and I don't have time to dig in more now.)


