### PR TITLE
use _update_params if defined for API schema gen

### DIFF
--- a/bullet_train-api/README.md
+++ b/bullet_train-api/README.md
@@ -208,6 +208,10 @@ If the methods defined in the `automatic_paths_for` for the endpoints support
 a write action (i.e. create or update), then doc generation uses the `strong_parameters`
 defined in the corresponding controller to generate the Parameters section in the schema.
 
+If your endpoint accepts different parameters for the create and update actions, if you define `<model>_update_params` in the
+corresponding controller to define the update parameters, these will be used to generate the Parameter for the
+update method in the schema.
+
 Automatic paths are generated for basic REST actions. You can customize those paths or add your own by creating a
 file at `app/views/api/<version>/open_api/<Model.underscore.plural>/_paths.yaml.erb`. For REST paths there's no need to
 duplicate all the schema, you can specify only what differs from auto-generated code.

--- a/bullet_train-api/app/helpers/api/open_api_helper.rb
+++ b/bullet_train-api/app/helpers/api/open_api_helper.rb
@@ -101,10 +101,11 @@ module Api
 
       if has_strong_parameters?("Api::#{@version.upcase}::#{model.name.pluralize}Controller".constantize)
         strong_parameter_keys = strong_parameter_keys_for(model.name, @version)
+        strong_parameter_keys_for_update = strong_parameter_keys_for(model.name, @version, "update")
 
         # Create separate parameter schema for create and update methods
         create_parameters_output = process_strong_parameters(model, strong_parameter_keys, schema_json, "create", **options)
-        update_parameters_output = process_strong_parameters(model, strong_parameter_keys, schema_json, "update", **options)
+        update_parameters_output = process_strong_parameters(model, strong_parameter_keys_for_update, schema_json, "update", **options)
 
         # We need to skip TeamParameters, UserParameters & InvitationParametersUpdate as they are not present in
         # the bullet train api schema
@@ -144,10 +145,10 @@ module Api
       parameters_output
     end
 
-    def strong_parameter_keys_for(model_name, version)
+    def strong_parameter_keys_for(model_name, version, method_type = "create")
       strong_params_module = "::Api::#{version.upcase}::#{model_name.pluralize}Controller::StrongParameters".constantize
       strong_params_reporter = BulletTrain::Api::StrongParametersReporter.new(model_name.constantize, strong_params_module)
-      strong_parameter_keys = strong_params_reporter.report
+      strong_parameter_keys = strong_params_reporter.report(method_type)
 
       if strong_parameter_keys.last.is_a?(Hash)
         strong_parameter_keys += strong_parameter_keys.pop.keys


### PR DESCRIPTION
If an API controller has a separate set of update params defined in the StrongParameters module (using the naming convention `<model>_update_params`), the OpenAPI schema generator will auto-detect and use those parameter for that schema.