### PR TITLE
Use `setup do` instead of `def setup` in tests

### DIFF
--- a/bullet_train-incoming_webhooks/test/controllers/webhooks/incoming/bullet_train_webhooks_controller_test.rb
+++ b/bullet_train-incoming_webhooks/test/controllers/webhooks/incoming/bullet_train_webhooks_controller_test.rb
@@ -3,8 +3,7 @@ require "test_helper"
 class Webhooks::Incoming::BulletTrainWebhooksControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
-  def setup
-    super
+  setup do
     @user = FactoryBot.create(:onboarded_user)
     @membership = @user.memberships.first
     @team = @user.current_team

--- a/bullet_train-roles/Gemfile.lock
+++ b/bullet_train-roles/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
-    nio4r (2.5.8)
+    nio4r (2.7.4)
     nokogiri (1.16.0-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.0-x86_64-darwin)
@@ -205,6 +205,7 @@ PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-darwin-21
   x86_64-linux
 

--- a/bullet_train-roles/test/lib/models/permit_test.rb
+++ b/bullet_train-roles/test/lib/models/permit_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class PermitTest < ActiveSupport::TestCase
   class ClassMethodsTest < ActiveSupport::TestCase
-    def setup
+    setup do
       @admin_user = FactoryBot.create :onboarded_user
       @admin_ability = Ability.new(@admin_user)
     end

--- a/bullet_train-roles/test/lib/models/role_test.rb
+++ b/bullet_train-roles/test/lib/models/role_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class RoleTest < ActiveSupport::TestCase
   class ClassMethodsTest < ActiveSupport::TestCase
-    def setup
+    setup do
       @admin_user = FactoryBot.create :onboarded_user
       @membership = FactoryBot.create :membership, user: @admin_user, team: @admin_user.current_team, role_ids: [Role.admin.id]
       @document = FactoryBot.create :document, membership: @membership
@@ -42,7 +42,7 @@ class RoleTest < ActiveSupport::TestCase
   end
 
   class InstanceMethodsTest < ActiveSupport::TestCase
-    def setup
+    setup do
       @admin_user = FactoryBot.create :onboarded_user
       @membership = FactoryBot.create :membership, user: @admin_user, team: @admin_user.current_team, role_ids: [Role.admin.id]
       @non_admin_user = FactoryBot.create :onboarded_user
@@ -162,7 +162,7 @@ class RoleTest < ActiveSupport::TestCase
   end
 
   class Role::AbilityGeneratorTest < ActiveSupport::TestCase
-    def setup
+    setup do
       @admin_user = FactoryBot.create :onboarded_user
       @membership = FactoryBot.create :membership, user: @admin_user, team: @admin_user.current_team, role_ids: [Role.admin.id]
       @admin_ability = Ability.new(@admin_user)


### PR DESCRIPTION
When using `def setup` things can behave unpredictably if developers forget to call `super`. Using the `setup do` hook eliminates that problem.

Partial fix for: https://github.com/bullet-train-co/bullet_train/issues/1626