### PR TITLE
Update super scaffolding workflow to match the starter repo

### DIFF
--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # For super scaffolding tests we need to have exactly 7 runners.
-        ci_runners: [TestSite, Project, 'Project::Step', Insight, 'Personality::Disposition', 'Personality::Observation', TestFile]
+        # For super scaffolding tests we need to have exactly 5 runners.
+        ci_runners: ["TestSite, Project", "Project::Step, Insight", "Personality::Disposition, Personality::Observation", "TestFile, PartialTest", Webhook]
     services:
       postgres:
         image: postgres:11-alpine
@@ -95,8 +95,12 @@ jobs:
           CIRCLE_NODE_INDEX: ${{ strategy.job-index }}
 
       - name: 'Run Super Scaffolding Test'
-        run: bin/rails test test/system/super_scaffolding/ test/controllers/webhooks/incoming/some_provider_webhooks_controller_test.rb
+        run: bin/rails test test/system/super_scaffolding/
         working-directory: tmp/starter
+
+      - name: 'Run Super Scaffolding Webhook Test'
+        run: bin/rails test test/controllers/webhooks/incoming/some_provider_webhooks_controller_test.rb
+        if: ${{ strategy.job-index == 5 }}
 
       - name: Test Summary
         uses: test-summary/action@v2


### PR DESCRIPTION
We made some changes to how super scaffold tests in the starter repo are run here: https://github.com/bullet-train-co/bullet_train/pull/1541

This PR just upates the core repo to do the same thing.