### PR TITLE
Update `pagy` to version 8

### DIFF
--- a/bullet_train-api/Gemfile.lock
+++ b/bullet_train-api/Gemfile.lock
@@ -49,7 +49,7 @@ PATH
       microscope
       nice_partials (~> 0.9)
       omniauth
-      pagy (~> 7)
+      pagy (~> 8)
       possessive
       premailer-rails
       rails (>= 6.0.0)
@@ -70,7 +70,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (~> 7)
+      pagy (~> 8)
       pagy_cursor
       rack-cors
       rails (>= 6.0.0)
@@ -294,7 +294,7 @@ GEM
       rack (>= 2.2.3)
       rack-protection
     orm_adapter (0.5.0)
-    pagy (7.0.11)
+    pagy (8.6.3)
     pagy_cursor (0.8.0)
       activerecord (>= 5)
       pagy (>= 6, < 9)

--- a/bullet_train-api/Gemfile.lock
+++ b/bullet_train-api/Gemfile.lock
@@ -49,7 +49,7 @@ PATH
       microscope
       nice_partials (~> 0.9)
       omniauth
-      pagy (< 7)
+      pagy (~> 7)
       possessive
       premailer-rails
       rails (>= 6.0.0)
@@ -70,7 +70,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (< 7)
+      pagy (~> 7)
       pagy_cursor
       rack-cors
       rails (>= 6.0.0)
@@ -294,10 +294,10 @@ GEM
       rack (>= 2.2.3)
       rack-protection
     orm_adapter (0.5.0)
-    pagy (6.0.4)
-    pagy_cursor (0.6.1)
+    pagy (7.0.11)
+    pagy_cursor (0.8.0)
       activerecord (>= 5)
-      pagy (>= 6, < 7)
+      pagy (>= 6, < 9)
     parallel (1.23.0)
     parser (3.2.2.3)
       ast (~> 2.4.1)

--- a/bullet_train-api/bullet_train-api.gemspec
+++ b/bullet_train-api/bullet_train-api.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bullet_train"
 
   spec.add_dependency "rails", ">= 6.0.0"
-  spec.add_dependency "pagy", "< 7"
+  spec.add_dependency "pagy", "~> 7"
   spec.add_dependency "pagy_cursor"
   spec.add_dependency "rack-cors"
   spec.add_dependency "doorkeeper"

--- a/bullet_train-api/bullet_train-api.gemspec
+++ b/bullet_train-api/bullet_train-api.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bullet_train"
 
   spec.add_dependency "rails", ">= 6.0.0"
-  spec.add_dependency "pagy", "~> 7"
+  spec.add_dependency "pagy", "~> 8"
   spec.add_dependency "pagy_cursor"
   spec.add_dependency "rack-cors"
   spec.add_dependency "doorkeeper"

--- a/bullet_train-fields/Gemfile.lock
+++ b/bullet_train-fields/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (< 7)
+      pagy (~> 8)
       pagy_cursor
       rack-cors
       rails (>= 6.0.0)
@@ -83,7 +83,7 @@ PATH
       microscope
       nice_partials (~> 0.9)
       omniauth
-      pagy (< 7)
+      pagy (~> 8)
       possessive
       premailer-rails
       rails (>= 6.0.0)
@@ -320,7 +320,7 @@ GEM
       rack-protection
     orm_adapter (0.5.0)
     ostruct (0.6.1)
-    pagy (6.5.0)
+    pagy (8.6.3)
     pagy_cursor (0.8.0)
       activerecord (>= 5)
       pagy (>= 6, < 9)

--- a/bullet_train-incoming_webhooks/Gemfile.lock
+++ b/bullet_train-incoming_webhooks/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (< 7)
+      pagy (~> 8)
       pagy_cursor
       rack-cors
       rails (>= 6.0.0)
@@ -64,7 +64,7 @@ PATH
       microscope
       nice_partials (~> 0.9)
       omniauth
-      pagy (< 7)
+      pagy (~> 8)
       possessive
       premailer-rails
       rails (>= 6.0.0)
@@ -320,10 +320,10 @@ GEM
       rack (>= 2.2.3)
       rack-protection
     orm_adapter (0.5.0)
-    pagy (6.2.0)
-    pagy_cursor (0.6.1)
+    pagy (8.6.3)
+    pagy_cursor (0.8.0)
       activerecord (>= 5)
