### PR TITLE
For sortable tables, only show main column when dragging

### DIFF
--- a/bullet_train-themes-light/app/assets/stylesheets/light/application.css
+++ b/bullet_train-themes-light/app/assets/stylesheets/light/application.css
@@ -28,3 +28,11 @@ ol.breadcrumb li:first-child svg { display: none; }
   height: 5px;
   @apply bg-primary-500;
 }
+
+/*
+  When dragging a sortable table row, only show the first column, usually containing the element's label.
+  Can be customize on a per-table basis.
+*/
+tr.gu-mirror > *:not(:first-child) {
+  display: none;
+}


### PR DESCRIPTION
Fixes the display of table rows while dragging, when sortable.

Before:

![CleanShot 2024-10-11 at 10 44 12](https://github.com/user-attachments/assets/697553b1-4bfc-41c8-be7a-291779d1267c)

After:

![CleanShot 2024-10-11 at 10 45 00](https://github.com/user-attachments/assets/62c95066-d92f-40b0-8125-c845acbbddb9)
