### PR TITLE
Improve file fields with the `multiple` option

### DIFF
--- a/bullet_train-fields/app/javascript/controllers/fields/file_field_controller.js
+++ b/bullet_train-fields/app/javascript/controllers/fields/file_field_controller.js
@@ -114,18 +114,7 @@ export default class extends Controller {
 
     if(files.length){
       for (const file of files) {
-        let fileElement = document.createElement('div');
-        fileElement.classList.add('py-1', 'flex', 'flex-wrap', 'items-center');
-        let nameElement = document.createElement('div');
-        nameElement.innerText = file.name;
-        let removeElement = document.createElement('span');
-        removeElement.innerText = "Cancel"
-        removeElement.dataset.action = "click->fields--file-field#cancelFileUpload"
-        removeElement.dataset.filename = file.name;
-        removeElement.classList.add('button-alternative','cursor-pointer', 'ml-auto');
-        fileElement.appendChild(nameElement);
-        fileElement.appendChild(removeElement);
-        this.selectedFileListTarget.appendChild(fileElement);
+        this.addSelectedFile(file);
       }
       statusText.innerText = "Select A Different File";
       icon.classList.remove("ti-upload");
@@ -137,6 +126,21 @@ export default class extends Controller {
       icon.classList.remove("ti-check");
       this.selectedFileListContainerTarget.classList.add('hidden')
     }
+  }
+
+  addSelectedFile(file){
+    let fileElement = document.createElement('div');
+    fileElement.classList.add('py-1', 'flex', 'flex-wrap', 'items-center');
+    let nameElement = document.createElement('div');
+    nameElement.innerText = file.name;
+    let removeElement = document.createElement('span');
+    removeElement.innerText = "Cancel"
+    removeElement.dataset.action = "click->fields--file-field#cancelFileUpload"
+    removeElement.dataset.filename = file.name;
+    removeElement.classList.add('button-alternative','cursor-pointer', 'ml-auto');
+    fileElement.appendChild(nameElement);
+    fileElement.appendChild(removeElement);
+    this.selectedFileListTarget.appendChild(fileElement);
   }
 
 }

--- a/bullet_train-fields/app/javascript/controllers/fields/file_field_controller.js
+++ b/bullet_train-fields/app/javascript/controllers/fields/file_field_controller.js
@@ -9,6 +9,7 @@ export default class extends Controller {
     "selectFileButton",
     "selectedFileListContainer",
     "selectedFileList",
+    "selectedFileRowTemplate",
     "progressBar",
     "progressLabel",
   ];
@@ -129,18 +130,9 @@ export default class extends Controller {
   }
 
   addSelectedFile(file){
-    let fileElement = document.createElement('div');
-    fileElement.classList.add('py-1', 'flex', 'flex-wrap', 'items-center');
-    let nameElement = document.createElement('div');
-    nameElement.innerText = file.name;
-    let removeElement = document.createElement('span');
-    removeElement.innerText = "Cancel"
-    removeElement.dataset.action = "click->fields--file-field#cancelFileUpload"
-    removeElement.dataset.filename = file.name;
-    removeElement.classList.add('button-alternative','cursor-pointer', 'ml-auto');
-    fileElement.appendChild(nameElement);
-    fileElement.appendChild(removeElement);
-    this.selectedFileListTarget.appendChild(fileElement);
+    let template = this.selectedFileRowTemplateTarget.innerHTML;
+    template = template.replaceAll("@FILENAME@", file.name);
+    this.selectedFileListTarget.insertAdjacentHTML('beforeend', template);
   }
 
 }