-      pagy (>= 6, < 7)
+      pagy (>= 6, < 9)
     pg (1.5.4)
     phonelib (0.8.5)
     possessive (1.0.1)

--- a/bullet_train-integrations-stripe/Gemfile.lock
+++ b/bullet_train-integrations-stripe/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (< 7)
+      pagy (~> 8)
       pagy_cursor
       rack-cors
       rails (>= 6.0.0)
@@ -66,7 +66,7 @@ PATH
       microscope
       nice_partials (~> 0.9)
       omniauth
-      pagy (< 7)
+      pagy (~> 8)
       possessive
       premailer-rails
       rails (>= 6.0.0)
@@ -340,10 +340,10 @@ GEM
       omniauth (~> 1.3)
       omniauth-oauth2 (~> 1.4)
     orm_adapter (0.5.0)
-    pagy (6.2.0)
-    pagy_cursor (0.6.1)
+    pagy (8.6.3)
+    pagy_cursor (0.8.0)
       activerecord (>= 5)
-      pagy (>= 6, < 7)
+      pagy (>= 6, < 9)
     phonelib (0.8.5)
     possessive (1.0.1)
     premailer (1.21.0)

--- a/bullet_train-outgoing_webhooks/Gemfile.lock
+++ b/bullet_train-outgoing_webhooks/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (< 7)
+      pagy (~> 8)
       pagy_cursor
       rack-cors
       rails (>= 6.0.0)
@@ -57,7 +57,7 @@ PATH
       microscope
       nice_partials (~> 0.9)
       omniauth
-      pagy (< 7)
+      pagy (~> 8)
       possessive
       premailer-rails
       rails (>= 6.0.0)
@@ -298,10 +298,10 @@ GEM
       rack (>= 2.2.3)
       rack-protection
     orm_adapter (0.5.0)
-    pagy (6.2.0)
-    pagy_cursor (0.6.1)
+    pagy (8.6.3)
+    pagy_cursor (0.8.0)
       activerecord (>= 5)
-      pagy (>= 6, < 7)
+      pagy (>= 6, < 9)
     parallel (1.23.0)
     parser (3.2.2.3)
       ast (~> 2.4.1)

--- a/bullet_train-sortable/Gemfile.lock
+++ b/bullet_train-sortable/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (< 7)
+      pagy (~> 8)
       pagy_cursor
       rack-cors
       rails (>= 6.0.0)
@@ -57,7 +57,7 @@ PATH
       microscope
       nice_partials (~> 0.9)
       omniauth
-      pagy (< 7)
+      pagy (~> 8)
       possessive
       premailer-rails
       rails (>= 6.0.0)
@@ -314,10 +314,10 @@ GEM
       rack (>= 2.2.3)
       rack-protection
     orm_adapter (0.5.0)
-    pagy (6.2.0)
-    pagy_cursor (0.6.1)
+    pagy (8.6.3)
+    pagy_cursor (0.8.0)
       activerecord (>= 5)
-      pagy (>= 6, < 7)
+      pagy (>= 6, < 9)
     parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)

--- a/bullet_train-super_scaffolding/Gemfile.lock
+++ b/bullet_train-super_scaffolding/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (< 7)
+      pagy (~> 8)
       pagy_cursor
       rack-cors
       rails (>= 6.0.0)
@@ -48,7 +48,7 @@ PATH
       microscope
       nice_partials (~> 0.9)
       omniauth
-      pagy (< 7)
+      pagy (~> 8)
       possessive
       premailer-rails
       rails (>= 6.0.0)
@@ -291,10 +291,10 @@ GEM
       rack (>= 2.2.3)
       rack-protection
     orm_adapter (0.5.0)
-    pagy (6.2.0)
-    pagy_cursor (0.6.1)
+    pagy (8.6.3)
+    pagy_cursor (0.8.0)
       activerecord (>= 5)
-      pagy (>= 6, < 7)
+      pagy (>= 6, < 9)
     parallel (1.23.0)
     parser (3.2.2.3)
       ast (~> 2.4.1)

--- a/bullet_train-themes-light/Gemfile.lock
+++ b/bullet_train-themes-light/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (< 7)
+      pagy (~> 8)
       pagy_cursor
       rack-cors
       rails (>= 6.0.0)
@@ -57,7 +57,7 @@ PATH
       microscope
       nice_partials (~> 0.9)
       omniauth
