### PR TITLE
Fix indentation on controller test generated by super scaffolding

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -1396,16 +1396,11 @@ class Scaffolding::Transformer
       test_name = transform_string("./test/controllers/api/v1/scaffolding/completely_concrete/tangible_things_controller_test.rb")
       test_lines = File.open(test_name).readlines
 
-      # Shift contents of controller test after skipping `unless scaffolding_things_disabled?` block.
-      class_block_index = Scaffolding::FileManipulator.find(test_lines, "class #{transform_string("Api::V1::Scaffolding::CompletelyConcrete::TangibleThingsControllerTest")}")
-      new_lines = Scaffolding::BlockManipulator.shift_block(lines: test_lines, block_start: test_lines[class_block_index], shift_contents_only: true)
-      Scaffolding::FileManipulator.write(test_name, new_lines)
-
       # Ensure variables built with factories are indented properly.
-      factory_hook_index = Scaffolding::FileManipulator.find(new_lines, RUBY_FACTORY_SETUP_HOOK)
-      factory_hook_indentation = Scaffolding::BlockManipulator.indentation_of(factory_hook_index, new_lines)
+      factory_hook_index = Scaffolding::FileManipulator.find(test_lines, RUBY_FACTORY_SETUP_HOOK)
+      factory_hook_indentation = Scaffolding::BlockManipulator.indentation_of(factory_hook_index, test_lines)
       indented_factory_lines = build_factory_setup.map { |line| "#{factory_hook_indentation}#{line}\n" }
-      scaffold_replace_line_in_file(test_name, indented_factory_lines.join, new_lines[factory_hook_index])
+      scaffold_replace_line_in_file(test_name, indented_factory_lines.join, test_lines[factory_hook_index])
     end
 
     # add children to the show page of their parent.


### PR DESCRIPTION
In https://github.com/bullet-train-co/bullet_train/pull/1207 we changed how the template controller test is structured. But we didn't updated the super scaffolder to accomodate the change in structure.

Since we no longer wrap the entire test in `unless scaffolding_things_disabled?` now we don't need to remove the indentation that was previously there due to that conditional.

Fixes https://github.com/bullet-train-co/bullet_train/issues/1519