### PR TITLE
Better handling in super scaffolding for `_id` fields that don't incldue a `class_name` option

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/attribute.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/attribute.rb
@@ -51,6 +51,14 @@ class Scaffolding::Attribute
     options[:required] || is_first_attribute?
   end
 
+  def association_class_name
+    if options[:class_name].present?
+      return options[:class_name].underscore.split("/").last
+    end
+    class_underscored = name.split("_id").first
+    return class_underscored
+  end
+
   def is_association?
     is_belongs_to? || is_has_many?
   end

--- a/bullet_train-super_scaffolding/lib/scaffolding/attribute.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/attribute.rb
@@ -55,8 +55,7 @@ class Scaffolding::Attribute
     if options[:class_name].present?
       return options[:class_name].underscore.split("/").last
     end
-    class_underscored = name.split("_id").first
-    return class_underscored
+    name.split("_id").first
   end
 
   def is_association?

--- a/bullet_train-super_scaffolding/lib/scaffolding/script.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/script.rb
@@ -169,7 +169,7 @@ def check_required_options_for_attributes(scaffolding_type, attributes, child, p
         is_active_record_class = class_name_constant&.ancestors&.include?(ActiveRecord::Base)
         unless File.exist?(file_name) && is_active_record_class
           puts ""
-          puts "Attributes that end with `_id` or `_ids` trigger awesome, powerful magic in Super Scaffolding. However, because no `#{attribute_options[:class_name]}` class was found defined in `#{file_name}`, you'll need to specify a `class_name` that exists to let us know what model class is on the other side of the association, like so:".red
+          puts "Attributes that end with `_id` or `_ids` trigger awesome, powerful magic in Super Scaffolding. However, because no `#{attribute_options[:class_name]}` class was found defined in your app, you'll need to specify a `class_name` that exists to let us know what model class is on the other side of the association, like so:".red
           puts ""
           puts "  bin/super-scaffold #{scaffolding_type} #{child}#{" " + parent if parent.present?} #{name}:#{type}{class_name=#{name.gsub(/_ids?$/, "").classify}}".red
           puts ""

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -758,7 +758,7 @@ class Scaffolding::Transformer
         end
 
         if attribute.is_association?
-          short = attribute.options[:class_name].underscore.split("/").last
+          short = attribute.association_class_name
           case attribute.type
           when "buttons", "options"
             field_attributes["\n  options"] = "@tangible_thing.#{valid_values}.map { |#{short}| [#{short}.id, #{short}.#{attribute.options[:label]}] }"


### PR DESCRIPTION
Fixes: https://github.com/bullet-train-co/bullet_train/issues/1456
Fixes: https://github.com/bullet-train-co/bullet_train/issues/1507

This makes it so that if someone super scaffolds a field that ends with `_id` but does not explicitly include a `class_name` option then we'll try to guess the `class_name` based on the name of the field (instead of throwing a cryptic error).

For instance if you do this:

```
rails g super_scaffold Task Team event_id:super_select
```

We'll guess that `event_id` is a reference to the `Event` class. If we can find an `Event` class in your app then everything proceeds as if you had done this:

```
rails g super_scaffold Task Team event_id:super_select{class_name=Event}
```

If we can't find an `Event` model then you'll get a message saying so and telling you about the `{vanilla}` option that you can use to disable the `_id` related magic.