### PR TITLE
WIP: Fix attachments in the Trix editor

### DIFF
--- a/bullet_train-fields/app/helpers/fields/html_editor_helper.rb
+++ b/bullet_train-fields/app/helpers/fields/html_editor_helper.rb
@@ -5,7 +5,7 @@ module Fields::HtmlEditorHelper
     return string unless string
     # TODO this is a hack to get around the fact that rails doesn't allow us to add any acceptable protocols.
     string = string.gsub("bullettrain://", TEMPORARY_REPLACEMENT)
-    string = sanitize(string, tags: %w[div br strong em b i del a h1 blockquote pre ul ol li], attributes: %w[href])
+    string = sanitize(string, tags: %w[div br strong em b i del a h1 blockquote pre ul ol li action-text-attachment figure figcaption img], attributes: %w[href sgid content-type url filename filesize width height presentation src class])
     # given the limited scope of what we're doing here, this string replace should work.
     # it should also use a lot less memory than nokogiri.
     string = string.gsub(/<a href="#{TEMPORARY_REPLACEMENT}(.*?)\/.*?">(.*?)<\/a>/o, "<span class=\"tribute-reference tribute-\\1-reference\">\\2</span>").html_safe

--- a/bullet_train-themes/app/views/themes/base/attributes/_html.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_html.html.erb
@@ -6,7 +6,7 @@
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
     <% # Here we manually add a trix-content class since sanitizing the body removes the Rails default. %>
     <% if object.send(attribute).is_a?(ActionText::RichText) %>
-      <%= tag.div(html_sanitize(object.public_send(attribute).body.to_trix_html).html_safe, class:"trix-content") %>
+      <%= tag.div(html_sanitize(object.public_send(attribute).body.to_s).html_safe, class:"trix-content") %>
     <% else %>
       <% # `.to_s` is for action text. %>
       <%= html_sanitize(object.public_send(attribute).to_s).html_safe %>


### PR DESCRIPTION
We were incorrectly sanitizing rich text content and were overzealously removing important elements that should be passed through.