### PR TITLE
Provide a visual indicator when fields are disabled

### DIFF
--- a/bullet_train-themes-light/app/views/themes/light/fields/_field.html.erb
+++ b/bullet_train-themes-light/app/views/themes/light/fields/_field.html.erb
@@ -54,6 +54,7 @@ has_errors = errors.any? || partial.error? || other_options[:error].present?
 # these classes, although we have the `has_errors` conditional with some style below.
 options[:class] = "#{options[:class]} block w-full rounded-md shadow-sm font-light dark:bg-slate-800 dark:text-slate-300"
 options[:class] += " text-base md:text-sm" # default to 16px on mobile to prevent zooming
+options[:class] += " disabled:bg-slate-200 disabled:dark:bg-slate-700" # classes to give a visual indicator when a field is disabled
 
 options[:class] += if has_errors
   " pr-10 border-red-500 text-red-900 placeholder-red-500 outline-none focus:ring-red-500 focus:border-red-500 dark:text-slate-300"

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_buttons.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_buttons.html.erb
@@ -41,6 +41,13 @@ if defined?(multiple)
 end
 %>
 
+<%
+  button_classes = "button-alternative mb-1.5 mr-1"
+  if options[:disabled]
+    button_classes += " bg-slate-200 dark:bg-slate-700 hover:bg-slate-200 hover:dark:bg-slate-700"
+  end
+%>
+
 <% content = render 'shared/fields/field', form: form, method: method, options: options, other_options: other_options do %>
   <% content_for :field do %>
     <div>
@@ -52,7 +59,7 @@ end
           <% else %>
             <%= form.radio_button method, value, options %>
           <% end %>
-          <button type="button" class="button-alternative mb-1.5 mr-1" data-action="<%= stimulus_controller %>#clickShadowField">
+          <button type="button" class="<%= button_classes %>" data-action="<%= stimulus_controller %>#clickShadowField">
             <%= label %>
           </button>
         </label>

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_date_and_time_field.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_date_and_time_field.html.erb
@@ -24,7 +24,7 @@ data_options = data_options.merge({ data: {"#{stimulus_controller}-target": 'fie
 
 # localized display options
 options[:id] ||=  "#{form.field_id(method)}_display"
-options[:class] = "form-control single-daterange w-full border-slate-300 dark:bg-slate-800 dark:border-slate-900 #{options[:class]}".strip
+options[:class] = "form-control single-daterange w-full border-slate-300 dark:bg-slate-800 dark:border-slate-900 disabled:bg-slate-200 disabled:dark:bg-slate-700 #{options[:class]}".strip
 raw_value = form.object.send(method)&.in_time_zone(current_user&.time_zone || current_team_time_zone || "UTC")
 options[:value] = raw_value && I18n.l(raw_value, format: :date_and_time_field)
 options = options.merge({ data: {"#{stimulus_controller}-target": 'displayField' }})

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_date_field.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_date_field.html.erb
@@ -15,7 +15,7 @@ data_options = data_options.merge({ data: {"#{stimulus_controller}-target": 'fie
 
 # localized display options
 options[:id] ||= "#{form.field_id(method)}_display"
-options[:class] = "form-control single-daterange w-full border-slate-300 dark:bg-slate-800 dark:border-slate-900 #{options[:class]}".strip
+options[:class] = "form-control single-daterange w-full border-slate-300 dark:bg-slate-800 dark:border-slate-900 disabled:bg-slate-200 disabled:dark:bg-slate-700 #{options[:class]}".strip
 options[:value] = form.object.send(method) && I18n.l(form.object.send(method), format: :date_field)
 options = options.merge({ data: {"#{stimulus_controller}-target": 'displayField' }})
 %>

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_option.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_option.html.erb
@@ -23,6 +23,7 @@ end
 #
 # the `append_class` local can be used to append any other styles desired for the element.
 options[:class] ||= "focus:ring-primary-500 h-4 w-4 text-primary-500 border-slate-300 dark:bg-slate-800 dark:border-slate-900 #{"rounded" if options[:multiple] || single_check_box}"
+options[:class] += " disabled:bg-slate-200 disabled:dark:bg-slate-700" # classes to give a visual indicator when a field is disabled
 options[:class] += " #{append_class}"
 %>
 

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_options.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_options.html.erb
@@ -79,7 +79,7 @@ end
             <%= check_box_tag "#{options[:id]}-select_all", 'select-all', false, data: {
               "select-all-target": 'toggleCheckbox',
               'action': "select-all#selectAllOrNone"
-            }, class: "focus:ring-primary-500 h-4 w-4 text-primary-500 border-slate-300 rounded" %>
+            }, class: "focus:ring-primary-500 h-4 w-4 text-primary-500 border-slate-300 rounded disabled:bg-slate-200 disabled:dark:bg-slate-700" %>
           </div>
           <div class="ml-2.5 text-sm pr-4">
             <%= t("global.bulk_select.all") %>


### PR DESCRIPTION
This makes it so that most fields will display differently if they are disabled.

Mostly fixes: https://github.com/bullet-train-co/bullet_train-core/issues/573

For comparison I added `options: {disabled: true}` to all the inputs on the TangibleThing form.

Before:

![CleanShot 2024-07-16 at 14 52 20](https://github.com/user-attachments/assets/fe30273c-8e10-4250-90a2-87576c80bac6)

After:

![CleanShot 2024-07-16 at 14 51 50](https://github.com/user-attachments/assets/dfc0ddfa-21ad-44dc-a87b-95d0df6879d3)

We still need to address the following field types:

* `color_picker`
* `options` with `multiple: true` (aka checkboxes)
* `super_select`
* `address`
* `trix_editor`