-      pagy (< 7)
+      pagy (~> 8)
       possessive
       premailer-rails
       rails (>= 6.0.0)
@@ -320,10 +320,10 @@ GEM
       rack (>= 2.2.3)
       rack-protection
     orm_adapter (0.5.0)
-    pagy (6.2.0)
-    pagy_cursor (0.6.1)
+    pagy (8.6.3)
+    pagy_cursor (0.8.0)
       activerecord (>= 5)
-      pagy (>= 6, < 7)
+      pagy (>= 6, < 9)
     parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)

--- a/bullet_train-themes-light/app/assets/stylesheets/light/tailwind/components.css
+++ b/bullet_train-themes-light/app/assets/stylesheets/light/tailwind/components.css
@@ -177,16 +177,15 @@
   .pagy {
     @apply flex space-x-1;
 
-    .page.prev.disabled,
-    .page.next.disabled {
-      @apply hidden;
-    }
-
     a:not(.gap) {
       @apply button-alternative;
 
       &:not([href]) { /* disabled links (aka: the current page) */
         @apply button;
+
+        &:not([aria-current]){ /* the prev link when on first page, next link when on last page */
+          @apply hidden;
+        }
       }
     }
   }

--- a/bullet_train-themes-light/app/assets/stylesheets/light/tailwind/components.css
+++ b/bullet_train-themes-light/app/assets/stylesheets/light/tailwind/components.css
@@ -174,21 +174,23 @@
     }
   }
 