--- a/bullet_train-fields/app/javascript/controllers/fields/file_field_controller.js
+++ b/bullet_train-fields/app/javascript/controllers/fields/file_field_controller.js
@@ -7,6 +7,8 @@ export default class extends Controller {
     "downloadFileButton",
     "removeFileButton",
     "selectFileButton",
+    "selectFileButtonText",
+    "selectFileButtonIcon",
     "selectedFileListContainer",
     "selectedFileList",
     "selectedFileRowTemplate",
@@ -19,7 +21,7 @@ export default class extends Controller {
   }
 
   connect() {
-    const statusText = this.selectFileButtonTarget.querySelector("span");
+    const statusText = this.selectFileButtonTextTarget;
     this.originalStatusText = statusText.innerText;
 
     // Add upload event listeners
@@ -112,8 +114,8 @@ export default class extends Controller {
   }
 
   updateSelectedFileList(files){
-    const statusText = this.selectFileButtonTarget.querySelector("span");
-    const icon = this.selectFileButtonTarget.querySelector("i");
+    const statusText = this.selectFileButtonTextTarget;
+    const icon = this.selectFileButtonIconTarget;
 
     this.selectedFileListTarget.innerHTML = "";
 

--- a/bullet_train-fields/app/javascript/controllers/fields/file_field_controller.js
+++ b/bullet_train-fields/app/javascript/controllers/fields/file_field_controller.js
@@ -7,11 +7,16 @@ export default class extends Controller {
     "downloadFileButton",
     "removeFileButton",
     "selectFileButton",
+    "selectedFileListContainer",
+    "selectedFileList",
     "progressBar",
     "progressLabel",
   ];
 
   connect() {
+    const statusText = this.selectFileButtonTarget.querySelector("span");
+    this.originalStatusText = statusText.innerText;
+
     // Add upload event listeners
     const initializeListener = document.addEventListener(
       "direct-upload:initialize",
@@ -77,16 +82,61 @@ export default class extends Controller {
     this.removeFileFlagTarget.value = true;
   }
 
-  handleFileSelected() {
-    const statusText = this.selectFileButtonTarget.querySelector("span");
-    const icon = this.selectFileButtonTarget.querySelector("i");
-
+  handleFileSelected(event) {
     if (this.hasDownloadFileButtonTarget) {
       this.downloadFileButtonTarget.remove();
     }
 
-    statusText.innerText = "Select Another File";
-    icon.classList.remove("ti-upload");
-    icon.classList.add("ti-check");
+    const files = event.target.files;
+    this.updateSelectedFileList(files);
   }
+
+  cancelFileUpload(event){
+    const fileInput = this.fileFieldTarget;
+    const files = fileInput.files;
+    const fileToCancel = event.target.dataset.filename;
+
+    const dt = new DataTransfer();
+    for (const file of files) {
+      if(file.name != fileToCancel){
+        dt.items.add(file);
+      }
+    }
+    fileInput.files = dt.files;
+    this.updateSelectedFileList(dt.files);
+  }
+
+  updateSelectedFileList(files){
+    const statusText = this.selectFileButtonTarget.querySelector("span");
+    const icon = this.selectFileButtonTarget.querySelector("i");
+
+    this.selectedFileListTarget.innerHTML = "";
+
+    if(files.length){
+      for (const file of files) {
+        let fileElement = document.createElement('div');
+        fileElement.classList.add('py-1', 'flex', 'flex-wrap', 'items-center');
+        let nameElement = document.createElement('div');
+        nameElement.innerText = file.name;
+        let removeElement = document.createElement('span');
+        removeElement.innerText = "Cancel"
+        removeElement.dataset.action = "click->fields--file-field#cancelFileUpload"
+        removeElement.dataset.filename = file.name;
+        removeElement.classList.add('button-alternative','cursor-pointer', 'ml-auto');
+        fileElement.appendChild(nameElement);
+        fileElement.appendChild(removeElement);
+        this.selectedFileListTarget.appendChild(fileElement);
+      }
+      statusText.innerText = "Select A Different File";
+      icon.classList.remove("ti-upload");
+      icon.classList.add("ti-check");
+      this.selectedFileListContainerTarget.classList.remove('hidden')
+    }else{
+      statusText.innerText = this.originalStatusText;
+      icon.classList.add("ti-upload");
+      icon.classList.remove("ti-check");
+      this.selectedFileListContainerTarget.classList.add('hidden')
+    }
+  }
+
 }

--- a/bullet_train-fields/app/javascript/controllers/fields/file_field_controller.js
+++ b/bullet_train-fields/app/javascript/controllers/fields/file_field_controller.js
@@ -14,6 +14,10 @@ export default class extends Controller {
     "progressLabel",
   ];
 
+  static values = {
+    selectDifferentFile: String
+  }
+
   connect() {
     const statusText = this.selectFileButtonTarget.querySelector("span");
     this.originalStatusText = statusText.innerText;
@@ -117,7 +121,7 @@ export default class extends Controller {
       for (const file of files) {
         this.addSelectedFile(file);
       }
-      statusText.innerText = "Select A Different File";
+      statusText.innerText = this.selectDifferentFileValue;
       icon.classList.remove("ti-upload");
       icon.classList.add("ti-check");
       this.selectedFileListContainerTarget.classList.remove('hidden')

--- a/bullet_train-fields/app/javascript/controllers/fields/file_item_controller.js
+++ b/bullet_train-fields/app/javascript/controllers/fields/file_item_controller.js
@@ -5,19 +5,34 @@ export default class extends Controller {
     "removeFileFlag",
     "downloadFileButton",
     "removeFileButton",
+    "cancelRemoveFileButton",
     "fileName"
   ];
 
   static values = { id: Number }
 
   removeFile() {
+    console.log('running removeFile 2')
     if (this.hasDownloadFileButtonTarget) {
       this.downloadFileButtonTarget.classList.add("hidden");
     }
 
     this.removeFileButtonTarget.classList.add("hidden");
-    this.fileNameTarget.classList.add("hidden");
+    this.cancelRemoveFileButtonTarget.classList.remove("hidden");
     this.removeFileFlagTarget.value = this.idValue;
+    this.element.classList.add("bg-red-100", "dark:bg-red-700");
+  }
+
+  cancelRemoveFile(){
+    console.log('running cancelRemoveFile')
+    if (this.hasDownloadFileButtonTarget) {
+      this.downloadFileButtonTarget.classList.remove("hidden");
+    }
+
+    this.removeFileButtonTarget.classList.remove("hidden");
+    this.cancelRemoveFileButtonTarget.classList.add("hidden");
+    this.removeFileFlagTarget.value = null;
+    this.element.classList.remove("bg-red-100", "dark:bg-red-700");
   }
 
 }

--- a/bullet_train-fields/app/javascript/controllers/fields/file_item_controller.js
+++ b/bullet_train-fields/app/javascript/controllers/fields/file_item_controller.js
@@ -30,7 +30,7 @@ export default class extends Controller {
     this.removeFileButtonTarget.classList.remove("hidden");
     this.cancelRemoveFileButtonTarget.classList.add("hidden");
     this.removeFileFlagTarget.value = null;
-    this.element.classList.remove("bg-red-100", "dark:bg-red-700");
+    this.element.classList.remove("bg-red-100", "dark:bg-red-700/40");
   }
 
 }

--- a/bullet_train-fields/app/javascript/controllers/fields/file_item_controller.js
+++ b/bullet_train-fields/app/javascript/controllers/fields/file_item_controller.js
@@ -12,7 +12,6 @@ export default class extends Controller {
   static values = { id: Number }
 
   removeFile() {
-    console.log('running removeFile 2')
     if (this.hasDownloadFileButtonTarget) {
       this.downloadFileButtonTarget.classList.add("hidden");
     }
@@ -24,7 +23,6 @@ export default class extends Controller {
   }
 
   cancelRemoveFile(){
-    console.log('running cancelRemoveFile')
     if (this.hasDownloadFileButtonTarget) {
       this.downloadFileButtonTarget.classList.remove("hidden");
     }

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/attributes/_file.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/attributes/_file.erb
@@ -6,7 +6,7 @@
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
     <%= link_to url_for(object.public_send(attribute)), class: 'button download-file' do %>
       <i class="leading-none mr-2 text-base ti ti-download"></i>
-      <span><%= t("global.file_fields.download") %></span>
+      <span><%= t("global.file_fields.download") %> - <%= object.public_send(attribute).filename %></span>
     <% end %>
   <% end %>
 <% end %>

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/attributes/_files.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/attributes/_files.erb
@@ -6,7 +6,7 @@
     <% object.send(attribute).each do |file| %>
       <%= link_to url_for(file), class: 'button download-file' do %>
         <i class="leading-none mr-2 text-base ti ti-download"></i>
-        <span>Download File</span>
+        <span><%= t("global.file_fields.download") %> - <%= file.filename %></span>
       <% end %>
     <% end %>
   <% end %>

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_file_field.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_file_field.html.erb
@@ -68,8 +68,8 @@ persisted_files = options[:multiple] ? form.object.send(method) : [form.object.s
           </template>
         </div>
         <div class="button-alternative cursor-pointer" data-action="click->fields--file-field#uploadFile" data-fields--file-field-target="selectFileButton">
-          <i class="leading-none mr-2 text-base ti ti-upload dark:text-white"></i>
-          <span class="dark:text-white">
+          <i class="leading-none mr-2 text-base ti ti-upload dark:text-white" data-fields--file-field-target="selectFileButtonIcon"></i>
+          <span class="dark:text-white" data-fields--file-field-target="selectFileButtonText">
             <% if form.object.send(method).attached? && !options[:multiple] %>
               <%= t('fields.replace_document') %>
             <% elsif form.object.send(method).attached? && options[:multiple] %>

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_file_field.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_file_field.html.erb
@@ -29,9 +29,9 @@ persisted_files = options[:multiple] ? form.object.send(method) : [form.object.s
         <% if form.object.send(method).attached? %>
           <div class="divide-y-2 divide-dashed">
             <% persisted_files.each do |file| %>
-              <div data-controller="fields--file-item" data-fields--file-item-id-value="<%= file.id %>">
+              <div data-controller="fields--file-item" data-fields--file-item-id-value="<%= file.id %>" class="py-1 flex flex-wrap items-center">
                 <%= form.hidden_field "#{method}_removal".to_sym, multiple: options[:multiple], value: nil, data: {'fields--file-item-target': 'removeFileFlag'} %>
-                <span data-fields--file-item-target="fileName" %>
+                <span data-fields--file-item-target="fileName" class="mr-auto"%>
                   <%= file.blob.filename %>
                 </span>
                 <%= link_to url_for(file), class: 'button download-file mr-3', data: {'fields--file-item-target': 'downloadFileButton'} do %>
@@ -42,12 +42,23 @@ persisted_files = options[:multiple] ? form.object.send(method) : [form.object.s
                   <i class="leading-none mr-2 text-base ti ti-trash"></i>
                   <span><%= t('fields.remove_document') %></span>
                 </div>
+                <div class="button-alternative cursor-pointer mr-3 hidden" data-action="click->fields--file-item#cancelRemoveFile" data-fields--file-item-target="cancelRemoveFileButton">
+                  <i class="leading-none mr-2 text-base ti ti-na"></i>
+                  <span><%= t('fields.cancel_remove_document') %></span>
+                </div>
               </div>
             <% end %>
           </div>
         <% end %>
       </div>
       <div class="mt-2">
+        <div data-fields--file-field-target="selectedFileListContainer" class="hidden mb-2">
+          <div class="dark:text-white mb-1">
+            To upload:
+          </div>
+          <div data-fields--file-field-target="selectedFileList" class="divide-y-2 divide-dashed">
+          </div>
+        </div>
         <div class="button-alternative cursor-pointer" data-action="click->fields--file-field#uploadFile" data-fields--file-field-target="selectFileButton">
           <i class="leading-none mr-2 text-base ti ti-upload dark:text-white"></i>
           <span class="dark:text-white">

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_file_field.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_file_field.html.erb
@@ -50,7 +50,15 @@ persisted_files = options[:multiple] ? form.object.send(method) : [form.object.s
       <div class="mt-2">
         <div class="button-alternative cursor-pointer" data-action="click->fields--file-field#uploadFile" data-fields--file-field-target="selectFileButton">
           <i class="leading-none mr-2 text-base ti ti-upload dark:text-white"></i>
-          <span class="dark:text-white"><%= t('fields.upload_document') %></span>
+          <span class="dark:text-white">
+            <% if form.object.send(method).attached? && !options[:multiple] %>
+              <%= t('fields.replace_document') %>
+            <% elsif form.object.send(method).attached? && options[:multiple] %>
+              <%= t('fields.add_another_document') %>
+            <% else %>
+              <%= t('fields.upload_document') %>
+            <% end %>
+          </span>
         </div>
         <div class="mt-2 hidden overflow-hidden text-xs rounded bg-slate-100 shadow-inner relative">
           <div data-fields--file-field-target="progressBar" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="absolute top-0 left-0 whitespace-nowrap overflow-hidden animate-pulse bg-primary-500 dark:bg-slate-800 rounded" role="progressbar" style="width: 0%;">&nbsp;</div>

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_file_field.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_file_field.html.erb
@@ -58,6 +58,14 @@ persisted_files = options[:multiple] ? form.object.send(method) : [form.object.s
           </div>
           <div data-fields--file-field-target="selectedFileList" class="divide-y-2 divide-dashed">
           </div>
+          <template data-fields--file-field-target="selectedFileRowTemplate">
+            <div class="py-1 flex flex-wrap items-center">
+              <div>@FILENAME@</div>
+              <span data-action="click->fields--file-field#cancelFileUpload" data-filename="@FILENAME@" class="button-alternative cursor-pointer ml-auto">
+                <%= t('global.buttons.cancel') %>
+              </span>
+            </div>
+          </template>
         </div>
         <div class="button-alternative cursor-pointer" data-action="click->fields--file-field#uploadFile" data-fields--file-field-target="selectFileButton">
           <i class="leading-none mr-2 text-base ti ti-upload dark:text-white"></i>

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_file_field.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_file_field.html.erb
@@ -66,6 +66,8 @@ persisted_files = options[:multiple] ? form.object.send(method) : [form.object.s
               <%= t('fields.replace_document') %>
             <% elsif form.object.send(method).attached? && options[:multiple] %>
               <%= t('fields.add_another_document') %>
+            <% elsif options[:multiple] %>
+              <%= t('fields.upload_documents') %>
             <% else %>
               <%= t('fields.upload_document') %>
             <% end %>

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_file_field.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_file_field.html.erb
@@ -23,7 +23,7 @@ persisted_files = options[:multiple] ? form.object.send(method) : [form.object.s
 
 <%= render 'shared/fields/field', form: form, method: method, helper: :file_field, options: options, other_options: other_options do %>
   <% content_for :field do %>
-    <div class="file-field" data-controller="fields--file-field">
+    <div class="file-field" data-controller="fields--file-field" data-fields--file-field-select-different-file-value="<%= t('fields.select_different_file') %>">
       <%= form.file_field method, options %>
       <div>
         <% if form.object.send(method).attached? %>

--- a/bullet_train-themes-tailwind_css/config/locales/en/fields.en.yml
+++ b/bullet_train-themes-tailwind_css/config/locales/en/fields.en.yml
@@ -2,12 +2,14 @@ en:
   fields:
     download_document: Download Current Document
     upload_document: Upload New Document
+    upload_documents: Upload New Documents
     add_another_document: Add Another Document
     replace_document: Replace Document
     remove_document: Remove Current Document
     cancel_remove_document: Cancel Removal
     download_image: Download Current Image
     upload_image: Upload New Image
+    upload_images: Upload New Images
     add_another_image: Add Another Image
     replace_image: Replace Image
     remove_image: Remove Current Image

--- a/bullet_train-themes-tailwind_css/config/locales/en/fields.en.yml
+++ b/bullet_train-themes-tailwind_css/config/locales/en/fields.en.yml
@@ -2,7 +2,11 @@ en:
   fields:
     download_document: Download Current Document
     upload_document: Upload New Document
+    add_another_document: Add Another Document
+    replace_document: Replace Document
     remove_document: Remove Current Document
     download_image: Download Current Image
     upload_image: Upload New Image
+    add_another_image: Add Another Image
+    replace_image: Replace Image
     remove_image: Remove Current Image

--- a/bullet_train-themes-tailwind_css/config/locales/en/fields.en.yml
+++ b/bullet_train-themes-tailwind_css/config/locales/en/fields.en.yml
@@ -5,8 +5,10 @@ en:
     add_another_document: Add Another Document
     replace_document: Replace Document
     remove_document: Remove Current Document
+    cancel_remove_document: Cancel Removal
     download_image: Download Current Image
     upload_image: Upload New Image
     add_another_image: Add Another Image
     replace_image: Replace Image
     remove_image: Remove Current Image
+    cancel_remove_image: Cancel Removal

--- a/bullet_train-themes-tailwind_css/config/locales/en/fields.en.yml
+++ b/bullet_train-themes-tailwind_css/config/locales/en/fields.en.yml
@@ -14,3 +14,4 @@ en:
     replace_image: Replace Image
     remove_image: Remove Current Image
     cancel_remove_image: Cancel Removal
+    select_different_file: Select A Different File


### PR DESCRIPTION
This PR makes a few improvements to the `file_field` partial.

* Wording of the buttons now more closely matches what the button will actually do. For instance, if you've already selected a file to upload instead of saying "Select Another File" the button connected to the file upload element will now say "Select A Different File" to indicate that you're replacing the previously selected file instead of adding to it.
* Once you've selected one or more files we'll now show you the name of the file(s) that will be uploaded.
* Now there's a "Cancel" button for each file that will be uploaded to allow you to change your mind after making the selection.
* After clicking the "Remove Current Document" button we'll now continue to show the name of the file, but will also show a "Cancel Removal" button to allow you to change your mind.
* Some visual polish to align buttons across all file upload elements.

The following screenshots both show the state of things after
* selecting 3 addition files to be uploaded to the "Files" element (`has_many_attached :files`)
* clicking "Remove Current Document" for one of the 4 pre-uploaded documents in the "Files" element
* selecting 1 file to replace the current "Single File" element (`has_one_attached :single_file`)

Before:

![CleanShot 2024-07-12 at 13 30 18](https://github.com/user-attachments/assets/143edc3f-a632-4717-8e07-13584c25c4e2)

After:

![CleanShot 2024-07-12 at 13 29 10](https://github.com/user-attachments/assets/04f29e12-71c4-47f5-a09d-0346bd8b9b2f)

Fixes: https://github.com/bullet-train-co/bullet_train/issues/1604
