### PR TITLE
Fixes for automatically setting user timezone during sign up

### DIFF
--- a/bullet_train/app/views/account/onboarding/user_details/edit.html.erb
+++ b/bullet_train/app/views/account/onboarding/user_details/edit.html.erb
@@ -48,7 +48,7 @@
 <% end %>
 
 <script type="text/javascript">
-  document.addEventListener('turbo:load', function() {
+  function btSetUserTimeZone(){
 
     // generate a mapping of js timezones compared to rails timezones.
     var jsTimezoneMapping = {
@@ -67,10 +67,17 @@
       var option = document.querySelector("#user_time_zone option[value=\"" + railsValue + "\"]")
       if(option){
         document.querySelector("#user_time_zone").value = railsValue;
+
+        // update the select2 as well. is there a better way to handle this?
+        // why don't _they_ handle this for us?
+        var select2 = document.querySelector("#select2-user_time_zone-container");
+        select2.attributes.title = option.text;
+        select2.textContent = option.text;
       }else{
         console.log('We were unable to find a timezone matching the rails detected value of ', railsValue);
       }
     }
 
-  });
+  }
+  document.addEventListener('turbo:load', btSetUserTimeZone, { once: true });
 </script>


### PR DESCRIPTION
This PR fixes a couple of problems with detecting and setting the users timezone during sign up.

1.  It updates the select2 instance to reflect the underlying data. For some reason select2 was showing the right thing if you reloaded the `user_details/edit` page, but not when the page first loaded after creating an account.
2.  It makes it so that the event listener that sets the timezone is registered to only be run once. Previously after signing up you'd see errors in the console as you navigated to other pages. The errors were due to the timezone detection function being run on pages where the expected DOM elements were missing.

Fixes: https://github.com/bullet-train-co/bullet_train/issues/1504