### PR TITLE
Prevent turbo-prefetch on team switch links

### DIFF
--- a/bullet_train-themes-light/app/views/themes/light/_team.html.erb
+++ b/bullet_train-themes-light/app/views/themes/light/_team.html.erb
@@ -2,7 +2,7 @@
 <% memberships ||= [] %>
 
 <li class="bg-white shadow overflow-hidden sm:rounded-md dark:bg-slate-700">
-  <%= link_to link_url, class: "group block hover:bg-slate-50 dark:hover:bg-slate-400 dark:text-slate-800" do %>
+  <%= link_to link_url, class: "group block hover:bg-slate-50 dark:hover:bg-slate-400 dark:text-slate-800", data: { turbo_prefetch: false } do %>
     <div class="px-4 py-4 flex items-center sm:pl-8 sm:pr-6">
       <div class="min-w-0 flex-1 sm:flex sm:items-center sm:justify-between">
         <div>


### PR DESCRIPTION
As a first step to alleviate issues such as #917, where `current_team` gets set on page load, we can at least disable turbo-prefetch on team switch links.

![CleanShot 2024-09-21 at 11 30 59](https://github.com/user-attachments/assets/fe132be3-2a36-4bae-b005-c3c27d334bb9)

