### PR TITLE
Make super selects a consistent height for single and multiple selects

### DIFF
--- a/bullet_train-themes-light/app/assets/stylesheets/light/fields/super_select.css
+++ b/bullet_train-themes-light/app/assets/stylesheets/light/fields/super_select.css
@@ -5,7 +5,8 @@
   }
 }
 
-.select2-selection.select2-selection--single {
+.select2-selection.select2-selection--single,
+.select2-selection.select2-selection--multiple {
   min-height: 37px;
   .select2-selection__rendered {
     padding-left: 12px;
@@ -53,8 +54,9 @@
     box-shadow: inset 0 0 0 1px var(--primary-500) !important;
     outline: 0 !important;
   }
-  
-  .select2-selection--single {
+
+  .select2-selection--single,
+  .select2-selection--multiple {
     height: 38px !important;
   }
 


### PR DESCRIPTION
Fixes: https://github.com/bullet-train-co/bullet_train-core/issues/975

It turns out that we had specifically targeted single super selects with some height related rules to make them the same size as text inputs. Applying the same rules to multiple super selects fixed the problem.

Before:

![CleanShot 2024-11-26 at 12 24 59](https://github.com/user-attachments/assets/0ee36472-b337-4145-83a1-acca75688027)


After:

![CleanShot 2024-11-26 at 12 25 30](https://github.com/user-attachments/assets/ea888b59-7667-4a06-a2e5-83380c225c5c)
