### PR TITLE
Fixed issue where Zapier couldn't connect because unique constraint.

### DIFF
--- a/bullet_train-api/lib/bullet_train/platform/connection_workflow.rb
+++ b/bullet_train-api/lib/bullet_train/platform/connection_workflow.rb
@@ -34,6 +34,7 @@ class BulletTrain::Platform::ConnectionWorkflow
             faux_membership = team.memberships.create(
               user: faux_user,
               platform_agent: true,
+              user_email: faux_user.email,
               platform_agent_of: @application,
               added_by: team.memberships.find_by(user: current_user)
             )


### PR DESCRIPTION
In Membership::Base a unique constraint of the user_email column was added last year which broke the Zapier's ConnectionWorkflow.

Simply adding user_email when creating the membership fixes this.