### PR TITLE
Imporoved Heroku Detection

### DIFF
--- a/bullet_train/lib/bullet_train.rb
+++ b/bullet_train/lib/bullet_train.rb
@@ -73,7 +73,7 @@ def default_url_options_from_base_url
 end
 
 def heroku?
-  ENV["PATH"]&.include?("/app/.heroku/")
+  ENV['HEROKU_APP_NAME'].present?
 end
 
 def inbound_email_enabled?

--- a/bullet_train/lib/bullet_train.rb
+++ b/bullet_train/lib/bullet_train.rb
@@ -73,7 +73,7 @@ def default_url_options_from_base_url
 end
 
 def heroku?
-  ENV['HEROKU_APP_NAME'].present?
+  ENV["HEROKU_APP_NAME"].present?
 end
 
 def inbound_email_enabled?


### PR DESCRIPTION
Heroku recently made some changes to how they set the `PATH` ENV var and now it no longer includes `/app/.heroku/` so our previous detection method is broken.

Now we'll look for `ENV['HEROKU_APP_NAME']`.