### PR TITLE
Fix association names when scaffolding join models if they don't match the table name

### DIFF
--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/join_model_scaffolder.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/join_model_scaffolder.rb
@@ -30,8 +30,8 @@ module BulletTrain
           end
 
           child = argv[0]
-
           check_class_name_for_namespace_conflict(child)
+
           primary_parent = argv[1].split("class_name=").last.split(",").first.split("}").first
           secondary_parent = argv[2].split("class_name=").last.split(",").first.split("}").first
 
@@ -83,7 +83,8 @@ module BulletTrain
 
           # Add the `has_many ... through:` association in both directions.
           # We pass the "opposing" attribute so that both the association name and the
-          # class name get wired up correctly
+          # class name get wired up correctly in cases where they don't match. For instance
+          # if you want an `assigned_to_membership` relationship to the `memberships` table.
           transformer.add_has_many_through_associations(has_many_through_transformer, attributes[1])
           inverse_transformer.add_has_many_through_associations(inverse_has_many_through_transformer, attributes[0])
 

--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/join_model_scaffolder.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/join_model_scaffolder.rb
@@ -30,17 +30,10 @@ module BulletTrain
           end
 
           child = argv[0]
-          child_attribute_name = child.underscore.tr("/", "_")
 
           check_class_name_for_namespace_conflict(child)
-
           primary_parent = argv[1].split("class_name=").last.split(",").first.split("}").first
-          primary_parent_attribute_name = argv[1].split("{").first.delete_suffix("_id")
-          primary_parent_attribute = argv[1]
-
           secondary_parent = argv[2].split("class_name=").last.split(",").first.split("}").first
-          secondary_parent_attribute_name = argv[2].split("{").first.delete_suffix("_id")
-          secondary_parent_attribute = argv[2]
 
           # There should only be two attributes.
           attributes = [argv[1], argv[2]]
@@ -62,13 +55,13 @@ module BulletTrain
           transformer = Scaffolding::Transformer.new(child, [primary_parent], @options)
 
           # We need this transformer to reflect on the class names _just_ between e.g. `Project` and `Projects::Tag`, without the join model.
-          has_many_through_transformer = Scaffolding::Transformer.new(secondary_parent, [primary_parent], @options, child_attribute_name, secondary_parent_attribute_name)
+          has_many_through_transformer = Scaffolding::Transformer.new(secondary_parent, [primary_parent], @options)
 
           # We need this transformer to reflect on the association between `Projects::Tag` and `Projects::AppliedTag` backwards.
           inverse_transformer = Scaffolding::Transformer.new(child, [secondary_parent], @options)
 
           # We need this transformer to reflect on the class names _just_ between e.g. `Projects::Tag` and `Project`, without the join model.
-          inverse_has_many_through_transformer = Scaffolding::Transformer.new(primary_parent, [secondary_parent], @options, child_attribute_name, primary_parent_attribute_name)
+          inverse_has_many_through_transformer = Scaffolding::Transformer.new(primary_parent, [secondary_parent], @options)
 
           # However, for the first attribute, we actually don't need the scope validator (and can't really implement it).
           attributes[0] = attributes[0].gsub("}", ",unscoped}")
@@ -89,6 +82,8 @@ module BulletTrain
           transformer.suppress_could_not_find = false
 
           # Add the `has_many ... through:` association in both directions.
+          # We pass the "opposing" attribute so that both the association name and the
+          # class name get wired up correctly
           transformer.add_has_many_through_associations(has_many_through_transformer, attributes[1])
           inverse_transformer.add_has_many_through_associations(inverse_has_many_through_transformer, attributes[0])
 

--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/join_model_scaffolder.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/join_model_scaffolder.rb
@@ -43,33 +43,14 @@ module BulletTrain
           # There should only be two attributes.
           attributes = [argv[1], argv[2]]
 
-          attributes_without_options = attributes.map { |attribute| attribute.gsub(/{.*}$/, "") }
-          attributes_without_id = attributes_without_options.map { |attribute| attribute.delete_suffix("_id") }
-          attributes_with_references = attributes_without_id.map { |attribute| attribute + ":references" }
-
           unless @options["skip-migration-generation"]
