### PR TITLE
Handle multiple levels of namespace nesting when generating routes

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/routes_file_manipulator.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/routes_file_manipulator.rb
@@ -413,13 +413,14 @@ class Scaffolding::RoutesFileManipulator
       #   end
       # end
 
-      parent_within = find_or_convert_resource_block(parent_resource, within: within)
+      #parent_within = find_or_convert_resource_block(parent_resource, within: within)
+      parent_within = find_resource([parent_resource], within: within)
       last_parent_within = find_or_convert_resource_block(parent_resource, within: within, find_last: true)
 
       puts "-------------------------"
       puts "within = #{within}"
-      puts "last_parent_within = #{last_parent_within}"
       puts "parent_within = #{parent_within}"
+      puts "last_parent_within = #{last_parent_within}"
       puts "-------------------------"
 
       # add the new resource within that namespace.

--- a/bullet_train-super_scaffolding/lib/scaffolding/routes_file_manipulator.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/routes_file_manipulator.rb
@@ -231,7 +231,6 @@ class Scaffolding::RoutesFileManipulator
     parts = parts.dup
     resource = parts.pop
     # TODO this doesn't take into account any options like we do in `find_resource`.
-    debugger
 
     puts ""
 
@@ -346,7 +345,6 @@ class Scaffolding::RoutesFileManipulator
     resource_statement_line = find_resource([parent_resource], options)
     puts "resource_statement_line = #{resource_statement_line}"
     if resource_statement_line
-      debugger
       resource_statement = lines[resource_statement_line]
       puts "resource_statement = #{resource_statement}"
       if resource_statement.match?(/ do(\s.*)?$/)
@@ -415,8 +413,8 @@ class Scaffolding::RoutesFileManipulator
       #   end
       # end
 
-      last_parent_within = find_or_convert_resource_block(parent_resource, within: within, find_last: true)
       parent_within = find_or_convert_resource_block(parent_resource, within: within)
+      last_parent_within = find_or_convert_resource_block(parent_resource, within: within, find_last: true)
 
       puts "-------------------------"
       puts "within = #{within}"

--- a/bullet_train-super_scaffolding/lib/scaffolding/routes_file_manipulator.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/routes_file_manipulator.rb
@@ -214,12 +214,13 @@ class Scaffolding::RoutesFileManipulator
     within = options[:within]
     parts = parts.dup
     resource = parts.pop
+    needle = /resources :#{resource}#{options[:options] ? ", #{options[:options].gsub(/({)(.*)(})/, '{\2}')}" : ""}(,?\s.*)? do(\s.*)?$/
 
     # TODO this doesn't take into account any options like we do in `find_resource`.
     if options[:find_last]
