### PR TITLE
Allow for comments on key lines in `roles.yml`

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/file_manipulator.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/file_manipulator.rb
@@ -50,7 +50,7 @@ module Scaffolding::FileManipulator
     insert_after = 1
     lines.each_with_index do |line, index|
       break if current_needle.nil?
-      if line.strip == current_needle + ":"
+      if line.split('#').first.strip == current_needle + ":"
         current_needle = location_array.shift.to_s
         insert_after = index
         current_space = line.match(/\s+/).to_s

--- a/bullet_train-super_scaffolding/lib/scaffolding/file_manipulator.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/file_manipulator.rb
@@ -50,7 +50,7 @@ module Scaffolding::FileManipulator
     insert_after = 1
     lines.each_with_index do |line, index|
       break if current_needle.nil?
-      if line.split('#').first.strip == current_needle + ":"
+      if line.split("#").first.strip == current_needle + ":"
         current_needle = location_array.shift.to_s
         insert_after = index
         current_space = line.match(/\s+/).to_s


### PR DESCRIPTION
Previously we were looking for exact matches on certain lines in `roles.yml`, so if you had added a trailing comment we'd end up putting things in the wrong spot.

Fixes https://github.com/bullet-train-co/bullet_train/issues/778