+            attributes_without_options = attributes.map { |attribute| attribute.gsub(/{.*}$/, "") }
+            attributes_without_id = attributes_without_options.map { |attribute| attribute.delete_suffix("_id") }
+            attributes_with_references = attributes_without_id.map { |attribute| attribute + ":references" }
+
             generation_command = "bin/rails generate model #{child} #{attributes_with_references.join(" ")}"
             puts "Generating model with '#{generation_command}'".green
             `#{generation_command}`
-
-            # TODO: Maybe this should go in a transformer
-            # TODO: Actually manipulate the migration
-
-            string_to_replace = "t.references :#{primary_parent_attribute_name}, null: false, foreign_key: true"
-            string_to_replace_with = "t.references :#{primary_parent_attribute_name}, null: false, foreign_key: { to_table: #{primary_parent.tableize} }"
-
-            puts "need to replace"
-            puts string_to_replace
-            puts "with"
-            puts string_to_replace_with
-
-            string_to_replace = "t.references :#{secondary_parent_attribute_name}, null: false, foreign_key: true"
-            string_to_replace_with = "t.references :#{secondary_parent_attribute_name}, null: false, foreign_key: { to_table: #{secondary_parent.tableize} }"
-
-            puts "need to replace"
-            puts string_to_replace
-            puts "with"
-            puts string_to_replace_with
           end
 
           # Pretend we're doing a `super_select` scaffolding because it will do the correct thing.

--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/join_model_scaffolder.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding/scaffolders/join_model_scaffolder.rb
@@ -36,9 +36,11 @@ module BulletTrain
 
           primary_parent = argv[1].split("class_name=").last.split(",").first.split("}").first
           primary_parent_attribute_name = argv[1].split("{").first.delete_suffix("_id")
+          primary_parent_attribute = argv[1]
 
           secondary_parent = argv[2].split("class_name=").last.split(",").first.split("}").first
           secondary_parent_attribute_name = argv[2].split("{").first.delete_suffix("_id")
+          secondary_parent_attribute = argv[2]
 
           # There should only be two attributes.
           attributes = [argv[1], argv[2]]
@@ -87,8 +89,8 @@ module BulletTrain
           transformer.suppress_could_not_find = false
 
           # Add the `has_many ... through:` association in both directions.
-          transformer.add_has_many_through_associations(has_many_through_transformer)
-          inverse_transformer.add_has_many_through_associations(inverse_has_many_through_transformer)
+          transformer.add_has_many_through_associations(has_many_through_transformer, attributes[1])
+          inverse_transformer.add_has_many_through_associations(inverse_has_many_through_transformer, attributes[0])
 
           additional_steps = (transformer.additional_steps + has_many_through_transformer.additional_steps + inverse_transformer.additional_steps + inverse_has_many_through_transformer.additional_steps).uniq
 

--- a/bullet_train-super_scaffolding/lib/scaffolding/attribute.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/attribute.rb
@@ -58,7 +58,7 @@ class Scaffolding::Attribute
     name.split("_id").first
   end
 
-  def association_table_name
+  def association_name
     association_class_name.tableize
   end
 

--- a/bullet_train-super_scaffolding/lib/scaffolding/attribute.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/attribute.rb
@@ -60,7 +60,7 @@ class Scaffolding::Attribute
 
   def association_name
     plural_association_name = association_class_name.tableize
-    is_has_many? plural_association_name : plural_association_name.singularize
+    is_has_many? ? plural_association_name : plural_association_name.singularize
   end
 
   def class_name_matches?

--- a/bullet_train-super_scaffolding/lib/scaffolding/attribute.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/attribute.rb
@@ -63,6 +63,12 @@ class Scaffolding::Attribute
   end
 
   def class_name_matches?
+    # if namespaces are involved, just don't...
+    # TODO: I'm not entirely sure that extracting this conditional was the right thing to do.
+    # Are there scenarios where we want to assume a match even when namespaces are involved?
+    if self.options[:class_name].include?("::")
+      return false
+    end
     self.name_without_id.tableize == self.options[:class_name].tableize.tr("/", "_")
   end
 