-      find_last_in_namespace(/resources :#{resource}#{options[:options] ? ", #{options[:options].gsub(/({)(.*)(})/, '{\2}')}" : ""}(,?\s.*)? do(\s.*)?$/, parts, within)
+      find_last_in_namespace(needle, parts, within)
     else
-      find_in_namespace(/resources :#{resource}#{options[:options] ? ", #{options[:options].gsub(/({)(.*)(})/, '{\2}')}" : ""}(,?\s.*)? do(\s.*)?$/, parts, within)
+      find_in_namespace(needle, parts, within)
     end
   end
 

--- a/bullet_train-super_scaffolding/test/lib/scaffolding/examples/result_8._rb
+++ b/bullet_train-super_scaffolding/test/lib/scaffolding/examples/result_8._rb
@@ -1,0 +1,249 @@
+Rails.application.routes.draw do
+  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+
+  # TODO 🍩 figure out how to extract this for the sprinkles gem.
+  # e.g. `resources :things, concerns: [:sortable]`
+  concern :sortable do
+    collection do
+      post :reorder
+    end
+  end
+
+  api_actions = [:index, :create, :show, :update, :destroy]
+  collection_actions = [:index, :new, :create]
+
+  if subscriptions_enabled?
+
+    # this is the gem we use for managing pricing pages, stripe subscriptions, etc.
+    mount Koudoku::Engine, at: 'koudoku'
+    scope module: 'koudoku' do
+      get 'pricing' => 'subscriptions#index', as: 'pricing'
+    end
+  end
+
+  devise_for :users, controllers: {
+    registrations: 'registrations',
+    omniauth_callbacks: 'account/oauth/omniauth_callbacks'
+  }
+
+  scope module: 'public' do
+    root to: "home#index"
+    get 'api' => 'home#api'
+  end
+  authenticate :user, lambda { |u| u.developer? } do
+
+    # # RAILS ADMIN
+    # # ⚠️ this is commented out because it represents a major liability for you and a major risk for your customers data
+    # # unless you have a robust security policy enforced around your admin user accounts. i don't know if we'll ever
+    # # enable this by default, but i certainly wouldn't enable it in any application that didn't require two-factor
+    # # authentication for developer accounts.
+    # mount RailsAdmin::Engine => '/developers/admin', as: 'rails_admin'
+
+    # sidekiq provides a web-based interface.
+    require 'sidekiq/web'
+    mount Sidekiq::Web => '/developers/sidekiq'
+  end
+
+  namespace :webhooks do
+    namespace :incoming do
+      resources :bullet_train_webhooks
+      resources :stripe_webhooks
+      namespace :oauth do
+        resources :stripe_account_webhooks
+      end
+    end
+  end
+
+  shallow do
+    namespace :api do
+      namespace :v1 do
+        get 'user' => 'user#user'
+        resources :teams do
+
+          unless scaffolding_things_disabled?
+            namespace :scaffolding do
+              resources :things, only: api_actions unless scaffolding_things_disabled?
+              namespace :absolutely_abstract do
+                resources :creative_concepts, only: api_actions
+              end
+              resources :absolutely_abstract_creative_concepts, path: 'absolutely_abstract/creative_concepts' do
+                namespace :completely_concrete do
+                  resources :tangible_things, only: api_actions
+                end
+              end
+            end
+          end
+
+          namespace :kanban do
+            resources :boards, only: api_actions do
+              resources :tags
+              resources :columns, only: api_actions do
+                resources :cards, only: api_actions
+              end
+            end
+          end
+
+          resources :conversations, only: api_actions do
+            namespace :conversations do
+              resources :messages, only: api_actions
+            end
+          end
+
+          # don't remove or edit the following comment or you'll break super scaffolding.
+          # the following api routes were added by super scaffolding.
+
+        end
+      end
+      namespace :webhooks do
+        namespace :outgoing do
+          resources :events
+          resources :endpoints do
+            resources :deliveries, only: [:index, :show] do
+              resources :delivery_attempts, only: [:index, :show]
+            end
+          end
+        end
+      end
+    end
+  end
+
+  namespace :account do
+
+    # TODO we need to either implement a dashboard or deprecate this.
+    root to: "dashboard#index", as: 'dashboard'
+
+    # this is the route the cloudinary field hits.
+    namespace :cloudinary do
+      resources :upload_signatures
+    end
+
+    # user-level onboarding tasks.
+    namespace :onboarding do
+      resources :user_details
+      resources :user_email
+    end
+
+    # user specific resources.
+    shallow do
+      resources :users do
+        resources :api_keys
+
+        namespace :conversations do
+          resources :subscriptions do
+            member do
+              post :subscribe
+              post :unsubscribe
+            end
+          end
+        end
+      end
+    end
+
+    # team-level resources.
+    shallow do
+      resources :teams do
+
+        resources :sites
+
+        namespace :oauth do
+          resources :stripe_accounts if stripe_enabled?
+          resources :twitter_accounts if twitter_enabled?
+          resources :facebook_accounts if facebook_enabled?
+          # 🚅 super scaffolding will insert new oauth providers above this line.
+        end
+
+        namespace :webhooks do
+          namespace :outgoing do
+            resources :events
+            resources :endpoints do
+              resources :deliveries, only: [:index, :show] do
+                resources :delivery_attempts, only: [:index, :show]
+              end
+            end
+          end
+        end
+
+        namespace :kanban do
+          resources :boards do
+            resources :tags
+            resources :columns, concerns: [:sortable] do
+              resources :cards, concerns: [:sortable] do
+                member do
+                  post :convert_to_challenge
+                end
+              end
+              collection do
+                post :reassign_cards
+              end
+              member do
+                get :remove
+              end
+            end
+          end
+        end
+
+        resources :conversations do
+          namespace :conversations do
+            resources :messages
+          end
+        end
+
+        # add your resources here.
+        unless scaffolding_things_disabled?
+          namespace :scaffolding do
+            resources :things
+            namespace :absolutely_abstract do
+              resources :creative_concepts
+            end
+            resources :absolutely_abstract_creative_concepts, path: 'absolutely_abstract/creative_concepts' do
+              namespace :completely_concrete do
+                resources :tangible_things
+              end
+            end
+          end
+        end
+
+        # don't remove or edit the following comment or you'll break super scaffolding.
+        # the following routes were added by super scaffolding.
+
+        resources :invitations do
+          member do
+            get :accept
+            post :accept
+          end
+        end
+
+        resources :memberships do
+          member do
+            post :demote
+            post :promote
+          end
+        end
+
+        resources :projects do
+          scope module: 'projects' do
+            resources :milestones, only: collection_actions
+            namespace :milestones do
+              resources :included_tasks, except: collection_actions, concerns: [:sortable]
+            end
+          end
+        end
+
+        namespace :projects do
+          resources :milestones, except: collection_actions do
+            scope module: 'milestones' do
+              resources :included_tasks, only: collection_actions, concerns: [:sortable]
+            end
+          end
+        end
+      end
+      member do
+        post :switch_to
+      end
+    end
+  end
+
+  if demo?
+    get '/call', to: redirect('https://calendly.com/bullettrain/introductions'), as: 'call'
+  end
+end

--- a/bullet_train-super_scaffolding/test/lib/scaffolding/routes_file_manipulator_test.rb
+++ b/bullet_train-super_scaffolding/test/lib/scaffolding/routes_file_manipulator_test.rb
@@ -145,7 +145,7 @@ class Scaffolding::RoutesFileManipulatorTest < ActiveSupport::TestCase
     manipulator.apply(["account"])
     Scaffolding::FileManipulator.write(test_file, manipulator.lines)
 
-    manipulator = subject.new(test_file, "Projects::Milestones::IncludedTask","Projects::Milestone", {"sortable" => true})
+    manipulator = subject.new(test_file, "Projects::Milestones::IncludedTask", "Projects::Milestone", {"sortable" => true})
     manipulator.apply(["account"])
     Scaffolding::FileManipulator.write(test_file, manipulator.lines)
 

--- a/bullet_train-super_scaffolding/test/lib/scaffolding/routes_file_manipulator_test.rb
+++ b/bullet_train-super_scaffolding/test/lib/scaffolding/routes_file_manipulator_test.rb
@@ -6,6 +6,14 @@ class Scaffolding::RoutesFileManipulatorTest < ActiveSupport::TestCase
 
   def example_file = "test/lib/scaffolding/examples/example._rb"
 
+  def test_file = "tmp/test_routes._rb"
+
+  setup do
+    if File.exist?(test_file)
+      FileUtils.rm(test_file)
+    end
+  end
+
   test "initializes" do
     subject.new(example_file, "CuriousKid", ["ProtectiveParent", "Team"])
   end
@@ -122,6 +130,28 @@ class Scaffolding::RoutesFileManipulatorTest < ActiveSupport::TestCase
     manipulator = subject.new(example_file, "Example", "Team", {"sortable" => true})
     manipulator.apply(["account"])
     assert_equal File.readlines("test/lib/scaffolding/examples/result_7._rb"), manipulator.lines
+  end
+
+  test "apply gets nested models and namespaces correct" do
+    # TODO: Is there a better way to test this? I couldn't figure out how to make multiple calls to `apply` do the right thing.
+    # Writing the results of each `apply` to a file and then proceeding is the only thing that seems to work.
+    FileUtils.cp example_file, test_file
+
+    manipulator = subject.new(test_file, "Project", "Team", {})
+    manipulator.apply(["account"])
+    Scaffolding::FileManipulator.write(test_file, manipulator.lines)
+
+    manipulator = subject.new(test_file, "Projects::Milestone", "Project", {})
+    manipulator.apply(["account"])
+    Scaffolding::FileManipulator.write(test_file, manipulator.lines)
+
+    manipulator = subject.new(test_file, "Projects::Milestones::IncludedTask","Projects::Milestone", {"sortable" => true})
+    manipulator.apply(["account"])
+    Scaffolding::FileManipulator.write(test_file, manipulator.lines)
+
+    assert_equal File.readlines("test/lib/scaffolding/examples/result_8._rb"), manipulator.lines
+
+    FileUtils.rm(test_file)
   end
 
   test "apply adds the activity concern to a new resource" do


### PR DESCRIPTION
When doing this:

```
bin/rails generate super_scaffold Task Team name:text_field
bin/rails generate super_scaffold Project Team name:text_field
bin/rails generate super_scaffold Projects::Milestone Project,Team name:text_field
bin/rails generate super_scaffold Projects::Milestones::IncludedTask Projects::Milestone,Project,Team task_id:super_select{class_name=Task} details:text_field --sortable
```

We used to incorrectly nest the routes like this:

```ruby
resources :tasks

resources :projects do
  scope module: 'projects' do
    resources :milestones, only: collection_actions do
      # ⚠️ This is in the wrong place!
      scope module: 'milestones' do
        resources :included_tasks, only: collection_actions, concerns: [:sortable]
      end
    end

    namespace :milestones do
      resources :included_tasks, except: collection_actions, concerns: [:sortable]
    end
  end
end

namespace :projects do
  resources :milestones, except: collection_actions
end
```

This PR makes it so that we nest the routes correctly like this:

```ruby
resources :tasks

resources :projects do
  scope module: 'projects' do
    resources :milestones, only: collection_actions

    namespace :milestones do
      resources :included_tasks, except: collection_actions, concerns: [:sortable]
    end
  end
end

namespace :projects do
  resources :milestones, except: collection_actions do 
    # ✅ This is the right place to put this!
    scope module: 'milestones' do
      resources :included_tasks, only: collection_actions, concerns: [:sortable]
    end
  end
end
```

Fixes: https://github.com/bullet-train-co/bullet_train/issues/1655