### PR TITLE
Enable scaffolding of image fields with the `multiple` option for ActiveStorage

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/attribute.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/attribute.rb
@@ -178,10 +178,10 @@ class Scaffolding::Attribute
       # TODO: We're preserving cloudinary_image here for backwards compatibility.
       # Remove it in a future major release.
       options[:height] = 200
-      "image"
+      "image#{"s" if is_multiple?}"
     when "image"
       options[:height] = 200
-      "image"
+      "image#{"s" if is_multiple?}"
     when "phone_field"
       "phone_number"
     when "date_field"

--- a/bullet_train-super_scaffolding/lib/scaffolding/script.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/script.rb
@@ -146,11 +146,21 @@ def check_required_options_for_attributes(scaffolding_type, attributes, child, p
       {}
     end
 
+    if type == "image" && cloudinary_enabled? && attribute_options[:multiple]
+      puts "You have Cloudinary enabled and tried to scaffold an image field with the `multiple` option. " \
+        "At this time we do not support multiple images in a single Cloudinary image attribute. " \
+        "We hope to add support for it in the near future. " \
+        "For now you could use individual named image attributes, or you might try disabling Cloudinary and using ActiveStorage.".red
+      exit
+    end
+
     data_type = if type == "image" && cloudinary_enabled?
       "string"
     elsif attribute_options[:multiple]
       case type
       when "file"
+        "attachments"
+      when "image"
         "attachments"
       else
         "jsonb"

--- a/bullet_train-super_scaffolding/lib/scaffolding/script.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/script.rb
@@ -158,7 +158,7 @@ def check_required_options_for_attributes(scaffolding_type, attributes, child, p
       "string"
     elsif attribute_options[:multiple]
       case type
-      when "file"
+      when "file_field"
         "attachments"
       when "image"
         "attachments"

--- a/bullet_train-super_scaffolding/lib/scaffolding/script.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/script.rb
@@ -149,7 +149,7 @@ def check_required_options_for_attributes(scaffolding_type, attributes, child, p
     if type == "image" && cloudinary_enabled? && attribute_options[:multiple]
       puts "You have Cloudinary enabled and tried to scaffold an image field with the `multiple` option. " \
         "At this time we do not support multiple images in a single Cloudinary image attribute. " \
-        "We hope to add support for it in the near future. " \
+        "We hope to add support for it in the future. " \
         "For now you could use individual named image attributes, or you might try disabling Cloudinary and using ActiveStorage.".red
       exit
     end

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_active_storage_image.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_active_storage_image.html.erb
@@ -27,7 +27,7 @@ options[:height] ||= 100
 
 <%= render 'shared/fields/field', form: form, method: method, helper: :file_field, options: options, other_options: other_options do %>
   <% content_for :field do %>
-    <div class="file-field" data-controller="fields--file-field">
+    <div class="file-field" data-controller="fields--file-field" data-fields--file-field-select-different-file-value="<%= t('fields.select_different_file') %>">
       <%= form.file_field method, class: 'file-upload hidden', multiple: options[:multiple], direct_upload: true, data: {'fields--file-field-target': 'fileField', action: 'change->fields--file-field#handleFileSelected'} %>
       <div>
         <% if form.object.send(method).attached? %>
@@ -61,14 +61,24 @@ options[:height] ||= 100
           </div>
           <div data-fields--file-field-target="selectedFileList" class="divide-y-2 divide-dashed">
           </div>
+          <template data-fields--file-field-target="selectedFileRowTemplate">
+            <div class="py-1 flex flex-wrap items-center">
+              <div>@FILENAME@</div>
+              <span data-action="click->fields--file-field#cancelFileUpload" data-filename="@FILENAME@" class="button-alternative cursor-pointer ml-auto">
+                <%= t('global.buttons.cancel') %>
+              </span>
+            </div>
+          </template>
         </div>
         <div class="button-alternative cursor-pointer" data-action="click->fields--file-field#uploadFile" data-fields--file-field-target="selectFileButton">
-          <i class="leading-none mr-2 text-base ti ti-upload dark:text-white"></i>
-          <span class="dark:text-white">
+          <i class="leading-none mr-2 text-base ti ti-upload dark:text-white" data-fields--file-field-target="selectFileButtonIcon"></i>
+          <span class="dark:text-white" data-fields--file-field-target="selectFileButtonText">
             <% if form.object.send(method).attached? && !options[:multiple] %>
               <%= t('fields.replace_image') %>
             <% elsif form.object.send(method).attached? && options[:multiple] %>
               <%= t('fields.add_another_image') %>
+            <% elsif options[:multiple] %>
+              <%= t('fields.upload_images') %>
             <% else %>
               <%= t('fields.upload_image') %>
             <% end %>

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_active_storage_image.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_active_storage_image.html.erb
@@ -33,9 +33,9 @@ options[:height] ||= 100
         <% if form.object.send(method).attached? %>
           <div class="divide-y-2 divide-dashed">
             <% persisted_files.each do |file| %>
-              <div data-controller="fields--file-item" data-fields--file-item-id-value="<%= file.id %>">
+              <div data-controller="fields--file-item" data-fields--file-item-id-value="<%= file.id %>" class="py-1 flex flex-wrap items-center">
                 <%= form.hidden_field "#{method}_removal".to_sym, multiple: options[:multiple], value: nil, data: {'fields--file-item-target': 'removeFileFlag'} %>
-                <%= image_tag photo_url_for_active_storage_attachment(file, options), class: 'mb-1.5', data: {'fields--file-item-target': "fileName"} %>
+                <%= image_tag photo_url_for_active_storage_attachment(file, options), class: 'mb-1.5 mr-auto', data: {'fields--file-item-target': "fileName"} %>
 
                 <%= link_to url_for(file), class: 'button download-file mr-3', data: {'fields--file-item-target': 'downloadFileButton'} do %>
                   <i class="leading-none mr-2 text-base ti ti-download"></i>
@@ -45,15 +45,34 @@ options[:height] ||= 100
                   <i class="leading-none mr-2 text-base ti ti-trash"></i>
                   <span><%= t('fields.remove_image') %></span>
                 </div>
+                <div class="button-alternative cursor-pointer mr-3 hidden" data-action="click->fields--file-item#cancelRemoveFile" data-fields--file-item-target="cancelRemoveFileButton">
+                  <i class="leading-none mr-2 text-base ti ti-na"></i>
+                  <span><%= t('fields.cancel_remove_image') %></span>
+                </div>
               </div>
             <% end %>
           </div>
         <% end %>
       </div>
       <div class="mt-2">
+        <div data-fields--file-field-target="selectedFileListContainer" class="hidden mb-2">
+          <div class="dark:text-white mb-1">
+            To upload:
+          </div>
+          <div data-fields--file-field-target="selectedFileList" class="divide-y-2 divide-dashed">
+          </div>
+        </div>
         <div class="button-alternative cursor-pointer" data-action="click->fields--file-field#uploadFile" data-fields--file-field-target="selectFileButton">
           <i class="leading-none mr-2 text-base ti ti-upload dark:text-white"></i>
-          <span class="dark:text-white"><%= t('fields.upload_image') %></span>
+          <span class="dark:text-white">
+            <% if form.object.send(method).attached? && !options[:multiple] %>
+              <%= t('fields.replace_image') %>
+            <% elsif form.object.send(method).attached? && options[:multiple] %>
+              <%= t('fields.add_another_image') %>
+            <% else %>
+              <%= t('fields.upload_image') %>
+            <% end %>
+          </span>
         </div>
         <div class="mt-2 hidden overflow-hidden text-xs rounded bg-slate-100 shadow-inner relative">
           <div data-fields--file-field-target="progressBar" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="absolute top-0 left-0 whitespace-nowrap overflow-hidden animate-pulse bg-primary-500 dark:bg-slate-800 rounded" role="progressbar" style="width: 0%;">&nbsp;</div>

--- a/bullet_train-themes/app/views/themes/base/attributes/_images.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_images.html.erb
@@ -1,0 +1,16 @@
+<% object ||= current_attributes_object %>
+<% strategy ||= current_attributes_strategy || :none %>
+<% url ||= nil %>
+<% options ||= {} %>
+<% options[:height] ||= 200 %>
+
+<% if cloudinary_enabled? %>
+  <%# TODO: How do we attach mutliple cloundinary images? %>
+  <%= cloudinary_image_tag object.public_send(attribute), options %>
+<% else %>
+  <% if object.public_send(attribute).attached? %>
+    <% object.send(attribute).each do |image| %>
+      <%= image_tag photo_url_for_active_storage_attachment(image, options) %>
+    <% end %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
This allows you to pass the `{multiple}` option when super scaffolding image fields **IF** you're using ActiveStorage and not Cloudinary.


If you have Cloudinary activated you'll see something like this:

```
$ rails g super_scaffold Widget Team name:text_field images:image{multiple} single_image:image
You have Cloudinary enabled and tried to scaffold an image field with the `multiple` option.
At this time we do not support multiple images in a single Cloudinary image attribute.
We hope to add support for it in the near future.
For now you could use individual named image attributes, or you might try disabling Cloudinary and using ActiveStorage.
```

Note: I pointed this PR into #886 because the `file_field` and `active_storage_image` field partials share the same Stimulus controller, so we need to update them simultaneously. When these are both ready to merge I plan to merge #886 first, then rebase this PR on `main` (if needed) and retarget it to `main` before merging it.

Fixes: https://github.com/bullet-train-co/bullet_train/issues/1598