--- a/bullet_train-super_scaffolding/lib/scaffolding/attribute.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/attribute.rb
@@ -58,6 +58,14 @@ class Scaffolding::Attribute
     name.split("_id").first
   end
 
+  def association_table_name
+    association_class_name.tableize
+  end
+
+  def class_name_matches?
+    self.name_without_id.tableize == self.options[:class_name].tableize.tr("/", "_")
+  end
+
   def is_association?
     is_belongs_to? || is_has_many?
   end

--- a/bullet_train-super_scaffolding/lib/scaffolding/attribute.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/attribute.rb
@@ -58,9 +58,8 @@ class Scaffolding::Attribute
     name.split("_id").first
   end
 
-  def association_name
-    plural_association_name = association_class_name.tableize
-    is_has_many? ? plural_association_name : plural_association_name.singularize
+  def plural_association_name
+    association_class_name.tableize
   end
 
   def class_name_matches?

--- a/bullet_train-super_scaffolding/lib/scaffolding/attribute.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/attribute.rb
@@ -59,7 +59,8 @@ class Scaffolding::Attribute
   end
 
   def association_name
-    association_class_name.tableize
+    plural_association_name = association_class_name.tableize
+    is_has_many? plural_association_name : plural_association_name.singularize
   end
 
   def class_name_matches?

--- a/bullet_train-super_scaffolding/lib/scaffolding/attribute.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/attribute.rb
@@ -66,10 +66,10 @@ class Scaffolding::Attribute
     # if namespaces are involved, just don't...
     # TODO: I'm not entirely sure that extracting this conditional was the right thing to do.
     # Are there scenarios where we want to assume a match even when namespaces are involved?
-    if self.options[:class_name].include?("::")
+    if options[:class_name].include?("::")
       return false
     end
-    self.name_without_id.tableize == self.options[:class_name].tableize.tr("/", "_")
+    name_without_id.tableize == options[:class_name].tableize.tr("/", "_")
   end
 
   def is_association?

--- a/bullet_train-super_scaffolding/lib/scaffolding/class_names_transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/class_names_transformer.rb
@@ -173,7 +173,7 @@ class Scaffolding::ClassNamesTransformer
     when "absolutely_abstract_creative_concepts"
       parent_class_name_in_context.underscore.tr("/", "_").pluralize
     when "completely_concrete_tangible_things"
-      parent_attribute_name&.pluralize || class_name_in_parent_context.underscore.tr("/", "_").pluralize
+      class_name_in_parent_context.underscore.tr("/", "_").pluralize
     when "absolutely_abstract/creative_concepts"
       parent_class_name_in_context.underscore.pluralize
     when "completely_concrete/tangible_things"

--- a/bullet_train-super_scaffolding/lib/scaffolding/class_names_transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/class_names_transformer.rb
@@ -1,7 +1,7 @@
 class Scaffolding::ClassNamesTransformer
   attr_accessor :child, :parent, :namespace, :child_attribute_name, :parent_attribute_name
 
-  def initialize(child, parent, namespace = "account", child_attribute_name, parent_attribute_name)
+  def initialize(child, parent, namespace = "account", child_attribute_name = nil, parent_attribute_name = nil)
     self.child = child
     self.parent = parent
     self.namespace = namespace

--- a/bullet_train-super_scaffolding/lib/scaffolding/class_names_transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/class_names_transformer.rb
@@ -1,10 +1,12 @@
 class Scaffolding::ClassNamesTransformer
-  attr_accessor :child, :parent, :namespace
+  attr_accessor :child, :parent, :namespace, :child_attribute_name, :parent_attribute_name
 
-  def initialize(child, parent, namespace = "account")
+  def initialize(child, parent, namespace = "account", child_attribute_name, parent_attribute_name)
     self.child = child
     self.parent = parent
     self.namespace = namespace
+    self.child_attribute_name = child_attribute_name
+    self.parent_attribute_name = parent_attribute_name
   end
 
   def belongs_to_needs_class_definition?
@@ -171,7 +173,7 @@ class Scaffolding::ClassNamesTransformer
     when "absolutely_abstract_creative_concepts"
       parent_class_name_in_context.underscore.tr("/", "_").pluralize
     when "completely_concrete_tangible_things"
