### PR TITLE
Update sqlite3 to verison 1.7.3

### DIFF
--- a/bullet_train-api/Gemfile
+++ b/bullet_train-api/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Specify your gem's dependencies in bullet_train-api.gemspec.
 gemspec
 
-gem "sqlite3"
+gem "sqlite3", "< 2"
 
 gem "sprockets-rails"
 

--- a/bullet_train-api/Gemfile.lock
+++ b/bullet_train-api/Gemfile.lock
@@ -405,8 +405,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.0-arm64-darwin)
-    sqlite3 (1.7.0-x86_64-linux)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
     standard (1.31.1)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -456,7 +456,7 @@ DEPENDENCIES
   bullet_train-super_scaffolding!
   minitest-reporters
   sprockets-rails
-  sqlite3
+  sqlite3 (< 2)
   standard
 
 BUNDLED WITH

--- a/bullet_train-has_uuid/Gemfile
+++ b/bullet_train-has_uuid/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Specify your gem's dependencies in bullet_train-has_uuid.gemspec.
 gemspec
 
-gem "sqlite3"
+gem "sqlite3", "< 2"
 
 gem "sprockets-rails"
 

--- a/bullet_train-has_uuid/Gemfile.lock
+++ b/bullet_train-has_uuid/Gemfile.lock
@@ -185,8 +185,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.0-arm64-darwin)
-    sqlite3 (1.7.0-x86_64-linux)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
     stringio (3.0.9)
     thor (1.3.0)
     timeout (0.4.1)
@@ -200,13 +200,14 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
   bullet_train-has_uuid!
   minitest-reporters
   sprockets-rails
-  sqlite3
+  sqlite3 (< 2)
 
 BUNDLED WITH
    2.4.20

--- a/bullet_train-incoming_webhooks/Gemfile
+++ b/bullet_train-incoming_webhooks/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Specify your gem's dependencies in bullet_train-incoming_webhooks.gemspec.
 gemspec
 
-gem "sqlite3"
+gem "sqlite3", "< 2"
 
 gem "sprockets-rails"
 

--- a/bullet_train-incoming_webhooks/Gemfile.lock
+++ b/bullet_train-incoming_webhooks/Gemfile.lock
@@ -421,8 +421,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.0-arm64-darwin)
-    sqlite3 (1.7.0-x86_64-linux)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
     stringio (3.0.9)
     thor (1.3.0)
     thread-local (1.1.0)
@@ -464,7 +464,7 @@ DEPENDENCIES
   minitest-reporters
   pg (~> 1.3)
   sprockets-rails
-  sqlite3
+  sqlite3 (< 2)
 
 BUNDLED WITH
    2.4.20

--- a/bullet_train-integrations-stripe/Gemfile
+++ b/bullet_train-integrations-stripe/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Specify your gem's dependencies in bullet_train-integrations-stripe.gemspec.
 gemspec
 
-gem "sqlite3"
+gem "sqlite3", "< 2"
 
 gem "sprockets-rails"
 

--- a/bullet_train-integrations-stripe/Gemfile.lock
+++ b/bullet_train-integrations-stripe/Gemfile.lock
@@ -441,8 +441,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.0-arm64-darwin)
-    sqlite3 (1.7.0-x86_64-linux)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
     stringio (3.0.9)
     stripe (10.1.0)
     thor (1.3.0)
@@ -484,7 +484,7 @@ DEPENDENCIES
   bullet_train-super_scaffolding!
   minitest-reporters
   sprockets-rails
-  sqlite3
+  sqlite3 (< 2)
 
 BUNDLED WITH
    2.4.20

--- a/bullet_train-integrations/Gemfile
+++ b/bullet_train-integrations/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Specify your gem's dependencies in bullet_train-integrations.gemspec.
 gemspec
 
-gem "sqlite3"
+gem "sqlite3", "< 2"
 
 gem "sprockets-rails"
 

--- a/bullet_train-integrations/Gemfile.lock
+++ b/bullet_train-integrations/Gemfile.lock
@@ -185,8 +185,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.0-arm64-darwin)
-    sqlite3 (1.7.0-x86_64-linux)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
     stringio (3.0.9)
     thor (1.3.0)
     timeout (0.4.1)
@@ -207,7 +207,7 @@ DEPENDENCIES
   bullet_train-integrations!
   minitest-reporters
   sprockets-rails
-  sqlite3
+  sqlite3 (< 2)
 
 BUNDLED WITH
    2.4.20

