### PR TITLE
Update to OpenAPI spec v3.1.0

### DIFF
--- a/bullet_train-api/app/helpers/api/open_api_helper.rb
+++ b/bullet_train-api/app/helpers/api/open_api_helper.rb
@@ -97,7 +97,10 @@ module Api
             "description" => attribute_name.titleize.to_s
           }
 
-          attributes_output["example"].merge!({attribute_name.to_s => nil})
+          attributes_output["examples"] = [{
+            "summary" => "default",
+            "value" => nil
+          }]
         end
       end
 


### PR DESCRIPTION
The current implementation uses the deprecated `example` field which causes test failures whenever creating a new Bullet Train application, and whenever a new Super Scaffold is generated.

This PR updates the implementation to use the current `examples` field instead.

SEE: https://spec.openapis.org/oas/latest.html#fixed-fields-5

> [!NOTE]
> This change satisifies the test failure problem but we should verify that it returns what's truly needed for the OpenAPI docs. 

Related: https://github.com/bullet-train-co/bullet_train/issues/1520