### PR TITLE
Add a template for Devise `email_changed`

### DIFF
--- a/bullet_train/app/views/devise/mailer/email_changed.html.erb
+++ b/bullet_train/app/views/devise/mailer/email_changed.html.erb
@@ -1,0 +1,3 @@
+<p><%= t('.hello', email: @resource.email) %></p>
+
+<p><%= t('.description', email: @resource.try(:unconfirmed_email?) ? @resource.unconfirmed_email : @resource.email) %></p>

--- a/bullet_train/config/locales/en/devise.en.yml
+++ b/bullet_train/config/locales/en/devise.en.yml
@@ -73,6 +73,11 @@ en:
         subject: "Password Changed"
         hello: Hello %{email}!
         description: We're contacting you to notify you that your password has been changed.
+      email_changed:
+        subject: "Email Changed"
+        hello: Hello %{email}!
+        description: We're contacting you to notify you that your email has been changed to %{email}
+
     omniauth_callbacks:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
       success: "Successfully authenticated from %{kind} account."


### PR DESCRIPTION
This adds a template and English translations for the Devise `email_changed` mailer. This is sent when someone changes their email in an app.

Fixes: https://github.com/bullet-train-co/bullet_train-core/issues/643