-      class_name_in_parent_context.underscore.tr("/", "_").pluralize
+      parent_attribute_name&.pluralize || class_name_in_parent_context.underscore.tr("/", "_").pluralize
     when "absolutely_abstract/creative_concepts"
       parent_class_name_in_context.underscore.pluralize
     when "completely_concrete/tangible_things"

--- a/bullet_train-super_scaffolding/lib/scaffolding/class_names_transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/class_names_transformer.rb
@@ -1,12 +1,10 @@
 class Scaffolding::ClassNamesTransformer
-  attr_accessor :child, :parent, :namespace, :child_attribute_name, :parent_attribute_name
+  attr_accessor :child, :parent, :namespace
 
-  def initialize(child, parent, namespace = "account", child_attribute_name = nil, parent_attribute_name = nil)
+  def initialize(child, parent, namespace = "account")
     self.child = child
     self.parent = parent
     self.namespace = namespace
-    self.child_attribute_name = child_attribute_name
-    self.parent_attribute_name = parent_attribute_name
   end
 
   def belongs_to_needs_class_definition?

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -5,7 +5,7 @@ require "scaffolding/class_names_transformer"
 require "scaffolding/attribute"
 
 class Scaffolding::Transformer
-  attr_accessor :child, :parent, :parents, :class_names_transformer, :cli_options, :additional_steps, :namespace, :suppress_could_not_find
+  attr_accessor :child, :parent, :parents, :class_names_transformer, :cli_options, :additional_steps, :namespace, :suppress_could_not_find, :attribute_name
 
   def update_models_abstract_class
   end
@@ -37,7 +37,7 @@ class Scaffolding::Transformer
   def update_action_models_abstract_class(targets_n)
   end
 
-  def initialize(child, parents, cli_options = {})
+  def initialize(child, parents, cli_options = {}, attribute_name = parents.first.underscore)
     self.child = child
     self.parent = parents.first
     self.parents = parents
@@ -45,6 +45,7 @@ class Scaffolding::Transformer
     self.class_names_transformer = Scaffolding::ClassNamesTransformer.new(child, parent, namespace)
     self.cli_options = cli_options
     self.additional_steps = []
+    self.attribute_name = attribute_name
   end
 
   RUBY_NEW_FIELDS_PROCESSING_HOOK = "# 🚅 super scaffolding will insert processing for new fields above this line."

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -5,7 +5,7 @@ require "scaffolding/class_names_transformer"
 require "scaffolding/attribute"
 
 class Scaffolding::Transformer
-  attr_accessor :child, :parent, :parents, :class_names_transformer, :cli_options, :additional_steps, :namespace, :suppress_could_not_find, :attribute_name
+  attr_accessor :child, :parent, :parents, :class_names_transformer, :cli_options, :additional_steps, :namespace, :suppress_could_not_find, :child_attribute_name, :parent_attribute_name
 
   def update_models_abstract_class
   end
@@ -37,15 +37,16 @@ class Scaffolding::Transformer
   def update_action_models_abstract_class(targets_n)
   end
 
-  def initialize(child, parents, cli_options = {}, attribute_name = parents.first.underscore)
+  def initialize(child, parents, cli_options = {}, child_attribute_name = nil, parent_attribute_name = nil)
     self.child = child
     self.parent = parents.first
     self.parents = parents
     self.namespace = cli_options["namespace"] || "account"
-    self.class_names_transformer = Scaffolding::ClassNamesTransformer.new(child, parent, namespace)
+    self.class_names_transformer = Scaffolding::ClassNamesTransformer.new(child, parent, namespace, child_attribute_name, parent_attribute_name)
     self.cli_options = cli_options
     self.additional_steps = []
-    self.attribute_name = attribute_name
+    self.child_attribute_name = child_attribute_name
+    self.parent_attribute_name = parent_attribute_name
   end
 
   RUBY_NEW_FIELDS_PROCESSING_HOOK = "# 🚅 super scaffolding will insert processing for new fields above this line."
@@ -606,7 +607,14 @@ class Scaffolding::Transformer
 
   def add_has_many_through_associations(has_many_through_transformer)
     has_many_association = add_has_many_association
