### PR TITLE
Remove dependency on bullet_train-routes

### DIFF
--- a/bullet_train-api/Gemfile.lock
+++ b/bullet_train-api/Gemfile.lock
@@ -59,7 +59,6 @@ PATH
       bullet_train-fields
       bullet_train-has_uuid
       bullet_train-roles
-      bullet_train-routes
       bullet_train-scope_validator
       bullet_train-super_load_and_authorize_resource
       bullet_train-themes
@@ -183,8 +182,6 @@ GEM
     base64 (0.1.1)
     bcrypt (3.1.19)
     builder (3.2.4)
-    bullet_train-routes (1.0.0)
-      rails (>= 6.0.0)
     cable_ready (5.0.1)
       actionpack (>= 5.2)
       actionview (>= 5.2)

--- a/bullet_train-fields/Gemfile.lock
+++ b/bullet_train-fields/Gemfile.lock
@@ -65,7 +65,6 @@ PATH
       bullet_train-fields
       bullet_train-has_uuid
       bullet_train-roles
-      bullet_train-routes
       bullet_train-scope_validator
       bullet_train-super_load_and_authorize_resource
       bullet_train-themes
@@ -182,8 +181,6 @@ GEM
     base64 (0.2.0)
     bcrypt (3.1.20)
     builder (3.2.4)
-    bullet_train-routes (1.0.0)
-      rails (>= 6.0.0)
     cable_ready (5.0.5)
       actionpack (>= 5.2)
       actionview (>= 5.2)

--- a/bullet_train-incoming_webhooks/Gemfile.lock
+++ b/bullet_train-incoming_webhooks/Gemfile.lock
@@ -74,7 +74,6 @@ PATH
       bullet_train-fields
       bullet_train-has_uuid
       bullet_train-roles
-      bullet_train-routes
       bullet_train-scope_validator
       bullet_train-super_load_and_authorize_resource
       bullet_train-themes
@@ -201,8 +200,6 @@ GEM
     bcrypt (3.1.19)
     bigdecimal (3.1.4)
     builder (3.2.4)
-    bullet_train-routes (1.0.0)
-      rails (>= 6.0.0)
     cable_ready (5.0.3)
       actionpack (>= 5.2)
       actionview (>= 5.2)

--- a/bullet_train-integrations-stripe/Gemfile.lock
+++ b/bullet_train-integrations-stripe/Gemfile.lock
@@ -83,7 +83,6 @@ PATH
       bullet_train-fields
       bullet_train-has_uuid
       bullet_train-roles
-      bullet_train-routes
       bullet_train-scope_validator
       bullet_train-super_load_and_authorize_resource
       bullet_train-themes
@@ -211,8 +210,6 @@ GEM
     bcrypt (3.1.19)
     bigdecimal (3.1.4)
     builder (3.2.4)
-    bullet_train-routes (1.0.0)
-      rails (>= 6.0.0)
     cable_ready (5.0.3)
       actionpack (>= 5.2)
       actionview (>= 5.2)

--- a/bullet_train-outgoing_webhooks/Gemfile.lock
+++ b/bullet_train-outgoing_webhooks/Gemfile.lock
@@ -74,7 +74,6 @@ PATH
       bullet_train-fields
       bullet_train-has_uuid
       bullet_train-roles
-      bullet_train-routes
       bullet_train-scope_validator
       bullet_train-super_load_and_authorize_resource
       bullet_train-themes
@@ -190,8 +189,6 @@ GEM
     base64 (0.1.1)
     bcrypt (3.1.19)
     builder (3.2.4)
-    bullet_train-routes (1.0.0)
-      rails (>= 6.0.0)
     cable_ready (5.0.3)
       actionpack (>= 5.2)
       actionview (>= 5.2)

--- a/bullet_train-sortable/Gemfile.lock
+++ b/bullet_train-sortable/Gemfile.lock
@@ -74,7 +74,6 @@ PATH
       bullet_train-fields
       bullet_train-has_uuid
       bullet_train-roles
-      bullet_train-routes
       bullet_train-scope_validator
       bullet_train-super_load_and_authorize_resource
       bullet_train-themes
@@ -199,8 +198,6 @@ GEM
     bcrypt (3.1.19)
     bigdecimal (3.1.4)
     builder (3.2.4)