--- a/bullet_train-obfuscates_id/Gemfile
+++ b/bullet_train-obfuscates_id/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Specify your gem's dependencies in bullet_train-obfuscates_id.gemspec.
 gemspec
 
-gem "sqlite3"
+gem "sqlite3", "< 2"
 
 gem "sprockets-rails"
 

--- a/bullet_train-obfuscates_id/Gemfile.lock
+++ b/bullet_train-obfuscates_id/Gemfile.lock
@@ -187,8 +187,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.0-arm64-darwin)
-    sqlite3 (1.7.0-x86_64-linux)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
     stringio (3.0.9)
     thor (1.3.0)
     timeout (0.4.1)
@@ -202,13 +202,14 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
   bullet_train-obfuscates_id!
   minitest-reporters
   sprockets-rails
-  sqlite3
+  sqlite3 (< 2)
 
 BUNDLED WITH
    2.4.20

--- a/bullet_train-outgoing_webhooks/Gemfile
+++ b/bullet_train-outgoing_webhooks/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Specify your gem's dependencies in bullet_train-outgoing_webhooks.gemspec.
 gemspec
 
-gem "sqlite3"
+gem "sqlite3", "< 2"
 
 gem "sprockets-rails"
 

--- a/bullet_train-outgoing_webhooks/Gemfile.lock
+++ b/bullet_train-outgoing_webhooks/Gemfile.lock
@@ -411,8 +411,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.0-arm64-darwin)
-    sqlite3 (1.7.0-x86_64-linux)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
     standard (1.31.1)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -464,7 +464,7 @@ DEPENDENCIES
   minitest-reporters
   pg (~> 1.3)
   sprockets-rails
-  sqlite3
+  sqlite3 (< 2)
   standard
 
 BUNDLED WITH

--- a/bullet_train-scope_questions/Gemfile
+++ b/bullet_train-scope_questions/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Specify your gem's dependencies in bullet_train-scope_questions.gemspec.
 gemspec
 
-gem "sqlite3"
+gem "sqlite3", "< 2"
 
 gem "sprockets-rails"
 

--- a/bullet_train-scope_questions/Gemfile.lock
+++ b/bullet_train-scope_questions/Gemfile.lock
@@ -185,8 +185,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.0-arm64-darwin)
-    sqlite3 (1.7.0-x86_64-linux)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
     stringio (3.0.9)
     thor (1.3.0)
     timeout (0.4.1)
@@ -200,13 +200,14 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
   bullet_train-scope_questions!
   minitest-reporters
   sprockets-rails
-  sqlite3
+  sqlite3 (< 2)
 
 BUNDLED WITH
    2.4.20

--- a/bullet_train-sortable/Gemfile
+++ b/bullet_train-sortable/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Specify your gem's dependencies in bullet_train-sortable.gemspec.
 gemspec
 
-gem "sqlite3"
+gem "sqlite3", "< 2"
 
 gem "sprockets-rails"
 

--- a/bullet_train-sortable/Gemfile.lock
+++ b/bullet_train-sortable/Gemfile.lock
@@ -437,8 +437,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.0-arm64-darwin)
-    sqlite3 (1.7.0-x86_64-linux)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
     standard (1.32.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -490,7 +490,7 @@ DEPENDENCIES
   bullet_train-super_scaffolding!
   minitest-reporters
   sprockets-rails
-  sqlite3
+  sqlite3 (< 2)
   standard
 
 BUNDLED WITH

--- a/bullet_train-super_load_and_authorize_resource/Gemfile
+++ b/bullet_train-super_load_and_authorize_resource/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Specify your gem's dependencies in bullet_train-super_load_and_authorize_resource.gemspec.
 gemspec
 
-gem "sqlite3"
+gem "sqlite3", "< 2"
 
 gem "sprockets-rails"
 

--- a/bullet_train-super_load_and_authorize_resource/Gemfile.lock
+++ b/bullet_train-super_load_and_authorize_resource/Gemfile.lock
@@ -192,8 +192,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.0-arm64-darwin)
-    sqlite3 (1.7.0-x86_64-linux)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
     stringio (3.0.9)
     thor (1.3.0)
     timeout (0.4.1)
@@ -207,6 +207,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -214,7 +215,7 @@ DEPENDENCIES
   minitest-reporters
   pry
   sprockets-rails
-  sqlite3
+  sqlite3 (< 2)
 
 BUNDLED WITH
    2.4.20

