### PR TITLE
Remove a redundant `.trix-content` div

### DIFF
--- a/bullet_train-themes/app/views/themes/base/attributes/_html.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_html.html.erb
@@ -4,9 +4,8 @@
 
 <% if object.public_send(attribute).present? %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
-    <% # Here we manually add a trix-content class since sanitizing the body removes the Rails default. %>
     <% if object.send(attribute).is_a?(ActionText::RichText) %>
-      <%= tag.div(html_sanitize(object.public_send(attribute).body.to_s).html_safe, class:"trix-content") %>
+      <%= html_sanitize(object.public_send(attribute).body.to_s).html_safe %>
     <% else %>
       <% # `.to_s` is for action text. %>
       <%= html_sanitize(object.public_send(attribute).to_s).html_safe %>


### PR DESCRIPTION
Previously we were manually adding a `div.trix-content` element but we only needed to do that because we didn't have a file in place that is created when you run `rails action_text:install`. I've added that file in the starter repo, where devs would normally expect to find it, so we don't need to manually add the div anymore.

https://github.com/bullet-train-co/bullet_train/pull/1583/files#diff-77f493605c04a022c76dff16f1eca94e25e08854d33261e06ea0d7144302bf74