### PR TITLE
Fix Trix link dialog in dark mode

### DIFF
--- a/bullet_train-themes-light/app/assets/stylesheets/light/tailwind/dark-mode.css
+++ b/bullet_train-themes-light/app/assets/stylesheets/light/tailwind/dark-mode.css
@@ -132,6 +132,18 @@
       .trix-button:disabled::before {
         @apply opacity-25;
       }
+
+      .trix-dialog {
+        @apply bg-slate-800 border-slate-900 shadow-lg shadow-slate-900 !important;
+
+        .trix-button--dialog {
+          @apply text-white ;
+        }
+
+        .trix-input--dialog {
+          @apply bg-slate-800 dark:text-slate-300 focus:ring-primary-500 focus:border-primary-500;
+        }
+      }
     }
 
     .tribute-container {

--- a/bullet_train-themes-light/app/assets/stylesheets/light/tailwind/dark-mode.css
+++ b/bullet_train-themes-light/app/assets/stylesheets/light/tailwind/dark-mode.css
@@ -137,7 +137,7 @@
         @apply bg-slate-800 border-slate-900 shadow-lg shadow-slate-900 !important;
 
         .trix-button--dialog {
-          @apply text-white ;
+          @apply text-white;
         }
 
         .trix-input--dialog {


### PR DESCRIPTION
Fixes #849 

Adds missing the styling for the link dialog in `dark-mode.css`.

Before:

![CleanShot 2024-06-07 at 11 18 11@2x](https://github.com/bullet-train-co/bullet_train-core/assets/104179/3b5fff60-c81c-49b0-bbbe-a50135cb2860)

After:

![CleanShot 2024-06-28 at 13 38 30@2x](https://github.com/bullet-train-co/bullet_train-core/assets/104179/302cee33-f55c-4a3f-a570-b414534500e2)

