### PR TITLE
Add generators for `PerformsExport` and `PerformsImport`

### DIFF
--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding.rb
@@ -20,7 +20,9 @@ module BulletTrain
       "oauth-provider" => "BulletTrain::SuperScaffolding::Scaffolders::OauthProviderScaffolder",
       "action-models:targets-many" => "BulletTrain::ActionModels::Scaffolders::TargetsManyScaffolder",
       "action-models:targets-one" => "BulletTrain::ActionModels::Scaffolders::TargetsOneScaffolder",
-      "action-models:targets-one-parent" => "BulletTrain::ActionModels::Scaffolders::TargetsOneParentScaffolder"
+      "action-models:targets-one-parent" => "BulletTrain::ActionModels::Scaffolders::TargetsOneParentScaffolder",
+      "action-models:performs-export" => "BulletTrain::ActionModels::Scaffolders::PerformsExportScaffolder",
+      "action-models:performs-import" => "BulletTrain::ActionModels::Scaffolders::PerformsImportScaffolder"
     }
 
     class Runner

--- a/bullet_train-super_scaffolding/lib/generators/super_scaffold/action_models/performs_export/USAGE
+++ b/bullet_train-super_scaffolding/lib/generators/super_scaffold/action_models/performs_export/USAGE
@@ -1,0 +1,27 @@
+Description:
+  Generate an action to export a list of model records.
+
+Example:
+  E.g. Generate an Export action that exports many Posts from a Team.
+    rails generate super_scaffold:action_models:performs_export Export Post Team
+
+  This will create:
+    app/avo/resources/posts_export_action.rb
+    app/controllers/account/posts/
+    app/controllers/avo/posts_export_actions_controller.rb
+    app/models/posts.rb
+    app/models/posts/
+    app/views/account/posts/export_actions/
+    config/locales/en/posts/
+    db/migrate/20240612185709_create_posts_export_actions.rb
+    test/factories/posts/
+    test/models/posts/
+  And update:
+    app/models/team.rb
+    app/views/account/posts/_index.html.erb
+    config/models/roles.yml
+    config/routes.rb
+    config/routes/api/v1.rb
+
+🏆 Protip: Commit your other changes before running Super Scaffolding so it's easy to undo if you (or we) make any mistakes.
+If you do that, you can reset to your last commit state by using `git checkout .` and `git clean -d -f`.

--- a/bullet_train-super_scaffolding/lib/generators/super_scaffold/action_models/performs_export/performs_export_generator.rb
+++ b/bullet_train-super_scaffolding/lib/generators/super_scaffold/action_models/performs_export/performs_export_generator.rb
@@ -1,0 +1,36 @@
+require_relative "../../super_scaffold_base"
+require "scaffolding/routes_file_manipulator"
+
+module ActionModels
+  class PerformsExportGenerator < Rails::Generators::Base
+    include SuperScaffoldBase
+
+    source_root File.expand_path("templates", __dir__)
+
+    namespace "super_scaffold:action_models:performs_export"
+
+    argument :action_model
+    argument :target_model
+    argument :parent_model
+
+    class_option :skip_migration_generation, type: :boolean, default: false, desc: "Don't generate the model migration"
+    class_option :skip_form, type: :boolean, default: false, desc: "Don't alter the new/edit form"
+    class_option :skip_show, type: :boolean, default: false, desc: "Don't alter the show view"
+    class_option :skip_table, type: :boolean, default: false, desc: "Only add to the new/edit form and show view."
+    class_option :skip_locales, type: :boolean, default: false, desc: "Don't alter locale files"
+    class_option :skip_api, type: :boolean, default: false, desc: "Don't alter the api payloads"
+    class_option :skip_model, type: :boolean, default: false, desc: "Don't alter the model file"
+
+    def generate
+      if defined?(BulletTrain::ActionModels)
+        # We add the name of the specific super_scaffolding command that we want to
+        # invoke to the beginning of the argument string.
+        ARGV.unshift "action-models:performs-export"
+        BulletTrain::SuperScaffolding::Runner.new.run
+      else
+        puts "You must have Action Models installed if you want to use this generator.".red
+        puts "Please refer to the documentation for more information: https://bullettrain.co/docs/action-models"
+      end
+    end
+  end
+end

