### PR TITLE
Allow address fields to be disabled

### DIFF
--- a/bullet_train-themes-light/app/assets/stylesheets/light/fields/super_select.css
+++ b/bullet_train-themes-light/app/assets/stylesheets/light/fields/super_select.css
@@ -91,6 +91,10 @@
     }
   }
 
+  .select2-container--default.select2-container--disabled .select2-selection--single{
+    @apply bg-slate-200 dark:bg-slate-700 hover:bg-slate-200 hover:dark:bg-slate-700
+  }
+
   .select2-container .select2-dropdown {
     @apply border-2 border-slate-300 shadow-sm overflow-hidden !important;
     @apply border-primary-500 !important;

--- a/bullet_train-themes-light/app/assets/stylesheets/light/fields/super_select.css
+++ b/bullet_train-themes-light/app/assets/stylesheets/light/fields/super_select.css
@@ -91,7 +91,8 @@
     }
   }
 
-  .select2-container--default.select2-container--disabled .select2-selection--single{
+  .select2-container--default.select2-container--disabled .select2-selection--single,
+  .select2-container--default.select2-container--disabled .select2-selection--multiple{
     @apply bg-slate-200 dark:bg-slate-700 hover:bg-slate-200 hover:dark:bg-slate-700
   }
 

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_address_field.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_address_field.html.erb
@@ -9,8 +9,10 @@ options ||= {}
 
 country_html_options ||= {}
 country_html_options[:data] ||= {}
-
 postal_code_options ||= {}
+postal_code_options[:data] ||= {}
+region_html_options ||= {}
+region_html_options[:data] ||= {}
 
 if options[:disabled].present?
   country_html_options[:disabled] = options[:disabled]
@@ -54,7 +56,14 @@ end
           html_options: { class: "block space-y-5" } do |dependent_fields_controller_name|
         %>
           <%
-            postal_code_options[:data] ||= { "#{dependent_fields_controller_name}-target": "field" }
+            # These have to be here instead of at the top of the file so that we have access
+            # to the address_form and dependent_fields_controller_name variables.
+            postal_code_options[:data]["#{dependent_fields_controller_name}-target"] ||= "field"
+            region_html_options[:data]["#{dependent_fields_controller_name}-target"] ||= "field"
+            region_html_options[:disabled] ||= address_form.object.country_id.nil?
+            if options[:disabled].present?
+              region_html_options[:disabled] = options[:disabled]
+            end
           %>
           <div class="grid grid-cols-1 gap-y gap-x sm:grid-cols-2">
             <div class="sm:col-span-1">
@@ -67,12 +76,7 @@ end
                   wrapper_class: "col-span-2 lg:col-span-1",
                   label: admin_division_label_for(address_form)
                 },
-                html_options: {
-                  disabled: address_form.object.country_id.nil?,
-                  data: {
-                    "#{dependent_fields_controller_name}-target": "field"
-                  }
-                }
+                html_options: region_html_options
               %>
             </div>
 

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_address_field.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_address_field.html.erb
@@ -10,11 +10,11 @@ form ||= current_fields_form
 
 <%= form.fields_for(method) do |address_form| %>
   <% with_field_settings form: address_form do %>
-  
+
     <%= render 'shared/fields/super_select',
       method: :country_id,
       choices: populate_country_options,
-      options: {include_blank: true}, 
+      options: {include_blank: true},
       other_options: {search: true, wrapper_class: "col-span-2"},
       html_options: {data: {}},
       wrapper_options: {
@@ -25,10 +25,10 @@ form ||= current_fields_form
         }
       }
     %>
-    
+
     <%= render 'shared/fields/text_field', method: :address_one %>
     <%= render 'shared/fields/text_field', method: :address_two %>
-    
+
     <div class="grid grid-cols-1 gap-y gap-x sm:grid-cols-3">
       <div class="sm:col-span-1">
         <%= render 'shared/fields/text_field', method: :city,
@@ -36,13 +36,13 @@ form ||= current_fields_form
         %>
       </div>
       <div class="sm:col-span-2">
-        <%= render "shared/fields/dependent_fields_frame", 
+        <%= render "shared/fields/dependent_fields_frame",
           id: address_form.field_id(:country, :dependent_fields),
           form: address_form,
           dependable_fields: [:country_id],
           html_options: { class: "block space-y-5" } do |dependent_fields_controller_name|
         %>
-        
+
           <div class="grid grid-cols-1 gap-y gap-x sm:grid-cols-2">
             <div class="sm:col-span-1">
               <%= render 'shared/fields/super_select',
@@ -62,7 +62,7 @@ form ||= current_fields_form
                 }
               %>
             </div>
