### PR TITLE
Fixed bug in /docs/field-partials/dynamic-forms-dependent-fields.md - data must be nested under options

### DIFF
--- a/bullet_train/docs/field-partials/dynamic-forms-dependent-fields.md
+++ b/bullet_train/docs/field-partials/dynamic-forms-dependent-fields.md
@@ -53,11 +53,13 @@ To let our `:heard_from_other` field handle the `dependable:updated` event, we'l
 <%= render 'shared/fields/text_field',
     method: :heard_from_other,
     id: form.field_id(:heard_from_other),
-    options: {disabled: true},
-    data: {
-      controller: "field-availability",
-      action: "dependable:updated->field-availability#toggle",
-      field_availability_expected_value: "other"
+    options: {
+      disabled: true,
+      data: {
+        controller: "field-availability",
+        action: "dependable:updated->field-availability#toggle",
+        field_availability_expected_value: "other"
+      }
     }
 %>
 ```
@@ -114,8 +116,10 @@ We'll move the conditional on the `disabled` property. And we'll also let the `d
 
   <%= render 'shared/fields/text_field',
     method: :heard_from_other,
-    options: {disabled: form.object&.heard_from != "other"},
-    data: {"#{dependent_fields_controller_name}-target": "field"}
+    options: {
+      disabled: form.object&.heard_from != "other",
+      data: {"#{dependent_fields_controller_name}-target": "field"}
+    }
   %>
 <% end %>
 ```


### PR DESCRIPTION
I was following the example on this docs page: https://bullettrain.co/docs/field-partials/dynamic-forms-dependent-fields
I couldn't figure out why my Stimulus controller wasn't being called, and I noticed that the input element didn't have any data attributes. I saw that there was a bug in the documentation - data needs to be nested inside the options hash, otherwise it is ignored.