-    bullet_train-routes (1.0.0)
-      rails (>= 6.0.0)
     cable_ready (5.0.3)
       actionpack (>= 5.2)
       actionview (>= 5.2)

--- a/bullet_train-super_scaffolding/Gemfile.lock
+++ b/bullet_train-super_scaffolding/Gemfile.lock
@@ -65,7 +65,6 @@ PATH
       bullet_train-fields
       bullet_train-has_uuid
       bullet_train-roles
-      bullet_train-routes
       bullet_train-scope_validator
       bullet_train-super_load_and_authorize_resource
       bullet_train-themes
@@ -183,8 +182,6 @@ GEM
     base64 (0.1.1)
     bcrypt (3.1.19)
     builder (3.2.4)
-    bullet_train-routes (1.0.0)
-      rails (>= 6.0.0)
     cable_ready (5.0.3)
       actionpack (>= 5.2)
       actionview (>= 5.2)

--- a/bullet_train-themes-light/Gemfile.lock
+++ b/bullet_train-themes-light/Gemfile.lock
@@ -81,7 +81,6 @@ PATH
       bullet_train-fields
       bullet_train-has_uuid
       bullet_train-roles
-      bullet_train-routes
       bullet_train-scope_validator
       bullet_train-super_load_and_authorize_resource
       bullet_train-themes
@@ -208,8 +207,6 @@ GEM
     bcrypt (3.1.19)
     bigdecimal (3.1.4)
     builder (3.2.4)
-    bullet_train-routes (1.0.0)
-      rails (>= 6.0.0)
     cable_ready (5.0.3)
       actionpack (>= 5.2)
       actionview (>= 5.2)

--- a/bullet_train-themes-tailwind_css/Gemfile.lock
+++ b/bullet_train-themes-tailwind_css/Gemfile.lock
@@ -74,7 +74,6 @@ PATH
       bullet_train-fields
       bullet_train-has_uuid
       bullet_train-roles
-      bullet_train-routes
       bullet_train-scope_validator
       bullet_train-super_load_and_authorize_resource
       bullet_train-themes
@@ -200,8 +199,6 @@ GEM
     bcrypt (3.1.19)
     bigdecimal (3.1.4)
     builder (3.2.4)
-    bullet_train-routes (1.0.0)
-      rails (>= 6.0.0)
     cable_ready (5.0.3)
       actionpack (>= 5.2)
       actionview (>= 5.2)

--- a/bullet_train-themes/Gemfile.lock
+++ b/bullet_train-themes/Gemfile.lock
@@ -66,7 +66,6 @@ PATH
       bullet_train-fields
       bullet_train-has_uuid
       bullet_train-roles
-      bullet_train-routes
       bullet_train-scope_validator
       bullet_train-super_load_and_authorize_resource
       bullet_train-themes
@@ -182,8 +181,6 @@ GEM
     base64 (0.2.0)
     bcrypt (3.1.20)
     builder (3.2.4)
-    bullet_train-routes (1.0.0)
-      rails (>= 6.0.0)
     cable_ready (5.0.5)
       actionpack (>= 5.2)
       actionview (>= 5.2)

--- a/bullet_train/Gemfile.lock
+++ b/bullet_train/Gemfile.lock
@@ -96,7 +96,6 @@ PATH
       bullet_train-fields
       bullet_train-has_uuid
       bullet_train-roles
-      bullet_train-routes
       bullet_train-scope_validator
       bullet_train-super_load_and_authorize_resource
       bullet_train-themes
@@ -205,8 +204,6 @@ GEM
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.4)
-    bullet_train-routes (1.0.0)
-      rails (>= 6.0.0)
     cable_ready (5.0.1)
       actionpack (>= 5.2)
       actionview (>= 5.2)

--- a/bullet_train/bullet_train.gemspec
+++ b/bullet_train/bullet_train.gemspec
@@ -38,7 +38,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bullet_train-has_uuid"
   spec.add_dependency "bullet_train-scope_validator"
   spec.add_dependency "bullet_train-themes"
-  spec.add_dependency "bullet_train-routes"
   spec.add_dependency "bullet_train-fields"
   spec.add_dependency "colorizer"
   spec.add_dependency "devise"


### PR DESCRIPTION
Is this gem actually used anymore? (Was it ever actually used?)