### PR TITLE
Enable corepack in CI

### DIFF
--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -63,6 +63,9 @@ jobs:
           working-directory: tmp/starter
           bundler-cache: true
 
+      - name: Enable corepack
+        run: corepack enable
+
       - name: Set up Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/_starter_repo_tests.yml
+++ b/.github/workflows/_starter_repo_tests.yml
@@ -65,6 +65,9 @@ jobs:
           working-directory: tmp/starter
           bundler-cache: true
 
+      - name: Enable corepack
+        run: corepack enable
+
       - name: Set up Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,6 +15,9 @@ jobs:
       with:
         bundler-cache: true
 
+    - name: Enable corepack
+      run: corepack enable
+
     - uses: "actions/setup-node@v3"
       with:
         node-version: '20.x'

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -28,6 +28,9 @@ jobs:
       with:
         bundler-cache: true
 
+    - name: Enable corepack
+      run: corepack enable
+
     - uses: "actions/setup-node@v3"
       with:
         node-version: '20.x'


### PR DESCRIPTION
We've updated the starter repo to use version 4 of `yarn` and to get that to work it requries running `corepack enable` prior to running the `setup-node` action.