### PR TITLE
Fix schema gen for classes with singleton methods

### DIFF
--- a/bullet_train-api/app/helpers/api/open_api_helper.rb
+++ b/bullet_train-api/app/helpers/api/open_api_helper.rb
@@ -65,8 +65,10 @@ module Api
 
       factory_path = "test/factories/#{model.model_name.collection}.rb"
       cache_key = [:example, model.model_name.param_key, File.ctime(factory_path)]
-      example = Rails.cache.fetch(cache_key) do
+      example = if model.name.constantize.singleton_methods.any?
         FactoryBot.example(model.model_name.param_key.to_sym)
+      else
+        Rails.cache.fetch(cache_key) { FactoryBot.example(model.model_name.param_key.to_sym) }
       end
 
       schema_json = jbuilder.json(

--- a/bullet_train-api/lib/bullet_train/api/example_bot.rb
+++ b/bullet_train-api/lib/bullet_train/api/example_bot.rb
@@ -66,13 +66,23 @@ module FactoryBot
       model_name = ActiveRecord::Base.descendants.find { |klass| klass.model_name.param_key == model.to_s }&.model_name
       factory_path = "test/factories/#{model_name.collection}.rb"
 
+      model_class = model_name.name.constantize
+
       if count > 1
         cache_key = [:example_list, model_name.param_key, File.ctime(factory_path)]
-        values = Rails.cache.fetch(cache_key) { FactoryBot.example_list(model, count) }
+        value = if model_class.singleton_methods.any?
+          FactoryBot.example_list(model, count)
+        else
+          Rails.cache.fetch(cache_key) { FactoryBot.example_list(model, count) }
+        end
         var_name = model_name.element.pluralize
       else
         cache_key = [:example, model_name.param_key, File.ctime(factory_path)]
-        values = Rails.cache.fetch(cache_key) { FactoryBot.example(model) }
+        values = if model_class.singleton_methods.any?
+          FactoryBot.example(model)
+        else
+          Rails.cache.fetch(cache_key) { FactoryBot.example(model) }
+        end
         var_name = model_name.element
       end
 

--- a/bullet_train-api/lib/bullet_train/api/example_bot.rb
+++ b/bullet_train-api/lib/bullet_train/api/example_bot.rb
@@ -70,7 +70,7 @@ module FactoryBot
 
       if count > 1
         cache_key = [:example_list, model_name.param_key, File.ctime(factory_path)]
-        value = if model_class.singleton_methods.any?
+        values = if model_class.singleton_methods.any?
           FactoryBot.example_list(model, count)
         else
           Rails.cache.fetch(cache_key) { FactoryBot.example_list(model, count) }


### PR DESCRIPTION
Doc generation currently fails if a model class has singleton methods defined since Rails cache doesn't support caching for those classes.

This skips caching for those models.