### PR TITLE
fix model_class_name variable in exception raise

### DIFF
--- a/bullet_train-super_load_and_authorize_resource/app/controllers/concerns/bullet_train/loads_and_authorizes_resource.rb
+++ b/bullet_train-super_load_and_authorize_resource/app/controllers/concerns/bullet_train/loads_and_authorizes_resource.rb
@@ -60,7 +60,7 @@ module BulletTrain::LoadsAndAuthorizesResource
         # reflect on the belongs_to association of the child model to figure out the class names of the parents.
         association = model_class.reflect_on_association(through_as_symbol)
         unless association
-          raise "Your 'account_load_and_authorize_resource' is broken. Tried to reflect on the `#{through_as_symbol}` association of #{model_class_name}, but didn't find one."
+          raise "Your 'account_load_and_authorize_resource' is broken. Tried to reflect on the `#{through_as_symbol}` association of #{model_class_names}, but didn't find one."
         end
 
         association.klass.name


### PR DESCRIPTION
`model_class_name` doesn't exist in the file anywhere - instead of raising the string exception an undefined local var exception is returned.

This is a super small fix so that the proper error is returned

current:
```
NameError
undefined local variable or method `model_class_name' for class
```

with change:
```
"Your 'account_load_and_authorize_resource' is broken. Tried to reflect on the `team` association of [\"example\"], but didn't find one.
```