### PR TITLE
Slim down mailer payloads by including less CSS

### DIFF
--- a/bullet_train-themes-light/app/views/themes/light/layouts/_mailer.html.erb
+++ b/bullet_train-themes-light/app/views/themes/light/layouts/_mailer.html.erb
@@ -4,7 +4,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <title>Welcome to <%= t('application.name') %>!</title>
 
-    <%= stylesheet_link_tag 'application', media: 'all'%>
     <%= stylesheet_link_tag 'application.mailer.light', media: 'all' %>
 
     <% # TODO: Find out why Tailwind colors aren't working properly. %>


### PR DESCRIPTION
Including both `application.css` and `application.mailer.light.css` is redundant, and `application.css` includes a lot of things that aren't needed in mailers.

Fixes https://github.com/bullet-train-co/bullet_train-core/issues/293