### PR TITLE
Make `two_factor_authentication_enabled?` aware of keys set via ENV vars

### DIFF
--- a/bullet_train/lib/bullet_train.rb
+++ b/bullet_train/lib/bullet_train.rb
@@ -128,7 +128,7 @@ def cloudinary_enabled?
 end
 
 def two_factor_authentication_enabled?
-  Rails.application.credentials.active_record_encryption&.primary_key.present?
+  Rails.application.credentials.active_record_encryption&.primary_key.present? || Rails.configuration&.active_record&.encryption&.primary_key.present?
 end
 
 # Don't redefine this if an application redefines it locally.


### PR DESCRIPTION
Fixes https://github.com/bullet-train-co/bullet_train-core/issues/895

Previously we only checked to see if a `primary_key` was set using Rails encrypted credentials files. If it was set via ENV var then ActiveRecord encryption would be enabled, but we'd incorrectly determine that it wasn't enabled. This makes it so that two factor stuff shows up when you've set the keys in the ENV.