### PR TITLE
Pin pagy to version 6

### DIFF
--- a/bullet_train-api/Gemfile.lock
+++ b/bullet_train-api/Gemfile.lock
@@ -70,7 +70,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy
+      pagy (< 7)
       pagy_cursor
       rack-cors
       rails (>= 6.0.0)
@@ -445,6 +445,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/bullet_train-api/Gemfile.lock
+++ b/bullet_train-api/Gemfile.lock
@@ -49,7 +49,7 @@ PATH
       microscope
       nice_partials (~> 0.9)
       omniauth
-      pagy
+      pagy (< 7)
       possessive
       premailer-rails
       rails (>= 6.0.0)

--- a/bullet_train-api/bullet_train-api.gemspec
+++ b/bullet_train-api/bullet_train-api.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bullet_train"
 
   spec.add_dependency "rails", ">= 6.0.0"
-  spec.add_dependency "pagy"
+  spec.add_dependency "pagy", "< 7"
   spec.add_dependency "pagy_cursor"
   spec.add_dependency "rack-cors"
   spec.add_dependency "doorkeeper"

--- a/bullet_train-fields/Gemfile.lock
+++ b/bullet_train-fields/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy
+      pagy (< 7)
       pagy_cursor
       rack-cors
       rails (>= 6.0.0)
@@ -48,7 +48,7 @@ PATH
       microscope
       nice_partials (~> 0.9)
       omniauth
-      pagy
+      pagy (< 7)
       possessive
       premailer-rails
       rails (>= 6.0.0)

--- a/bullet_train-incoming_webhooks/Gemfile.lock
+++ b/bullet_train-incoming_webhooks/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy
+      pagy (< 7)
       pagy_cursor
       rack-cors
       rails (>= 6.0.0)
@@ -64,7 +64,7 @@ PATH
       microscope
       nice_partials (~> 0.9)
       omniauth
-      pagy
+      pagy (< 7)
       possessive
       premailer-rails
       rails (>= 6.0.0)

--- a/bullet_train-incoming_webhooks/Gemfile.lock
+++ b/bullet_train-incoming_webhooks/Gemfile.lock
@@ -450,6 +450,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/bullet_train-integrations-stripe/Gemfile.lock
+++ b/bullet_train-integrations-stripe/Gemfile.lock
@@ -472,6 +472,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/bullet_train-integrations-stripe/Gemfile.lock
+++ b/bullet_train-integrations-stripe/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy
+      pagy (< 7)
       pagy_cursor
       rack-cors
       rails (>= 6.0.0)
@@ -66,7 +66,7 @@ PATH
       microscope
       nice_partials (~> 0.9)
       omniauth
-      pagy
+      pagy (< 7)
       possessive
       premailer-rails
       rails (>= 6.0.0)

--- a/bullet_train-integrations/Gemfile.lock
+++ b/bullet_train-integrations/Gemfile.lock
@@ -200,6 +200,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/bullet_train-outgoing_webhooks/Gemfile.lock
+++ b/bullet_train-outgoing_webhooks/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy
+      pagy (< 7)
       pagy_cursor
       rack-cors
       rails (>= 6.0.0)
@@ -57,7 +57,7 @@ PATH
       microscope
       nice_partials (~> 0.9)
       omniauth
-      pagy
+      pagy (< 7)
       possessive
       premailer-rails
       rails (>= 6.0.0)

--- a/bullet_train-outgoing_webhooks/Gemfile.lock
+++ b/bullet_train-outgoing_webhooks/Gemfile.lock
@@ -451,6 +451,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/bullet_train-sortable/Gemfile.lock
+++ b/bullet_train-sortable/Gemfile.lock
@@ -479,6 +479,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/bullet_train-sortable/Gemfile.lock
+++ b/bullet_train-sortable/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy
+      pagy (< 7)
       pagy_cursor
       rack-cors
       rails (>= 6.0.0)
@@ -57,7 +57,7 @@ PATH
       microscope
       nice_partials (~> 0.9)
       omniauth
-      pagy
+      pagy (< 7)
       possessive
       premailer-rails
       rails (>= 6.0.0)

--- a/bullet_train-super_scaffolding/Gemfile.lock
+++ b/bullet_train-super_scaffolding/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy
+      pagy (< 7)
       pagy_cursor
       rack-cors
       rails (>= 6.0.0)
@@ -48,7 +48,7 @@ PATH
       microscope
       nice_partials (~> 0.9)
       omniauth
-      pagy
+      pagy (< 7)
       possessive
       premailer-rails
       rails (>= 6.0.0)

--- a/bullet_train-super_scaffolding/Gemfile.lock
+++ b/bullet_train-super_scaffolding/Gemfile.lock
@@ -443,6 +443,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/bullet_train-themes-light/Gemfile.lock
+++ b/bullet_train-themes-light/Gemfile.lock
@@ -485,6 +485,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/bullet_train-themes-light/Gemfile.lock
+++ b/bullet_train-themes-light/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy
+      pagy (< 7)
       pagy_cursor
       rack-cors
       rails (>= 6.0.0)
@@ -57,7 +57,7 @@ PATH
       microscope
       nice_partials (~> 0.9)
       omniauth
-      pagy
+      pagy (< 7)
       possessive
       premailer-rails
       rails (>= 6.0.0)

--- a/bullet_train-themes-tailwind_css/Gemfile.lock
+++ b/bullet_train-themes-tailwind_css/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy
+      pagy (< 7)
       pagy_cursor
       rack-cors
       rails (>= 6.0.0)
@@ -57,7 +57,7 @@ PATH
       microscope
       nice_partials (~> 0.9)
       omniauth
-      pagy
+      pagy (< 7)
       possessive
       premailer-rails
       rails (>= 6.0.0)

--- a/bullet_train-themes/Gemfile.lock
+++ b/bullet_train-themes/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy
+      pagy (< 7)
       pagy_cursor
       rack-cors
       rails (>= 6.0.0)
@@ -57,7 +57,7 @@ PATH
       microscope
       nice_partials (~> 0.9)
       omniauth
-      pagy
+      pagy (< 7)
       possessive
       premailer-rails
       rails (>= 6.0.0)

--- a/bullet_train/Gemfile.lock
+++ b/bullet_train/Gemfile.lock
@@ -15,7 +15,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy
+      pagy (< 7)
       pagy_cursor
       rack-cors
       rails (>= 6.0.0)
@@ -107,7 +107,7 @@ PATH
       microscope
       nice_partials (~> 0.9)
       omniauth
-      pagy
+      pagy (< 7)
       possessive
       premailer-rails
       rails (>= 6.0.0)

--- a/bullet_train/bullet_train.gemspec
+++ b/bullet_train/bullet_train.gemspec
@@ -99,7 +99,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "unicode-emoji"
 
   # Pagination.
-  spec.add_runtime_dependency "pagy"
+  spec.add_runtime_dependency "pagy", "< 7"
 
   # We don't want to develop in a world where we don't have `binding.pry` or `object.pry` for debugging.
   spec.add_development_dependency "pry"


### PR DESCRIPTION
There are breaking changes in versions 7 & 8 that we need to spend some time on to make updates. For now I'm just pinning it to version 6 explicitly so that `depfu` doesn't try to upgrade it.