-            
+
             <div class="sm:col-span-1">
               <%= render 'shared/fields/text_field', method: :postal_code,
                 options: {
@@ -77,7 +77,7 @@ form ||= current_fields_form
               %>
             </div>
           </div>
-        
+
         <% end %>
       </div>
     </div>

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_address_field.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_address_field.html.erb
@@ -9,6 +9,9 @@ options ||= {}
 
 country_html_options ||= {}
 country_html_options[:data] ||= {}
+address_one_options ||= {}
+address_two_options ||= {}
+city_options ||= {}
 postal_code_options ||= {}
 postal_code_options[:data] ||= {}
 region_html_options ||= {}
@@ -16,6 +19,9 @@ region_html_options[:data] ||= {}
 
 if options[:disabled].present?
   country_html_options[:disabled] = options[:disabled]
+  address_one_options[:disabled] = options[:disabled]
+  address_two_options[:disabled] = options[:disabled]
+  city_options[:disabled] = options[:disabled]
   postal_code_options[:disabled] = options[:disabled]
 end
 %>
@@ -38,13 +44,13 @@ end
       }
     %>
 
-    <%= render 'shared/fields/text_field', method: :address_one, options: options %>
-    <%= render 'shared/fields/text_field', method: :address_two, options: options %>
+    <%= render 'shared/fields/text_field', method: :address_one, options: address_one_options %>
+    <%= render 'shared/fields/text_field', method: :address_two, options: address_two_options %>
 
     <div class="grid grid-cols-1 gap-y gap-x sm:grid-cols-3">
       <div class="sm:col-span-1">
         <%= render 'shared/fields/text_field', method: :city,
-          options: options,
+          options: city_options,
           other_options: {wrapper_class: "col-span-2 lg:col-span-1"}
         %>
       </div>
@@ -61,7 +67,10 @@ end
             postal_code_options[:data]["#{dependent_fields_controller_name}-target"] ||= "field"
             region_html_options[:data]["#{dependent_fields_controller_name}-target"] ||= "field"
             region_html_options[:disabled] ||= address_form.object.country_id.nil?
-            if options[:disabled].present?
+            # If the entire address field is disabled, we clobber the :disabled value that we
+            # calculate based on the country field. This makes it so that region will still be
+            # disabled even if the address field had been filled out previously.
+            if options[:disabled].present? && options[:disabled]
               region_html_options[:disabled] = options[:disabled]
             end
           %>

--- a/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_address_field.html.erb
+++ b/bullet_train-themes-tailwind_css/app/views/themes/tailwind_css/fields/_address_field.html.erb
@@ -4,8 +4,18 @@
 form ||= current_fields_form
 
 # TODO: All options and other_options below are written inline. Do we need these?
-# options ||= {}
+options ||= {}
 # other_options ||= {}
+
+country_html_options ||= {}
+country_html_options[:data] ||= {}
+
+postal_code_options ||= {}
+
+if options[:disabled].present?
+  country_html_options[:disabled] = options[:disabled]
+  postal_code_options[:disabled] = options[:disabled]
+end
 %>
 
 <%= form.fields_for(method) do |address_form| %>
@@ -16,7 +26,7 @@ form ||= current_fields_form
       choices: populate_country_options,
       options: {include_blank: true},
       other_options: {search: true, wrapper_class: "col-span-2"},
-      html_options: {data: {}},
+      html_options: country_html_options,
       wrapper_options: {
         data: {
           'controller': "dependable",
@@ -26,12 +36,13 @@ form ||= current_fields_form
       }
     %>
 
-    <%= render 'shared/fields/text_field', method: :address_one %>
-    <%= render 'shared/fields/text_field', method: :address_two %>
+    <%= render 'shared/fields/text_field', method: :address_one, options: options %>
+    <%= render 'shared/fields/text_field', method: :address_two, options: options %>
 
     <div class="grid grid-cols-1 gap-y gap-x sm:grid-cols-3">
       <div class="sm:col-span-1">
         <%= render 'shared/fields/text_field', method: :city,
+          options: options,
           other_options: {wrapper_class: "col-span-2 lg:col-span-1"}
         %>
       </div>
@@ -42,7 +53,9 @@ form ||= current_fields_form
           dependable_fields: [:country_id],
           html_options: { class: "block space-y-5" } do |dependent_fields_controller_name|
         %>
-
+          <%
+            postal_code_options[:data] ||= { "#{dependent_fields_controller_name}-target": "field" }
+          %>
           <div class="grid grid-cols-1 gap-y gap-x sm:grid-cols-2">
             <div class="sm:col-span-1">
               <%= render 'shared/fields/super_select',
@@ -65,11 +78,7 @@ form ||= current_fields_form
 
             <div class="sm:col-span-1">
               <%= render 'shared/fields/text_field', method: :postal_code,
-                options: {
-                  data: {
-                    "#{dependent_fields_controller_name}-target": "field"
-                  }
-                },
+                options: postal_code_options,
                 other_options: {
                   wrapper_class: "col-span-2 lg:col-span-1",
                   label: postal_code_label_for(address_form)


### PR DESCRIPTION
This allows you to pass `options: {disabled: true}` to disable the entire address field.

Like this:

```erb
<%= render 'shared/fields/address_field', method: :address_value, options: {disabled: true} %>
```

It disabled every input that's a part of the address, regardless of whether the address has been populated previously.

Empty initial state:

![CleanShot 2024-11-26 at 10 24 13](https://github.com/user-attachments/assets/73a1784e-1e9d-4707-83ea-d1bf49d76616)

With a previously populated address:

![CleanShot 2024-11-26 at 10 24 44](https://github.com/user-attachments/assets/09f85e94-45fd-44e0-ba64-a99167054617)

This finally fixes #573 
