### PR TITLE
Allow more field partials to be disabled

### DIFF
--- a/bullet_train-themes-light/app/assets/stylesheets/light/fields/trix_editor.css
+++ b/bullet_train-themes-light/app/assets/stylesheets/light/fields/trix_editor.css
@@ -92,6 +92,9 @@ trix-editor {
     border-color: var(--primary-500);
     box-shadow: inset 0 0 0 1px var(--primary-500);
   }
+  &[disabled]{
+    @apply bg-slate-200 dark:bg-slate-700 hover:bg-slate-200 hover:dark:bg-slate-700
+  }
 }
 
 .trix-hide-toolbar {

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_color_picker.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_color_picker.html.erb
@@ -40,11 +40,17 @@ end
 value = form.object.send(method)
 
 color_selected_classes = "ring-2 ring-offset-2"
+
+input_classes = "rounded-md shadow-sm font-light font-mono text-sm focus:ring-blue focus:border-blue border-slate-300 w-48 dark:bg-slate-800 dark:border-slate-900"
+if options[:disabled]
+  input_classes += " bg-slate-200 dark:bg-slate-700 hover:bg-slate-200 hover:dark:bg-slate-700"
+  stimulus_controller = ""
+end
 %>
 
 <% content = render 'shared/fields/field', form: form, method: method, options: options, other_options: other_options do %>
   <% content_for :field do %>
-    <div class="space-x-1" 
+    <div class="space-x-1"
       data-controller="<%= stimulus_controller %>"
       data-<%= stimulus_controller %>-initial-color-value="<%= value %>"
       data-<%= stimulus_controller %>-color-selected-class="<%= color_selected_classes %>"
@@ -53,7 +59,13 @@ color_selected_classes = "ring-2 ring-offset-2"
       <div class="inline space-x-1" data-<%= stimulus_controller %>-target="colorOptions">
         <% color_picker_field_options.each do |color| %>
           <label class="btn-toggle btn-color-picker">
-            <button type="button" class="button-color mb-1.5 dark:ring-offset-slate-700 <%= color == value ? color_selected_classes : '' %>" style="background-color: <%= color %>; --tw-ring-color: <%= color %>" data-action="<%= stimulus_controller %>#pickColor" data-<%= stimulus_controller %>-target="colorButton" data-color="<%= color %>">&nbsp;</button>
+            <button type="button"
+                    class="button-color mb-1.5 dark:ring-offset-slate-700 <%= color == value ? color_selected_classes : '' %>"
+                    style="background-color: <%= color %>; --tw-ring-color: <%= color %>"
+                    data-action="<%= stimulus_controller %>#pickColor"
+                    data-<%= stimulus_controller %>-target="colorButton"
+                    data-color="<%= color %>"
+                    <%= "disabled"if options[:disabled] %>>&nbsp;</button>
           </label>
         <% end %>
       </div>
@@ -61,7 +73,7 @@ color_selected_classes = "ring-2 ring-offset-2"
         <button type="button" class="button-color mr-1 dark:ring-offset-slate-700 <%= value.blank? || color_picker_field_options.include?(value) ? 'hidden' : color_selected_classes %>" data-action="<%= stimulus_controller %>#pickColor" data-<%= stimulus_controller %>-target="userSelectedColor colorButton" data-color="<%= value %>" style="background-color: <%= value %>; --tw-ring-color: <%= value %>">&nbsp;</button>
       </label>
       <span class="relative">
-        <input type="text" disabled="disabled" class="rounded-md shadow-sm font-light font-mono text-sm focus:ring-blue focus:border-blue border-slate-300 w-48 dark:bg-slate-800 dark:border-slate-900" value="<%= value %>" data-<%= stimulus_controller %>-target="colorInput"/>
+        <input type="text" disabled="disabled" class="<%= input_classes %>" value="<%= value %>" data-<%= stimulus_controller %>-target="colorInput"/>
         <span class="absolute right-0">
           <button type="button" class="py-2 px-1 border border-transparent inline-flex items-center whitespace-nowrap rounded-md text-lg" data-action="<%= stimulus_controller %>#pickRandomColor">
             <i class="leading-5 ti ti-reload dark:text-blue-500"></i>

--- a/bullet_train-themes/app/views/themes/base/fields/_trix_editor.html.erb
+++ b/bullet_train-themes/app/views/themes/base/fields/_trix_editor.html.erb
@@ -32,8 +32,6 @@ options[:data][:topics] ||= []
 <% if options[:disabled] %>
   <script charset="utf-8">
     document.addEventListener("trix-initialize", function() {
-      console.log("element");
-      console.log(document.getElementById("<%= field_id(form.object, method) %>"));
       document.getElementById("<%= field_id(form.object, method) %>").editor.element.setAttribute('contentEditable', false)
     });
   </script>

--- a/bullet_train-themes/app/views/themes/base/fields/_trix_editor.html.erb
+++ b/bullet_train-themes/app/views/themes/base/fields/_trix_editor.html.erb
@@ -28,3 +28,13 @@ options[:data][:topics] ||= []
   <% end %>
 <% end %>
 </div>
+
+<% if options[:disabled] %>
+  <script charset="utf-8">
+    document.addEventListener("trix-initialize", function() {
+      console.log("element");
+      console.log(document.getElementById("<%= field_id(form.object, method) %>"));
+      document.getElementById("<%= field_id(form.object, method) %>").editor.element.setAttribute('contentEditable', false)
+    });
+  </script>
+<% end %>


### PR DESCRIPTION
Makes some progress on https://github.com/bullet-train-co/bullet_train-core/issues/573

This allows `color_picker` fields to be disabled:

![CleanShot 2024-11-25 at 17 01 01](https://github.com/user-attachments/assets/0e349ed0-553b-4496-989b-0fc10682dab3)

As well as `trix_editor` fields:

![CleanShot 2024-11-25 at 17 01 08](https://github.com/user-attachments/assets/54076894-77d6-48c6-964a-7b8c58886592)
