### PR TITLE
Add generator for Conversations

### DIFF
--- a/bullet_train-super_scaffolding/lib/generators/super_scaffold/conversations/USAGE
+++ b/bullet_train-super_scaffolding/lib/generators/super_scaffold/conversations/USAGE
@@ -1,0 +1,17 @@
+Description:
+  Generate files needed to add conversations to a model.
+
+Example:
+  E.g. Add conversations to Posts from a Team.
+    rails generate super_scaffold:conversations Post Team
+
+  This will create:
+    db/migrate/20240716162627_add_project_to_conversations.rb
+  And update:
+    app/models/ability.rb
+    app/models/conversation.rb
+    app/models/project.rb
+    app/views/account/projects/show.html.erb
+
+🏆 Protip: Commit your other changes before running Super Scaffolding so it's easy to undo if you (or we) make any mistakes.
+If you do that, you can reset to your last commit state by using `git checkout .` and `git clean -d -f`.

--- a/bullet_train-super_scaffolding/lib/generators/super_scaffold/conversations/conversations_generator.rb
+++ b/bullet_train-super_scaffolding/lib/generators/super_scaffold/conversations/conversations_generator.rb
@@ -1,0 +1,25 @@
+require_relative "../super_scaffold_base"
+require "scaffolding/routes_file_manipulator"
+
+class ConversationsGenerator < Rails::Generators::Base
+  include SuperScaffoldBase
+
+  source_root File.expand_path("templates", __dir__)
+
+  namespace "super_scaffold:conversations"
+
+  argument :target_model
+  argument :parent_model
+
+  def generate
+    if defined?(BulletTrain::Conversations)
+      # We add the name of the specific super_scaffolding command that we want to
+      # invoke to the beginning of the argument string.
+      ARGV.unshift "conversations"
+      BulletTrain::SuperScaffolding::Runner.new.run
+    else
+      puts "You must have Conversations installed if you want to use this generator.".red
+      puts "Please refer to the documentation for more information: https://bullettrain.co/docs/conversations"
+    end
+  end
+end


### PR DESCRIPTION
This makes it so that you can generate Conversations with the new form (`rails g super_scaffold:conversations`) instead of the old form (`bin/super-scaffold conversations`).

Fixes: https://github.com/bullet-train-pro/bullet_train-conversations/issues/1