### PR TITLE
Pass attribute down to _base partial

### DIFF
--- a/bullet_train-themes/app/views/themes/base/attributes/_attribute.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_attribute.html.erb
@@ -2,7 +2,7 @@
 <% strategy ||= current_attributes_strategy || :none %>
 <% url ||= nil %>
 
-<%= render 'shared/attributes/base', strategy: strategy, url: url do |p| %>
+<%= render 'shared/attributes/base', strategy: strategy, url: url, attribute: attribute do |p| %>
   <% p.heading t("#{object.class.name.pluralize.underscore}.fields.#{attribute}.heading", default: object.class.human_attribute_name(attribute)) %>
   <% p.body yield %>
 <% end %>


### PR DESCRIPTION
I would love to pass `attribute` down to the theme's `attributes/_base` partial.

That would allow for more versatile _strategies_ to be crafted.