### PR TITLE
dependent_fields_frame: update URL from src of ancestor turbo_frame

### DIFF
--- a/bullet_train-fields/app/javascript/controllers/dependent_fields_frame_controller.js
+++ b/bullet_train-fields/app/javascript/controllers/dependent_fields_frame_controller.js
@@ -32,7 +32,7 @@ export default class extends Controller {
   }
 
   constructNewUrlUpdatingField(fieldName, fieldValue) {
-    const url = new URL(window.location.href)
+    const url = new URL(this.currentUrl)
     url.searchParams.set(fieldName, fieldValue)
 
     return url.href
@@ -80,5 +80,10 @@ export default class extends Controller {
     }
 
     field.value = value
+  }
+
+  get currentUrl() {
+    const turboFrameWithUrl = this.element.closest("turbo-frame[src]")
+    return turboFrameWithUrl ? turboFrameWithUrl.src : window.location.href
   }
 }


### PR DESCRIPTION
Fixes #938 

![CleanShot 2024-11-09 at 11 52 04](https://github.com/user-attachments/assets/046dcd91-5940-434a-886f-fea01dc9e384)
