### PR TITLE
Better handling for empty values in some attributes

### DIFF
--- a/bullet_train-themes/app/views/themes/base/attributes/_boolean.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_boolean.html.erb
@@ -1,9 +1,15 @@
 <% object ||= current_attributes_object %>
 <% strategy ||= current_attributes_strategy || :none %>
 <% url ||= nil %>
+<% default_message = local_assigns[:default_message] || t("global.not_set") %>
+<% display_when_blank = local_assigns[:display_when_blank] || false %>
 
-<%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
-  <% unless object[attribute].nil? %>
-    <%= t("#{object.class.name.underscore.pluralize}.fields.#{attribute}.options.#{object.public_send(attribute)}") %>
+<% if !object[attribute].nil? || display_when_blank %>
+  <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
+    <% unless object[attribute].nil? %>
+      <%= t("#{object.class.name.underscore.pluralize}.fields.#{attribute}.options.#{object.public_send(attribute)}") %>
+    <% else %>
+      <%= default_message %>
+    <% end %>
   <% end %>
 <% end %>

--- a/bullet_train-themes/app/views/themes/base/attributes/_date.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_date.html.erb
@@ -2,11 +2,14 @@
 <% strategy ||= current_attributes_strategy || :none %>
 <% url ||= nil %>
 <% default_message = local_assigns[:default_message] || t('global.formats.timestamp_unavailable') %>
+<% display_when_blank = local_assigns[:display_when_blank] || false %>
 
-<% if object.public_send(attribute).present? %>
+<% if object.public_send(attribute).present? || display_when_blank %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
-    <%= display_date(object.public_send(attribute), **local_assigns.slice(:format), **local_assigns.slice(:date_format)) %>
+    <% if object.public_send(attribute).present? %>
+      <%= display_date(object.public_send(attribute), **local_assigns.slice(:format), **local_assigns.slice(:date_format)) %>
+    <% else %>
+      <%= default_message %>
+    <% end %>
   <% end %>
-<% else %>
-  <%= default_message %>
 <% end %>

--- a/bullet_train-themes/app/views/themes/base/attributes/_date_and_time.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_date_and_time.html.erb
@@ -2,11 +2,14 @@
 <% strategy ||= current_attributes_strategy || :none %>
 <% url ||= nil %>
 <% default_message = local_assigns[:default_message] || t('global.formats.timestamp_unavailable') %>
+<% display_when_blank = local_assigns[:display_when_blank] || false %>
 
-<% if object.public_send(attribute).present? %>
+<% if object.public_send(attribute).present? || display_when_blank %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
-    <%= display_date_and_time(object.public_send(attribute), **local_assigns.slice(:format), **local_assigns.slice(:date_format), **local_assigns.slice(:time_format)) %>
+    <% if object.public_send(attribute).present? %>
+      <%= display_date_and_time(object.public_send(attribute), **local_assigns.slice(:format), **local_assigns.slice(:date_format), **local_assigns.slice(:time_format)) %>
+    <% else %>
+      <%= default_message %>
+    <% end %>
   <% end %>
-<% else %>
-  <%= default_message %>
 <% end %>

--- a/bullet_train-themes/app/views/themes/base/attributes/_days_ago.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_days_ago.html.erb
@@ -2,11 +2,14 @@
 <% strategy ||= current_attributes_strategy || :none %>
 <% url ||= nil %>
 <% default_message = local_assigns[:default_message] || t("global.never") %>
+<% display_when_blank = local_assigns[:display_when_blank] || false %>
 
-<%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
-  <% if object.public_send(attribute) %>
-    <%= t("global.time_ago", time: time_ago_in_words(object.send(attribute))) %>
-  <% else %>
-    <%= default_message %>
+<% if object.public_send(attribute) || display_when_blank %>
+  <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
+    <% if object.public_send(attribute).present? %>
+      <%= t("global.time_ago", time: time_ago_in_words(object.send(attribute))) %>
+    <% else %>
+      <%= default_message %>
+    <% end %>
   <% end %>
 <% end %>

--- a/bullet_train/config/locales/en/base.yml
+++ b/bullet_train/config/locales/en/base.yml
@@ -48,6 +48,7 @@ en:
     creator: Bullet Train, Inc.
     time_ago: "%{time} ago"
     never: Never
+    not_set: Not Set
     buttons:
       other: Other
       debug: Debug


### PR DESCRIPTION
Fixes https://github.com/bullet-train-co/bullet_train-core/issues/247

The attribute display for `date`, `date_and_time`, and `boolean_button` did some unexpected things if the attribute in question was empty.

* `boolean_button` would display a label, but no value.
* `date` and `date_and_time` would display the word "Never" but without a label

All of the other attribute type don't display anything if their value is empty.

In order to allow apps to continue to show those values even if they are empty (but now with a label) those attribute partials now accept a `display_when_blank` option. It can be used like this:

```erb
<%= render 'shared/attributes/date', attribute: :date_field_value, display_when_blank: true %>
```

Before:

![CleanShot 2024-11-21 at 10 26 41](https://github.com/user-attachments/assets/6120ac58-a866-4d20-8430-7464ba50c6fc)

After, default behavior:

![CleanShot 2024-11-21 at 10 29 54](https://github.com/user-attachments/assets/995fa88c-7285-4451-afa1-f3070480d1b4)

After, passing `display_when_blank: true`:

![CleanShot 2024-11-21 at 10 34 09](https://github.com/user-attachments/assets/4d601d44-6ad3-4202-a8f4-6b236742f7ce)