-  .pagy-nav .page a,
-  .pagy-nav .page.active {
-    @apply button-alternative;
+  .pagy {
+    @apply flex space-x-1;
+
+    .page.prev.disabled,
+    .page.next.disabled {
+      @apply hidden;
+    }
+
+    a:not(.gap) {
+      @apply button-alternative;
+
+      &:not([href]) { /* disabled links (aka: the current page) */
+        @apply button;
+      }
+    }
   }
 
-  .pagy-nav .page.prev.disabled,
-  .pagy-nav .page.next.disabled {
-    @apply hidden;
-  }
-
-  .pagy-nav .page.active,
-  .pagy-nav-js .page.active {
-    @apply button;
-  }
-  
   /* Fix Safari issue related to <summary> / <details> arrow */
   details > summary.list-none::-webkit-details-marker,
   details > summary.list-none::marker {

--- a/bullet_train-themes-tailwind_css/Gemfile.lock
+++ b/bullet_train-themes-tailwind_css/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (< 7)
+      pagy (~> 8)
       pagy_cursor
       rack-cors
       rails (>= 6.0.0)
@@ -57,7 +57,7 @@ PATH
       microscope
       nice_partials (~> 0.9)
       omniauth
-      pagy (< 7)
+      pagy (~> 8)
       possessive
       premailer-rails
       rails (>= 6.0.0)
@@ -315,10 +315,10 @@ GEM
       rack (>= 2.2.3)
       rack-protection
     orm_adapter (0.5.0)
-    pagy (6.2.0)
-    pagy_cursor (0.6.1)
+    pagy (8.6.3)
+    pagy_cursor (0.8.0)
       activerecord (>= 5)
-      pagy (>= 6, < 7)
+      pagy (>= 6, < 9)
     parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)

--- a/bullet_train-themes/Gemfile.lock
+++ b/bullet_train-themes/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (< 7)
+      pagy (~> 8)
       pagy_cursor
       rack-cors
       rails (>= 6.0.0)
@@ -84,7 +84,7 @@ PATH
       microscope
       nice_partials (~> 0.9)
       omniauth
-      pagy (< 7)
+      pagy (~> 8)
       possessive
       premailer-rails
       rails (>= 6.0.0)
@@ -317,7 +317,7 @@ GEM
       rack-protection
     orm_adapter (0.5.0)
     ostruct (0.6.1)
-    pagy (6.5.0)
+    pagy (8.6.3)
     pagy_cursor (0.8.0)
       activerecord (>= 5)
       pagy (>= 6, < 9)

--- a/bullet_train/Gemfile.lock
+++ b/bullet_train/Gemfile.lock
@@ -15,7 +15,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (~> 7)
+      pagy (~> 8)
       pagy_cursor
       rack-cors
       rails (>= 6.0.0)
@@ -107,7 +107,7 @@ PATH
       microscope
       nice_partials (~> 0.9)
       omniauth
-      pagy (~> 7)
+      pagy (~> 8)
       possessive
       premailer-rails
       rails (>= 6.0.0)
@@ -340,7 +340,7 @@ GEM
       rack (>= 2.2.3)
       rack-protection
     orm_adapter (0.5.0)
-    pagy (7.0.11)
+    pagy (8.6.3)
     pagy_cursor (0.8.0)
       activerecord (>= 5)
       pagy (>= 6, < 9)

--- a/bullet_train/Gemfile.lock
+++ b/bullet_train/Gemfile.lock
@@ -15,7 +15,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (< 7)
+      pagy (~> 7)
       pagy_cursor
       rack-cors
       rails (>= 6.0.0)
@@ -107,7 +107,7 @@ PATH
       microscope
       nice_partials (~> 0.9)
       omniauth
-      pagy (< 7)
+      pagy (~> 7)
       possessive
       premailer-rails
       rails (>= 6.0.0)
@@ -340,10 +340,10 @@ GEM
       rack (>= 2.2.3)
       rack-protection
     orm_adapter (0.5.0)
-    pagy (6.1.0)
-    pagy_cursor (0.6.1)
+    pagy (7.0.11)
+    pagy_cursor (0.8.0)
       activerecord (>= 5)
-      pagy (>= 6, < 7)
+      pagy (>= 6, < 9)
     parallel (1.22.1)
     parser (3.1.3.0)
       ast (~> 2.4.1)

--- a/bullet_train/bullet_train.gemspec
+++ b/bullet_train/bullet_train.gemspec
@@ -99,7 +99,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "unicode-emoji"
 
   # Pagination.
-  spec.add_runtime_dependency "pagy", "< 7"
+  spec.add_runtime_dependency "pagy", "~> 7"
 
   # We don't want to develop in a world where we don't have `binding.pry` or `object.pry` for debugging.
   spec.add_development_dependency "pry"

--- a/bullet_train/bullet_train.gemspec
+++ b/bullet_train/bullet_train.gemspec
@@ -99,7 +99,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "unicode-emoji"
 
   # Pagination.
-  spec.add_runtime_dependency "pagy", "~> 7"
+  spec.add_runtime_dependency "pagy", "~> 8"
 
   # We don't want to develop in a world where we don't have `binding.pry` or `object.pry` for debugging.
   spec.add_development_dependency "pry"


### PR DESCRIPTION
I'm not updating all the way to version 9 because we also use `pagy_cursor` and the latest version (`0.8.0`) is pinned to `pagy` version `< 9`. If I update `pagy` to version 9 it downgrades `pagy_cursor` to `0.2.0`, which is more than 4 years old.

Related issue on `pagy_cursor`: https://github.com/Uysim/pagy-cursor/issues/68

Joint PR in the starter repo: https://github.com/bullet-train-co/bullet_train/pull/1767

In `pagy` version 7 they [changed the default text](https://github.com/ddnexus/pagy/blob/master/CHANGELOG_LEGACY.md#visual-changes-possibly-breaking-testviews) for the "next page" and "previous page" buttons. For simplicity, and to reduce the amount of code that we need to support, we're sticking with the `pagy` defaults. Previously those buttons read `< Prev` and `Next >` and now they've dropped the text and just use the symbols `<` and `>`.

If you want to maintain the previous behavior you can [copy the pagy translation file](https://github.com/ddnexus/pagy/blob/master/gem/locales/en.yml) into your app, customize it, and then [configure pagy to use it](https://ddnexus.github.io/pagy/docs/how-to/#customize-the-dictionary).

If you stick with the new defaults you may need to [update some system tests to alter how they move from page to page](https://github.com/bullet-train-co/bullet_train/pull/1767/files#diff-6ebc1d555ac83492c25fe74eb07272332f9c47aceada8081f63350d0be3d5a1b) (if you have any of your own tests around pagination).

Before upgrading `pagy`:

![CleanShot 2024-11-19 at 09 54 28](https://github.com/user-attachments/assets/91a7d5e4-3193-4625-83c0-a1cf32e0e247)

After upgrading `pagy`:

![CleanShot 2024-11-19 at 09 54 40](https://github.com/user-attachments/assets/66ca07b4-a916-4766-bc7d-766d6f0bb323)

Fixes: https://github.com/bullet-train-co/bullet_train/issues/1582
Fixes: https://github.com/bullet-train-co/bullet_train/issues/1450