### PR TITLE
Bug fix for `devise-two-factor` missing `$` and some documentation robustification

### DIFF
--- a/bullet_train/app/views/account/two_factors/create.js.erb
+++ b/bullet_train/app/views/account/two_factors/create.js.erb
@@ -1,1 +1,1 @@
-$("#two-factor").html("<%= j render partial: "devise/registrations/two_factor"%>");
+jQuery("#two-factor").html("<%= j render partial: "devise/registrations/two_factor"%>");

--- a/bullet_train/app/views/account/two_factors/destroy.js.erb
+++ b/bullet_train/app/views/account/two_factors/destroy.js.erb
@@ -1,1 +1,1 @@
-$("#two-factor").html("<%= j render partial: "devise/registrations/two_factor"%>");
+jQuery("#two-factor").html("<%= j render partial: "devise/registrations/two_factor"%>");

--- a/bullet_train/app/views/account/two_factors/verify.js.erb
+++ b/bullet_train/app/views/account/two_factors/verify.js.erb
@@ -1,1 +1,1 @@
-$("#two-factor").html("<%= j render partial: "devise/registrations/two_factor", locals: {verified: @verified}%>");
+jQuery("#two-factor").html("<%= j render partial: "devise/registrations/two_factor", locals: {verified: @verified}%>");

--- a/bullet_train/app/views/devise/sessions/pre_otp.js.erb
+++ b/bullet_train/app/views/devise/sessions/pre_otp.js.erb
@@ -1,11 +1,12 @@
 <% if @email %>
-  $("#step-1").addClass("hidden");
-  $("#step-2").removeClass("hidden");
+  document.querySelector("#step-1").classList.add("hidden");
+  document.querySelector("#step-2").classList.remove("hidden");
   <% if @user&.otp_required_for_login %>
-  $("#step-2-otp").removeClass("hidden");
+  document.querySelector("#step-2-otp").classList.remove("hidden");
   <% end %>
   setTimeout(function() {
-    $("#user_password").focus();
-    $("#new_user").attr('action', '/users/sign_in').attr('data-remote', 'false');
+    document.querySelector("#user_password").focus();
+    document.querySelector("#new_user").setAttribute('action', '/users/sign_in')
+    document.querySelector("#new_user").setAttribute('data-remote', 'false');
   }, 1);
 <% end %>

--- a/bullet_train/docs/authentication.md
+++ b/bullet_train/docs/authentication.md
@@ -24,8 +24,49 @@ If you want to disable new registrations completely, put an unguessable value in
 Note that in both of these scenarios that existing users will still be able to invite new collaborators to their teams and those collaborators will have the option of creating a new account, but no users in the application will be allowed to create a new team without an invitation code and following the above URL.
 
 ## Enabling Two-Factor Authentication (2FA)
-Two-factor authentication is enabled by default in Bullet Train, but you must have Rails built-in encrypted secrets and Active Record Encryption configured. To do this, just run:
+Two-factor authentication is enabled by default in Bullet Train, but you must have Rails built-in encrypted secrets and Active Record Encryption configured.
+
+To do this, first run:
 
 ```
 bin/secrets
 ```
+
+That will generate some credentails files for you.
+
+Then you'll need to set encryption keys, either in those newly generated credentials files, or you can do it via environment variables.
+
+Generate some keys by running:
+
+```
+bin/rails db:encryption:init
+```
+
+That will output something like this:
+
+```
+active_record_encryption:
+  primary_key: NLngkt...
+  deterministic_key: edpu...
+  key_derivation_salt: Bfwy...
+```
+
+Then to add them to your `development` credentials file run:
+
+```
+bin/rails credentials:edit --environment development
+```
+
+That will decrypt `config/credentials/development.yml.enc` and open it in your editor. Paste in the block of keys you generated in the previous step, save, and close the file.
+
+If you'd rather set them via environment variables you could add something like this to `config/application.rb`:
+
+```
+config.active_record.encryption.primary_key = ENV['ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY']
+config.active_record.encryption.deterministic_key = ENV['ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY']
+config.active_record.encryption.key_derivation_salt = ENV['ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT']
+```
+
+And then populate those ENV variables by whatever means you use. (Maybe setting them in `.env` or possibly exporting them directly.)
+
+After you have things working in development you'll need to follow the same process for your production environment, and any others.


### PR DESCRIPTION
Fixes https://github.com/bullet-train-co/bullet_train/issues/1555
Fixes https://github.com/bullet-train-co/bullet_train/issues/1556

The files in `bullet_train/app/views/account/two_factors/` still rely on a global `jQuery` object.

I tried to change them from this pattern:

```javascript
jQuery("#two-factor").html("<%= j render partial: "devise/registrations/two_factor"%>");
```

To this pattern:

```javascript
document.querySelector("#two-factor").innerHtml = "<%= j render partial: "devise/registrations/two_factor"%>";
```

But after I did that clicking the "Enable" button in the MFA setup area just didn't do anything. Not sure why.