### PR TITLE
Allow dependent fields to work with multiple dependencies

### DIFF
--- a/bullet_train-fields/app/javascript/controllers/dependent_fields_frame_controller.js
+++ b/bullet_train-fields/app/javascript/controllers/dependent_fields_frame_controller.js
@@ -32,7 +32,7 @@ export default class extends Controller {
   }
 
   constructNewUrlUpdatingField(fieldName, fieldValue) {
-    const url = new URL(window.location.href)
+    const url = new URL(this.element.src || window.location.href)
     url.searchParams.set(fieldName, fieldValue)
 
     return url.href


### PR DESCRIPTION
Previously we were clobbering any query params that had been set by a previous update to dependent fields since we relied only on `window.location.href`. This PR makes it so that we retain any query params that were already set (by using `this.element.src` if present) and we just update the one that has changed.