-    has_many_through_string = has_many_through_transformer.transform_string("has_many :completely_concrete_tangible_things, through: :$HAS_MANY_ASSOCIATION")
+    has_many_through_parts = [
+      "has_many :completely_concrete_tangible_things",
+      "through: :$HAS_MANY_ASSOCIATION"
+    ]
+    if has_many_through_transformer.parent_attribute_name.present?
+      has_many_through_parts << "class_name: \"Scaffolding::CompletelyConcrete::TangibleThing\""
+    end
+    has_many_through_string = has_many_through_transformer.transform_string(has_many_through_parts.join(", "))
     has_many_through_string.gsub!("$HAS_MANY_ASSOCIATION", has_many_association)
     add_line_to_file(transform_string("./app/models/scaffolding/absolutely_abstract/creative_concept.rb"), has_many_through_string, HAS_MANY_HOOK, prepend: true)
   end

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -604,8 +604,6 @@ class Scaffolding::Transformer
   end
 
   def add_has_many_through_associations(has_many_through_transformer, attribute_definition)
-
-    # TODO: Do we need a real index here, instead of 0?
     attribute = Scaffolding::Attribute.new(attribute_definition, :crud_field, 0)
     has_many_association = add_has_many_association
     has_many_through_parts = [
@@ -624,7 +622,7 @@ class Scaffolding::Transformer
       # has_many :memberships, through: :assignments, class_name: "Membership"
       # into something like this:
       # has_many :assigned_to_memberships, through: :assignments, class_name: "Membership"
-      has_many_through_string.gsub!("has_many :#{attribute.association_name}"  ,"has_many :#{attribute.name_without_id.tableize}")
+      has_many_through_string.gsub!("has_many :#{attribute.association_name}", "has_many :#{attribute.name_without_id.tableize}")
     end
     add_line_to_file(transform_string("./app/models/scaffolding/absolutely_abstract/creative_concept.rb"), has_many_through_string, HAS_MANY_HOOK, prepend: true)
   end

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -624,7 +624,7 @@ class Scaffolding::Transformer
       # has_many :memberships, through: :assignments, class_name: "Membership"
       # into something like this:
       # has_many :assigned_to_memberships, through: :assignments, class_name: "Membership"
-      has_many_through_string.gsub!("has_many :#{attribute.association_table_name}"  ,"has_many :#{attribute.name_without_id.tableize}")
+      has_many_through_string.gsub!("has_many :#{attribute.association_name}"  ,"has_many :#{attribute.name_without_id.tableize}")
     end
     add_line_to_file(transform_string("./app/models/scaffolding/absolutely_abstract/creative_concept.rb"), has_many_through_string, HAS_MANY_HOOK, prepend: true)
   end
@@ -649,7 +649,6 @@ class Scaffolding::Transformer
 
     # add attributes to various views.
     attributes.each_with_index do |attribute_definition, index|
-      #debugger
       attribute = Scaffolding::Attribute.new(attribute_definition, scaffolding_options[:type], index)
 
       if attribute.is_first_attribute? && ["trix_editor", "ckeditor", "text_area"].include?(attribute.type)

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -1162,16 +1162,8 @@ class Scaffolding::Transformer
 
           end
 
-          class_name_matches = attribute.class_name_matches?
-
-          # but also, if namespaces are involved, just don't...
-          # TODO: Should this also be extracted to the attribute.class_name_matches? method?
-          if attribute.options[:class_name].include?("::")
-            class_name_matches = false
-          end
-
           # unless the table name matches the association name.
-          unless class_name_matches
+          unless attribute.class_name_matches?
             if migration_file_name
               # There are two forms this association creation can take.
               replace_in_file(migration_file_name, "foreign_key: true", "foreign_key: {to_table: \"#{attribute.options[:class_name].tableize.tr("/", "_")}\"}", /t\.references :#{attribute.name_without_id}/)
@@ -1188,7 +1180,7 @@ class Scaffolding::Transformer
           # if the `belongs_to` is already there from `rails g model`..
           scaffold_replace_line_in_file(
             "./app/models/scaffolding/completely_concrete/tangible_thing.rb",
-            class_name_matches ?
+            attribute.class_name_matches? ?
               "belongs_to :#{attribute.name_without_id}#{optional_line}" :
               "belongs_to :#{attribute.name_without_id}, class_name: \"#{attribute.options[:class_name]}\"#{optional_line}",
             "belongs_to :#{attribute.name_without_id}"
@@ -1198,7 +1190,7 @@ class Scaffolding::Transformer
           # however, this won't do anything if the association is already there.
           scaffold_add_line_to_file(
             "./app/models/scaffolding/completely_concrete/tangible_thing.rb",
-            class_name_matches ?
+            attribute.class_name_matches? ?
               "belongs_to :#{attribute.name_without_id}#{optional_line}" :
               "belongs_to :#{attribute.name_without_id}, class_name: \"#{attribute.options[:class_name]}\"#{optional_line}",
             BELONGS_TO_HOOK,

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -622,7 +622,7 @@ class Scaffolding::Transformer
       # has_many :memberships, through: :assignments, class_name: "Membership"
       # into something like this:
       # has_many :assigned_to_memberships, through: :assignments, class_name: "Membership"
-      has_many_through_string.gsub!("has_many :#{attribute.association_name}", "has_many :#{attribute.name_without_id.tableize}")
+      has_many_through_string.gsub!("has_many :#{attribute.plural_association_name}", "has_many :#{attribute.name_without_id.tableize}")
     end
     add_line_to_file(transform_string("./app/models/scaffolding/absolutely_abstract/creative_concept.rb"), has_many_through_string, HAS_MANY_HOOK, prepend: true)
   end

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -5,7 +5,7 @@ require "scaffolding/class_names_transformer"
 require "scaffolding/attribute"
 
 class Scaffolding::Transformer
-  attr_accessor :child, :parent, :parents, :class_names_transformer, :cli_options, :additional_steps, :namespace, :suppress_could_not_find, :child_attribute_name, :parent_attribute_name
+  attr_accessor :child, :parent, :parents, :class_names_transformer, :cli_options, :additional_steps, :namespace, :suppress_could_not_find
 
   def update_models_abstract_class
   end
@@ -37,16 +37,14 @@ class Scaffolding::Transformer
   def update_action_models_abstract_class(targets_n)
   end
 
-  def initialize(child, parents, cli_options = {}, child_attribute_name = nil, parent_attribute_name = nil)
+  def initialize(child, parents, cli_options = {})
     self.child = child
     self.parent = parents.first
     self.parents = parents
     self.namespace = cli_options["namespace"] || "account"
-    self.class_names_transformer = Scaffolding::ClassNamesTransformer.new(child, parent, namespace, child_attribute_name, parent_attribute_name)
+    self.class_names_transformer = Scaffolding::ClassNamesTransformer.new(child, parent, namespace)
     self.cli_options = cli_options
     self.additional_steps = []
-    self.child_attribute_name = child_attribute_name
-    self.parent_attribute_name = parent_attribute_name
   end
 
   RUBY_NEW_FIELDS_PROCESSING_HOOK = "# 🚅 super scaffolding will insert processing for new fields above this line."
@@ -621,7 +619,11 @@ class Scaffolding::Transformer
     has_many_through_string = has_many_through_transformer.transform_string(has_many_through_parts.join(", "))
     has_many_through_string.gsub!("$HAS_MANY_ASSOCIATION", has_many_association)
     unless attribute.class_name_matches?
-      #debugger
+      # This handles the case where you're generating a join model where you want association names
+      # to be different than the class name, so it'll transform something like this:
+      # has_many :memberships, through: :assignments, class_name: "Membership"
+      # into something like this:
+      # has_many :assigned_to_memberships, through: :assignments, class_name: "Membership"
       has_many_through_string.gsub!("has_many :#{attribute.association_table_name}"  ,"has_many :#{attribute.name_without_id.tableize}")
     end
     add_line_to_file(transform_string("./app/models/scaffolding/absolutely_abstract/creative_concept.rb"), has_many_through_string, HAS_MANY_HOOK, prepend: true)


### PR DESCRIPTION
Fixes the association naming problem in: https://github.com/bullet-train-co/bullet_train/issues/1508

I'm going to create a separate issue about the incorrect `valid_` method that's added on one side of the association.