--- a/bullet_train-super_scaffolding/Gemfile
+++ b/bullet_train-super_scaffolding/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Specify your gem's dependencies in bullet_train-super_scaffolding.gemspec.
 gemspec
 
-gem "sqlite3"
+gem "sqlite3", "< 2"
 
 gem "sprockets-rails"
 

--- a/bullet_train-super_scaffolding/Gemfile.lock
+++ b/bullet_train-super_scaffolding/Gemfile.lock
@@ -403,8 +403,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.0-arm64-darwin)
-    sqlite3 (1.7.0-x86_64-linux)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
     standard (1.31.1)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -453,7 +453,7 @@ DEPENDENCIES
   bullet_train-super_scaffolding!
   minitest-reporters
   sprockets-rails
-  sqlite3
+  sqlite3 (< 2)
   standard
 
 BUNDLED WITH

--- a/bullet_train-themes-light/Gemfile
+++ b/bullet_train-themes-light/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Specify your gem's dependencies in bullet_train-themes-light.gemspec.
 gemspec
 
-gem "sqlite3"
+gem "sqlite3", "< 2"
 
 gem "sprockets-rails"
 

--- a/bullet_train-themes-light/Gemfile.lock
+++ b/bullet_train-themes-light/Gemfile.lock
@@ -443,8 +443,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.0-arm64-darwin)
-    sqlite3 (1.7.0-x86_64-linux)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
     standard (1.32.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -496,7 +496,7 @@ DEPENDENCIES
   bullet_train-themes-light!
   minitest-reporters
   sprockets-rails
-  sqlite3
+  sqlite3 (< 2)
   standard
 
 BUNDLED WITH

--- a/bullet_train-themes-tailwind_css/Gemfile
+++ b/bullet_train-themes-tailwind_css/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Specify your gem's dependencies in bullet_train-themes-tailwind_css.gemspec.
 gemspec
 
-gem "sqlite3"
+gem "sqlite3", "< 2"
 
 gem "sprockets-rails"
 

--- a/bullet_train-themes-tailwind_css/Gemfile.lock
+++ b/bullet_train-themes-tailwind_css/Gemfile.lock
@@ -438,8 +438,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.0-arm64-darwin)
-    sqlite3 (1.7.0-x86_64-linux)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
     standard (1.32.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -491,7 +491,7 @@ DEPENDENCIES
   bullet_train-themes-tailwind_css!
   minitest-reporters
   sprockets-rails
-  sqlite3
+  sqlite3 (< 2)
   standard
 
 BUNDLED WITH

--- a/bullet_train-themes/Gemfile
+++ b/bullet_train-themes/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Specify your gem's dependencies in bullet_train-themes.gemspec.
 gemspec
 
-gem "sqlite3"
+gem "sqlite3", "< 2"
 
 gem "sprockets-rails"
 

--- a/bullet_train-themes/Gemfile.lock
+++ b/bullet_train-themes/Gemfile.lock
@@ -404,8 +404,9 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.5.4)
+    sqlite3 (1.7.3)
       mini_portile2 (~> 2.8.0)
+    sqlite3 (1.7.3-arm64-darwin)
     standard (1.20.0)
       language_server-protocol (~> 3.17.0.2)
       rubocop (= 1.40.0)
@@ -444,7 +445,7 @@ DEPENDENCIES
   bullet_train-themes!
   minitest-reporters
   sprockets-rails
-  sqlite3
+  sqlite3 (< 2)
   standard
 
 BUNDLED WITH

--- a/bullet_train/Gemfile
+++ b/bullet_train/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Specify your gem's dependencies in bullet_train.gemspec.
 gemspec
 
-gem "sqlite3"
+gem "sqlite3", "< 2"
 
 gem "sprockets-rails"
 

--- a/bullet_train/Gemfile.lock
+++ b/bullet_train/Gemfile.lock
@@ -453,7 +453,10 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.4)
+    sqlite3 (1.7.3)
+      mini_portile2 (~> 2.8.0)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
     standard (1.19.1)
       language_server-protocol (~> 3.17.0.2)
       rubocop (= 1.39.0)
@@ -503,7 +506,7 @@ DEPENDENCIES
   pry
   pry-stack_explorer
   sprockets-rails
-  sqlite3
+  sqlite3 (< 2)
   standard
 
 BUNDLED WITH


### PR DESCRIPTION
We use this in tests for some of the gems and this updates all of the gems to be on the latest release `< 2`. This is a stepping stone PR to eventually get us to the latest version of sqlite3 (currently `2.2.0`).