--- a/bullet_train-super_scaffolding/lib/generators/super_scaffold/action_models/performs_import/USAGE
+++ b/bullet_train-super_scaffolding/lib/generators/super_scaffold/action_models/performs_import/USAGE
@@ -1,0 +1,26 @@
+Description:
+  Generate an action that imports a list of records to its parent.
+
+Example:
+  E.g. Generate a CSV Importer that creates many Posts on a Team.
+    rails generate super_scaffold:action_models:performs_import CsvImport Post Team
+
+  This will create:
+    app/avo/resources/posts_import_action.rb
+    app/controllers/account/posts/import_actions_controller.rb
+    app/controllers/avo/posts_import_actions_controller.rb
+    app/models/posts/import_action.rb
+    app/views/account/posts/import_actions/
+    config/locales/en/posts/import_actions.en.yml
+    db/migrate/20240612185843_create_posts_import_actions.rb
+    test/factories/posts/import_actions.rb
+    test/models/posts/import_action_test.rb
+  And update:
+    app/models/team.rb
+    app/views/account/posts/_index.html.erb
+    config/models/roles.yml
+    config/routes.rb
+    config/routes/api/v1.rb
+
+🏆 Protip: Commit your other changes before running Super Scaffolding so it's easy to undo if you (or we) make any mistakes.
+If you do that, you can reset to your last commit state by using `git checkout .` and `git clean -d -f`.

--- a/bullet_train-super_scaffolding/lib/generators/super_scaffold/action_models/performs_import/performs_import_generator.rb
+++ b/bullet_train-super_scaffolding/lib/generators/super_scaffold/action_models/performs_import/performs_import_generator.rb
@@ -1,0 +1,36 @@
+require_relative "../../super_scaffold_base"
+require "scaffolding/routes_file_manipulator"
+
+module ActionModels
+  class PerformsImportGenerator < Rails::Generators::Base
+    include SuperScaffoldBase
+
+    source_root File.expand_path("templates", __dir__)
+
+    namespace "super_scaffold:action_models:performs_import"
+
+    argument :action_model
+    argument :model_to_process
+    argument :target_parent_model
+
+    class_option :skip_migration_generation, type: :boolean, default: false, desc: "Don't generate the model migration"
+    class_option :skip_form, type: :boolean, default: false, desc: "Don't alter the new/edit form"
+    class_option :skip_show, type: :boolean, default: false, desc: "Don't alter the show view"
+    class_option :skip_table, type: :boolean, default: false, desc: "Only add to the new/edit form and show view."
+    class_option :skip_locales, type: :boolean, default: false, desc: "Don't alter locale files"
+    class_option :skip_api, type: :boolean, default: false, desc: "Don't alter the api payloads"
+    class_option :skip_model, type: :boolean, default: false, desc: "Don't alter the model file"
+
+    def generate
+      if defined?(BulletTrain::ActionModels)
+        # We add the name of the specific super_scaffolding command that we want to
+        # invoke to the beginning of the argument string.
+        ARGV.unshift "action-models:performs-import"
+        BulletTrain::SuperScaffolding::Runner.new.run
+      else
+        puts "You must have Action Models installed if you want to use this generator.".red
+        puts "Please refer to the documentation for more information: https://bullettrain.co/docs/action-models"
+      end
+    end
+  end
+end


### PR DESCRIPTION
As we transitioned to using generators we somehow dropped support for these two ActionModels.

This is just a quick and dirty PR to get things working. There may be additional options we should add (or existing options we should remove) in the future as these get used.