### PR TITLE
Raise an error if a namespaced model would clobber an existing class

### DIFF
--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/crud_scaffolder.rb
@@ -28,6 +28,8 @@ module BulletTrain
           end
 
           child = argv[0]
+          check_class_name_for_namespace_conflict(child)
+
           parents = argv[1] ? argv[1].split(",") : []
 
           # Raise an error if the developer skipped adding the parent and went straight to the attributes.

--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/join_model_scaffolder.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/join_model_scaffolder.rb
@@ -30,6 +30,8 @@ module BulletTrain
           end
 
           child = argv[0]
+          check_class_name_for_namespace_conflict(child)
+
           primary_parent = argv[1].split("class_name=").last.split(",").first.split("}").first
           secondary_parent = argv[2].split("class_name=").last.split(",").first.split("}").first
 

--- a/bullet_train-super_scaffolding/lib/scaffolding/script.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/script.rb
@@ -57,7 +57,7 @@ def check_class_name_for_namespace_conflict(class_name)
   if class_name.include?("::")
     parts = class_name.split("::") # ["Task", "Widget"]
     # We drop the last segment because that's tne new model we're trying to create
-    parts.pop() # ["Task"]
+    parts.pop # ["Task"]
     possible_conflicted_class_name = ""
     parts.each do |part|
       possible_conflicted_class_name += "::#{part}"
@@ -66,7 +66,7 @@ def check_class_name_for_namespace_conflict(class_name)
         is_active_record_class = klass&.ancestors&.include?(ActiveRecord::Base)
         is_aactive_hash_class = klass&.ancestors&.include?(ActiveHash::Base)
         if klass && (is_active_record_class || is_aactive_hash_class)
-          problematic_namespace = possible_conflicted_class_name[2..-1]
+          problematic_namespace = possible_conflicted_class_name[2..]
           puts "It looks like the namespace you gave for this model conflicts with an existing class: #{klass.name}".red
           puts "You should use a namespace that doesn't clobber an existing class.".red
           puts ""
@@ -74,7 +74,6 @@ def check_class_name_for_namespace_conflict(class_name)
           puts ""
           puts "For instance instead of #{problematic_namespace} use #{problematic_namespace.pluralize}".red
           exit
-          return problematic_namespace;
         end
       rescue NameError
         # this is good actually, it means we don't already have a class that will be clobbered

--- a/bullet_train-super_scaffolding/lib/scaffolding/script.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/script.rb
@@ -49,6 +49,40 @@ def get_untracked_files
   `git ls-files --other --exclude-standard`.split("\n")
 end
 
+# class_name is a potentially namespaced class like
+# "Tasks::Widget" or "Task::Widget". Here we ensure that
+# the namespace doesn't clobber an existing model. If it does
+# we suggest that the namespace could be pluralized.
+def check_class_name_for_namespace_conflict(class_name)
+  if class_name.include?("::")
+    parts = class_name.split("::") # ["Task", "Widget"]
+    # We drop the last segment because that's tne new model we're trying to create
+    parts.pop() # ["Task"]
+    possible_conflicted_class_name = ""
+    parts.each do |part|
+      possible_conflicted_class_name += "::#{part}"
+      begin
+        klass = possible_conflicted_class_name.constantize
+        is_active_record_class = klass&.ancestors&.include?(ActiveRecord::Base)
+        is_aactive_hash_class = klass&.ancestors&.include?(ActiveHash::Base)
+        if klass && (is_active_record_class || is_aactive_hash_class)
+          problematic_namespace = possible_conflicted_class_name[2..-1]
+          puts "It looks like the namespace you gave for this model conflicts with an existing class: #{klass.name}".red
+          puts "You should use a namespace that doesn't clobber an existing class.".red
+          puts ""
+          puts "We reccomend using the pluralized version of the existing class.".red
+          puts ""
+          puts "For instance instead of #{problematic_namespace} use #{problematic_namespace.pluralize}".red
+          exit
+          return problematic_namespace;
+        end
+      rescue NameError
+        # this is good actually, it means we don't already have a class that will be clobbered
+      end
+    end
+  end
+end
+
 def check_required_options_for_attributes(scaffolding_type, attributes, child, parent = nil)
   tableized_parent = nil
 


### PR DESCRIPTION
Fixes: https://github.com/bullet-train-co/bullet_train/issues/1457

Previously superscaffolding commands would hang indefinitely if you tried to geneate a model that has a namespace that exactly matches an existing class.

Now we'll detect that problem and will show you a message letting you know that you need to deconflict the namespace.

```
$ rails generate super_scaffold:join_model InputItem::PromptExecution prompt_execution_id{class_name=PromptExecution} input_item_id{class_name=InputItem}
It looks like the namespace you gave for this model conflicts with an existing class: InputItem
You should use a namespace that doesn't clobber an existing class.

We reccomend using the pluralized version of the existing class.

For instance instead of InputItem use InputItems
```