### PR TITLE
dependent_fields_frame: fix if toggled by checkbox

### DIFF
--- a/bullet_train-fields/app/javascript/controllers/dependent_fields_frame_controller.js
+++ b/bullet_train-fields/app/javascript/controllers/dependent_fields_frame_controller.js
@@ -50,7 +50,7 @@ export default class extends Controller {
   storeFieldValues() {
     this.fieldTargets.forEach(field => {
       let storeUpdate = {}
-      storeUpdate[field.name] = getValueForField(field)
+      storeUpdate[field.name] = this.getValueForField(field)
       this.valuesStoreValue = Object.assign(this.valuesStoreValue, storeUpdate)
     })
   }

--- a/bullet_train-fields/app/javascript/controllers/dependent_fields_frame_controller.js
+++ b/bullet_train-fields/app/javascript/controllers/dependent_fields_frame_controller.js
@@ -21,7 +21,7 @@ export default class extends Controller {
     this.disableFieldInputWhileRefreshing()
 
     const frame = this.element
-    frame.src = this.constructNewUrlUpdatingField(field.name, field.value)
+    frame.src = this.constructNewUrlUpdatingField(field.name, this.getValueForField(field))
   }
 
   finishFrameUpdate(event) {
@@ -32,7 +32,7 @@ export default class extends Controller {
   }
 
   constructNewUrlUpdatingField(fieldName, fieldValue) {
-    const url = new URL(this.element.src || window.location.href)
+    const url = new URL(window.location.href)
     url.searchParams.set(fieldName, fieldValue)
 
     return url.href
@@ -50,7 +50,7 @@ export default class extends Controller {
   storeFieldValues() {
     this.fieldTargets.forEach(field => {
       let storeUpdate = {}
-      storeUpdate[field.name] = field.value
+      storeUpdate[field.name] = getValueForField(field)
       this.valuesStoreValue = Object.assign(this.valuesStoreValue, storeUpdate)
     })
   }
@@ -59,10 +59,26 @@ export default class extends Controller {
     this.fieldTargets.forEach(field => {
       const storedValue = this.valuesStoreValue[field.name]
       if (storedValue === undefined) { return }
-      field.value = storedValue
+      this.setValueForField(field, storedValue)
       field.dispatchEvent(new Event('change')) // ensures cascading effects, including super-select validating against valid options
     })
 
     this.valuesStoreValue = {}
+  }
+
+  getValueForField(field) {
+    if (field.type === "checkbox") {
+      return field.checked
+    }
+
+    return field.value
+  }
+
+  setValueForField(field, value) {
+    if (field.type === "checkbox") {
+      field.checked = value
+    }
+
+    field.value = value
   }
 }


### PR DESCRIPTION
If the dependable field is a checkbox, `field.value` won't store the `checked` state of the checkbox, and so the dependent fields frame will always be evaluated to true.

This PR fixes this issue.