### PR TITLE
Improvements for CI in GitHub Actions

### DIFF
--- a/.github/workflows/_combine_coverage_data.yml
+++ b/.github/workflows/_combine_coverage_data.yml
@@ -156,13 +156,13 @@ jobs:
             }
             core.summary.write()
 
-  remove_coverage_data:
-    name: "Cleanup"
-    runs-on: ubuntu-latest
-    needs: combine_coverage_data
-    steps:
-      - name: Delete artifacts
-        uses: geekyeggo/delete-artifact@v5
-        with:
-          name: test_coverage_*.log
-          failOnError: false
+  #remove_coverage_data:
+    #name: "Cleanup"
+    #runs-on: ubuntu-latest
+    #needs: combine_coverage_data
+    #steps:
+      #- name: Delete artifacts
+        #uses: geekyeggo/delete-artifact@v5
+        #with:
+          #name: test_coverage_*.log
+          #failOnError: false

--- a/.github/workflows/_combine_coverage_data.yml
+++ b/.github/workflows/_combine_coverage_data.yml
@@ -159,6 +159,7 @@ jobs:
       - name: Delete artifacts
         uses: geekyeggo/delete-artifact@v5
         with:
-            name: test_coverage_*.log
+          name: test_coverage_*.log
+          failOnError: false
 
 

--- a/.github/workflows/_combine_coverage_data.yml
+++ b/.github/workflows/_combine_coverage_data.yml
@@ -161,8 +161,8 @@ jobs:
     #runs-on: ubuntu-latest
     #needs: combine_coverage_data
     #steps:
-      #- name: Delete artifacts
-        #uses: geekyeggo/delete-artifact@v5
-        #with:
-          #name: test_coverage_*.log
-          #failOnError: false
+      - name: Delete artifacts
+        uses: geekyeggo/delete-artifact@v5
+        with:
+          name: test_coverage_*.log
+          failOnError: false

--- a/.github/workflows/_combine_coverage_data.yml
+++ b/.github/workflows/_combine_coverage_data.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout Core Repo
         uses: actions/checkout@v4
         with:
-          path: tmp/starter/local-core
+          path: tmp/starter/local/bullet_train-core
 
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/_combine_coverage_data.yml
+++ b/.github/workflows/_combine_coverage_data.yml
@@ -23,6 +23,11 @@ jobs:
           target_dir: tmp/starter
           repository: bullet-train-co/bullet_train
 
+      - name: Checkout Core Repo
+        uses: actions/checkout@v4
+        with:
+          path: tmp/starter/core
+
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/_combine_coverage_data.yml
+++ b/.github/workflows/_combine_coverage_data.yml
@@ -2,13 +2,13 @@
 # them into one set of test coverage data.
 #
 # This workflow is meant to be called by other workflows.
-name: "🫣 SimpleCov Report"
+name: "♻️  SimpleCov Report"
 on:
   workflow_call:
 
 jobs:
   combine_coverage_data:
-    name: "🫣"
+    name: "♻️ "
     runs-on: ubuntu-latest
     env:
       RAILS_ENV: test

--- a/.github/workflows/_combine_coverage_data.yml
+++ b/.github/workflows/_combine_coverage_data.yml
@@ -7,7 +7,7 @@ on:
   workflow_call:
 
 jobs:
-  combine_runtime_logs:
+  combine_coverage_data:
     name: "🫣"
     runs-on: ubuntu-latest
     env:
@@ -156,10 +156,13 @@ jobs:
             }
             core.summary.write()
 
+  remove_coverage_data:
+    name: "Cleanup"
+    runs-on: ubuntu-latest
+    needs: combine_coverage_data
+    steps:
       - name: Delete artifacts
         uses: geekyeggo/delete-artifact@v5
         with:
           name: test_coverage_*.log
           failOnError: false
-
-

--- a/.github/workflows/_combine_coverage_data.yml
+++ b/.github/workflows/_combine_coverage_data.yml
@@ -40,6 +40,9 @@ jobs:
         run: ls -alR tmp/starter/coverage_artifacts
         shell: bash
 
+      - name: Cat an artifact
+        run: cat tmp/starter/coverage_artifacts/test_coverage_*.log/.resultset.json
+        shell: bash
 
       - name: Combine Coverage Data With Groups
         working-directory: tmp/starter

--- a/.github/workflows/_combine_coverage_data.yml
+++ b/.github/workflows/_combine_coverage_data.yml
@@ -156,11 +156,6 @@ jobs:
             }
             core.summary.write()
 
-  #remove_coverage_data:
-    #name: "Cleanup"
-    #runs-on: ubuntu-latest
-    #needs: combine_coverage_data
-    #steps:
       - name: Delete artifacts
         uses: geekyeggo/delete-artifact@v5
         with:

--- a/.github/workflows/_combine_coverage_data.yml
+++ b/.github/workflows/_combine_coverage_data.yml
@@ -23,6 +23,8 @@ jobs:
           target_dir: tmp/starter
           repository: bullet-train-co/bullet_train
 
+      # We have to put the core code into place so that simplecov will recognize
+      # it as being part of the probject when it collates all the coverage data.
       - name: Checkout Core Repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/_combine_coverage_data.yml
+++ b/.github/workflows/_combine_coverage_data.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout Core Repo
         uses: actions/checkout@v4
         with:
-          path: tmp/starter/core
+          path: tmp/starter/local-core
 
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
@@ -53,7 +53,7 @@ jobs:
 
       - name: Combine Coverage Data With Groups
         working-directory: tmp/starter
-        run: "bundle exec rake coverage:report_with_groups[coverage_artifacts/**/.resultset.json]"
+        run: "bundle exec rake coverage:report_with_gem_groups[coverage_artifacts/**/.resultset.json]"
         shell: bash
 
       - name: Copy coverage.json to coverage_with_groups.json

--- a/.github/workflows/_combine_coverage_data.yml
+++ b/.github/workflows/_combine_coverage_data.yml
@@ -51,6 +51,16 @@ jobs:
         run: cat tmp/starter/coverage_artifacts/test_coverage_*.log/.resultset.json
         shell: bash
 
+      - name: Combine Coverage Data
+        working-directory: tmp/starter
+        run: "bundle exec rake coverage:report[coverage_artifacts/**/.resultset.json]"
+        shell: bash
+
+      - name: Copy coverage.json to coverage_with_stats.json
+        run: cp tmp/starter/coverage/coverage.json tmp/starter/coverage/coverage_with_stats.json
+        continue-on-error: true
+        shell: bash
+
       - name: Combine Coverage Data With Groups
         working-directory: tmp/starter
         run: "bundle exec rake coverage:report_with_gem_groups[coverage_artifacts/**/.resultset.json]"
@@ -59,11 +69,6 @@ jobs:
       - name: Copy coverage.json to coverage_with_groups.json
         run: cp tmp/starter/coverage/coverage.json tmp/starter/coverage/coverage_with_groups.json
         continue-on-error: true
-        shell: bash
-
-      - name: Combine Coverage Data
-        working-directory: tmp/starter
-        run: "bundle exec rake coverage:report[coverage_artifacts/**/.resultset.json]"
         shell: bash
 
       - name: List coverage dir
@@ -89,7 +94,7 @@ jobs:
           script: |
             try {
               const fs = require('fs')
-              const jsonString = fs.readFileSync('tmp/starter/coverage/coverage.json')
+              const jsonString = fs.readFileSync('tmp/starter/coverage/coverage_with_stats.json')
               var coverageData = JSON.parse(jsonString)
 
               const groupJsonString = fs.readFileSync('tmp/starter/coverage/coverage_with_groups.json')

--- a/.github/workflows/_combine_runtime_logs.yml
+++ b/.github/workflows/_combine_runtime_logs.yml
@@ -68,4 +68,5 @@ jobs:
       - name: Delete artifacts
         uses: geekyeggo/delete-artifact@v5
         with:
-            name: parallel_runtime_test_*.log
+          name: parallel_runtime_test_*.log
+          failOnError: false

--- a/.github/workflows/_combine_runtime_logs.yml
+++ b/.github/workflows/_combine_runtime_logs.yml
@@ -70,8 +70,8 @@ jobs:
     #runs-on: ubuntu-latest
     #needs: combine_runtime_logs
     #steps:
-      #- name: Delete artifacts
-        #uses: geekyeggo/delete-artifact@v5
-        #with:
-          #name: parallel_runtime_test_*.log
-          #failOnError: false
+      - name: Delete artifacts
+        uses: geekyeggo/delete-artifact@v5
+        with:
+          name: parallel_runtime_test_*.log
+          failOnError: false

--- a/.github/workflows/_combine_runtime_logs.yml
+++ b/.github/workflows/_combine_runtime_logs.yml
@@ -65,6 +65,11 @@ jobs:
         run: wc -l tmp/starter/tmp/parallel_runtime_test.log
         shell: bash
 
+  remove_runtime_logs:
+    name: "Cleanup"
+    runs-on: ubuntu-latest
+    needs: combine_runtime_logs
+    steps:
       - name: Delete artifacts
         uses: geekyeggo/delete-artifact@v5
         with:

--- a/.github/workflows/_combine_runtime_logs.yml
+++ b/.github/workflows/_combine_runtime_logs.yml
@@ -65,11 +65,6 @@ jobs:
         run: wc -l tmp/starter/tmp/parallel_runtime_test.log
         shell: bash
 
-  #remove_runtime_logs:
-    #name: "Cleanup"
-    #runs-on: ubuntu-latest
-    #needs: combine_runtime_logs
-    #steps:
       - name: Delete artifacts
         uses: geekyeggo/delete-artifact@v5
         with:

--- a/.github/workflows/_combine_runtime_logs.yml
+++ b/.github/workflows/_combine_runtime_logs.yml
@@ -65,13 +65,13 @@ jobs:
         run: wc -l tmp/starter/tmp/parallel_runtime_test.log
         shell: bash
 
-  remove_runtime_logs:
-    name: "Cleanup"
-    runs-on: ubuntu-latest
-    needs: combine_runtime_logs
-    steps:
-      - name: Delete artifacts
-        uses: geekyeggo/delete-artifact@v5
-        with:
-          name: parallel_runtime_test_*.log
-          failOnError: false
+  #remove_runtime_logs:
+    #name: "Cleanup"
+    #runs-on: ubuntu-latest
+    #needs: combine_runtime_logs
+    #steps:
+      #- name: Delete artifacts
+        #uses: geekyeggo/delete-artifact@v5
+        #with:
+          #name: parallel_runtime_test_*.log
+          #failOnError: false

--- a/.github/workflows/_combine_summary_logs.yml
+++ b/.github/workflows/_combine_summary_logs.yml
@@ -10,10 +10,6 @@ jobs:
   combine_summary_logs:
     name: "📊"
     runs-on: ubuntu-latest
-    env:
-      RAILS_ENV: test
-      BUNDLE_JOBS: 2
-      BUNDLE_RETRY: 3
 
     steps:
       - name: Checkout code
@@ -42,11 +38,6 @@ jobs:
           paths: "artifacts/**/TEST-*.xml"
         if: always()
 
-  #remove_summary_logs:
-    #name: "Cleanup"
-    #runs-on: ubuntu-latest
-    #needs: combine_summary_logs
-    #steps:
       - name: Delete artifacts
         uses: geekyeggo/delete-artifact@v5
         with:

--- a/.github/workflows/_combine_summary_logs.yml
+++ b/.github/workflows/_combine_summary_logs.yml
@@ -42,13 +42,13 @@ jobs:
           paths: "artifacts/**/TEST-*.xml"
         if: always()
 
-  remove_summary_logs:
-    name: "Cleanup"
-    runs-on: ubuntu-latest
-    needs: combine_summary_logs
-    steps:
-      - name: Delete artifacts
-        uses: geekyeggo/delete-artifact@v5
-        with:
-          name: test_summary_*.log
-          failOnError: false
+  #remove_summary_logs:
+    #name: "Cleanup"
+    #runs-on: ubuntu-latest
+    #needs: combine_summary_logs
+    #steps:
+      #- name: Delete artifacts
+        #uses: geekyeggo/delete-artifact@v5
+        #with:
+          #name: test_summary_*.log
+          #failOnError: false

--- a/.github/workflows/_combine_summary_logs.yml
+++ b/.github/workflows/_combine_summary_logs.yml
@@ -45,4 +45,5 @@ jobs:
       - name: Delete artifacts
         uses: geekyeggo/delete-artifact@v5
         with:
-            name: test_summary_*.log
+          name: test_summary_*.log
+          failOnError: false

--- a/.github/workflows/_combine_summary_logs.yml
+++ b/.github/workflows/_combine_summary_logs.yml
@@ -42,6 +42,11 @@ jobs:
           paths: "artifacts/**/TEST-*.xml"
         if: always()
 
+  remove_summary_logs:
+    name: "Cleanup"
+    runs-on: ubuntu-latest
+    needs: combine_summary_logs
+    steps:
       - name: Delete artifacts
         uses: geekyeggo/delete-artifact@v5
         with:

--- a/.github/workflows/_combine_summary_logs.yml
+++ b/.github/workflows/_combine_summary_logs.yml
@@ -47,8 +47,8 @@ jobs:
     #runs-on: ubuntu-latest
     #needs: combine_summary_logs
     #steps:
-      #- name: Delete artifacts
-        #uses: geekyeggo/delete-artifact@v5
-        #with:
-          #name: test_summary_*.log
-          #failOnError: false
+      - name: Delete artifacts
+        uses: geekyeggo/delete-artifact@v5
+        with:
+          name: test_summary_*.log
+          failOnError: false

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -7,22 +7,15 @@ on:
   workflow_dispatch:
 
 jobs:
+  # NOTE: This is here just to make the workflow visualization layout better.
+  # Without it the layout is really bad and confusing.
   calculate_matrix:
-    name: 🧮 Calculate Dynamic Matrix
+    name: 🧮 Fake Matrix
     runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.dynamic-matrix.outputs.matrix }}
-      totalRunners: ${{ steps.dynamic-matrix.outputs.totalRunners }}
-      testRunnersPerNode: ${{ steps.dynamic-matrix.outputs.testRunnersPerNode }}
     steps:
-      - name: Dynamic Matrix
-        id: dynamic-matrix
-        uses: bullet-train-co/parallel-test-dynamic-matrix@v1
-        with:
-          # You can explicitly set the number of test nodes, or it will default to 4
-          numberOfTestNodes: 4
-          # You can explicitly set the number of runners per node, or it will default to 4 for public repos and 2 for private
-          # testRunnersPerNode: 2
+      - name: Do Nothing
+        run: echo "This is a useless step that just helps things look nicer..."
+        shell: bash
   test:
     name: "🏗️"
     runs-on: ubuntu-latest

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -87,7 +87,7 @@ jobs:
           cache-dependency-path: tmp/starter/yarn.lock
 
       - name: Link Core Repo
-        uses: bullet-train-co/link-core-gems@beta
+        uses: bullet-train-co/link-core-gems@v1
         with:
           application_dir: tmp/starter
           core_dir: tmp/starter/local/bullet_train-core

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -56,7 +56,7 @@ jobs:
       BUNDLE_JOBS: 2
       BUNDLE_RETRY: 3
       MINITEST_JUNIT_REPORTER: yes
-      CAPTURE_SIMPLECOV_AT_RUNTIME: true
+      #CAPTURE_SIMPLECOV_AT_RUNTIME: true
       SIMPLECOV_RUNTIME_COMMAND_NAME: super-scaffold-${{ strategy.job-index }}
     steps:
       - name: Checkout Starter Repo

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -118,13 +118,14 @@ jobs:
 
       - name: Upload Test Summary Logs
         uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: test_summary_super_scaffolding_${{ strategy.job-index }}_${{ inputs.use-core-repo }}.log
           path: tmp/starter/test/reports/**/TEST-*.xml
-        if: always()
 
       - name: Upload Test Coverage Data
         uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: test_coverage_super_scaffolding_${{ strategy.job-index }}_${{ inputs.use-core-repo }}.log
           path: tmp/starter/coverage/.resultset.json

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -55,6 +55,7 @@ jobs:
       DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
       BUNDLE_JOBS: 2
       BUNDLE_RETRY: 3
+      MINITEST_JUNIT_REPORTER: yes
     steps:
       - name: Checkout Core Repo
         uses: actions/checkout@v4

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -55,9 +55,6 @@ jobs:
       DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
       BUNDLE_JOBS: 2
       BUNDLE_RETRY: 3
-      MINITEST_JUNIT_REPORTER: yes
-      #CAPTURE_SIMPLECOV_AT_RUNTIME: true
-      SIMPLECOV_RUNTIME_COMMAND_NAME: super-scaffold-${{ strategy.job-index }}
     steps:
       - name: Checkout Starter Repo
         uses: bullet-train-co/checkout-repo-with-matching-branch@v1
@@ -106,7 +103,6 @@ jobs:
         working-directory: tmp/starter
         env:
           CIRCLE_NODE_INDEX: ${{ strategy.job-index }}
-          SIMPLECOV_RUNTIME_COMMAND_NAME: super-scaffold-${{ strategy.job-index }}
 
       - name: 'Run Super Scaffolding Test'
         run: bin/rails test test/system/super_scaffolding/

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -87,7 +87,7 @@ jobs:
           cache-dependency-path: tmp/starter/yarn.lock
 
       - name: Link Core Repo
-        uses: bullet-train-co/link-core-gems@v1
+        uses: bullet-train-co/link-core-gems@beta
         with:
           application_dir: tmp/starter
           core_dir: tmp/starter/local/bullet_train-core

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -56,6 +56,7 @@ jobs:
       BUNDLE_JOBS: 2
       BUNDLE_RETRY: 3
       MINITEST_JUNIT_REPORTER: yes
+      CAPTURE_SIMPLECOV_AT_RUNTIME: true
     steps:
       - name: Checkout Starter Repo
         uses: bullet-train-co/checkout-repo-with-matching-branch@v1
@@ -104,6 +105,7 @@ jobs:
         working-directory: tmp/starter
         env:
           CIRCLE_NODE_INDEX: ${{ strategy.job-index }}
+          SIMPLECOV_RUNTIME_COMMAND_NAME: super-scaffold-${{ strategy.job-index }}
 
       - name: 'Run Super Scaffolding Test'
         run: bin/rails test test/system/super_scaffolding/

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -9,17 +9,17 @@ on:
 jobs:
   # NOTE: This is here just to make the workflow visualization layout better.
   # Without it the layout is really bad and confusing.
-  calculate_matrix:
-    name: 🤷 Fake Matrix
-    runs-on: ubuntu-latest
-    steps:
-      - name: Do Nothing
-        run: echo "This is a useless step that just helps things look nicer..."
-        shell: bash
+  #calculate_matrix:
+    #name: 🤷 Fake Matrix
+    #runs-on: ubuntu-latest
+    #steps:
+      #- name: Do Nothing
+        #run: echo "This is a useless step that just helps things look nicer..."
+        #shell: bash
   test:
     name: "🏗️"
     runs-on: ubuntu-latest
-    needs: calculate_matrix
+    #needs: calculate_matrix
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -57,6 +57,7 @@ jobs:
       BUNDLE_RETRY: 3
       MINITEST_JUNIT_REPORTER: yes
       CAPTURE_SIMPLECOV_AT_RUNTIME: true
+      SIMPLECOV_RUNTIME_COMMAND_NAME: super-scaffold-${{ strategy.job-index }}
     steps:
       - name: Checkout Starter Repo
         uses: bullet-train-co/checkout-repo-with-matching-branch@v1

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -9,17 +9,17 @@ on:
 jobs:
   # NOTE: This is here just to make the workflow visualization layout better.
   # Without it the layout is really bad and confusing.
-  #calculate_matrix:
-    #name: 🤷 Fake Matrix
-    #runs-on: ubuntu-latest
-    #steps:
-      #- name: Do Nothing
-        #run: echo "This is a useless step that just helps things look nicer..."
-        #shell: bash
+  calculate_matrix:
+    name: 🤷 Fake Matrix
+    runs-on: ubuntu-latest
+    steps:
+      - name: Do Nothing
+        run: echo "This is a useless step that just helps things look nicer..."
+        shell: bash
   test:
     name: "🏗️"
     runs-on: ubuntu-latest
-    #needs: calculate_matrix
+    needs: calculate_matrix
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -10,7 +10,7 @@ jobs:
   # NOTE: This is here just to make the workflow visualization layout better.
   # Without it the layout is really bad and confusing.
   calculate_matrix:
-    name: 🧮 Fake Matrix
+    name: 🤷 Fake Matrix
     runs-on: ubuntu-latest
     steps:
       - name: Do Nothing

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -7,9 +7,26 @@ on:
   workflow_dispatch:
 
 jobs:
+  calculate_matrix:
+    name: 🧮 Calculate Dynamic Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.dynamic-matrix.outputs.matrix }}
+      totalRunners: ${{ steps.dynamic-matrix.outputs.totalRunners }}
+      testRunnersPerNode: ${{ steps.dynamic-matrix.outputs.testRunnersPerNode }}
+    steps:
+      - name: Dynamic Matrix
+        id: dynamic-matrix
+        uses: bullet-train-co/parallel-test-dynamic-matrix@v1
+        with:
+          # You can explicitly set the number of test nodes, or it will default to 4
+          numberOfTestNodes: 4
+          # You can explicitly set the number of runners per node, or it will default to 4 for public repos and 2 for private
+          # testRunnersPerNode: 2
   test:
     name: "🏗️"
     runs-on: ubuntu-latest
+    needs: calculate_matrix
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -57,16 +57,16 @@ jobs:
       BUNDLE_RETRY: 3
       MINITEST_JUNIT_REPORTER: yes
     steps:
-      - name: Checkout Core Repo
-        uses: actions/checkout@v4
-        with:
-          path: tmp/core
-
       - name: Checkout Starter Repo
         uses: bullet-train-co/checkout-repo-with-matching-branch@v1
         with:
           target_dir: tmp/starter
           repository: bullet-train-co/bullet_train
+
+      - name: Checkout Core Repo
+        uses: actions/checkout@v4
+        with:
+          path: tmp/starter/local/bullet_train-core
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -88,7 +88,7 @@ jobs:
         uses: bullet-train-co/link-core-gems@v1
         with:
           application_dir: tmp/starter
-          core_dir: tmp/core
+          core_dir: tmp/starter/local/bullet_train-core
 
       # TODO: This might be a bad idea. Maybe we should just have spring in the Gemfile all the time.
       - name: Allow adding of spring

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -16,14 +16,14 @@ jobs:
       - name: Checkout Core Repo
         uses: "actions/checkout@v4"
         with:
-          path: tmp/starter/core
+          path: tmp/starter/local-core
 
       - uses: actions/github-script@v7
         id: generate-gem-list
         name: Generate Gem List
         with:
           script: |
-            const globber = await glob.create('tmp/starter/core/*/*.gemspec')
+            const globber = await glob.create('tmp/starter/local-core/*/*.gemspec')
             const gems = []
             for await (const file of globber.globGenerator()) {
               console.log(file)
@@ -68,13 +68,13 @@ jobs:
 
     defaults:
       run:
-        working-directory: tmp/starter/core/${{ matrix.gem }}
+        working-directory: tmp/starter/local-core/${{ matrix.gem }}
 
     steps:
       - name: Checkout Core Repo
         uses: "actions/checkout@v4"
         with:
-          path: tmp/starter/core
+          path: tmp/starter/local-core
 
       - name: Copy .ruby-version
         run: cp ../.ruby-version ./
@@ -84,7 +84,7 @@ jobs:
           rubygems: latest
           bundler: latest
           bundler-cache: true
-          working-directory: tmp/starter/core/${{ matrix.gem }} # setup-ruby does't pick up the job default.
+          working-directory: tmp/starter/local-core/${{ matrix.gem }} # setup-ruby does't pick up the job default.
 
       # TODO: Sometimes the step above complains about the lockfile being fronzen.
       # When that happens you can get things moving again by chaning the bundler-cache
@@ -98,7 +98,7 @@ jobs:
       #- run: git diff Gemfile.lock
 
       - run: bin/rails db:setup
-        if: ${{ hashFiles(format('tmp/starter/core/{0}/test/dummy/db/schema.rb', matrix.gem)) != '' }}
+        if: ${{ hashFiles(format('tmp/starter/local-core/{0}/test/dummy/db/schema.rb', matrix.gem)) != '' }}
 
       - name: Run Tests
         run: bin/rails test
@@ -107,14 +107,14 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test_coverage_${{ matrix.gem }}.log
-          path: tmp/starter/core/${{ matrix.gem }}/coverage/.resultset.json
+          path: tmp/starter/local-core/${{ matrix.gem }}/coverage/.resultset.json
           include-hidden-files: true
 
       - name: Upload Test Summary Logs
         uses: actions/upload-artifact@v4
         with:
           name: test_summary_${{ matrix.gem }}.log
-          path: ${{ format('tmp/starter/core/{0}/test/reports/**/TEST-*.xml', matrix.gem) }}
+          path: ${{ format('tmp/starter/local-core/{0}/test/reports/**/TEST-*.xml', matrix.gem) }}
         if: always()
 
       #- name: Test Summary

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -98,7 +98,7 @@ jobs:
       #- run: git diff Gemfile.lock
 
       - run: bin/rails db:setup
-        if: ${{ hashFiles(format('{0}/test/dummy/db/schema.rb', matrix.gem)) != '' }}
+        if: ${{ hashFiles(format('tmp/starter/core/{0}/test/dummy/db/schema.rb', matrix.gem)) != '' }}
 
       - name: Run Tests
         run: bin/rails test

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -7,8 +7,25 @@ on:
   workflow_dispatch:
 
 jobs:
+  calculate_matrix:
+    name: 🧮 Calculate Dynamic Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.dynamic-matrix.outputs.matrix }}
+      totalRunners: ${{ steps.dynamic-matrix.outputs.totalRunners }}
+      testRunnersPerNode: ${{ steps.dynamic-matrix.outputs.testRunnersPerNode }}
+    steps:
+      - name: Dynamic Matrix
+        id: dynamic-matrix
+        uses: bullet-train-co/parallel-test-dynamic-matrix@v1
+        with:
+          # You can explicitly set the number of test nodes, or it will default to 4
+          numberOfTestNodes: 4
+          # You can explicitly set the number of runners per node, or it will default to 4 for public repos and 2 for private
+          # testRunnersPerNode: 2
   test:
     runs-on: ubuntu-latest
+    needs: calculate_matrix
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -16,14 +16,14 @@ jobs:
       - name: Checkout Core Repo
         uses: "actions/checkout@v4"
         with:
-          path: tmp/starter/local-core
+          path: tmp/starter/local/bullet_train-core
 
       - uses: actions/github-script@v7
         id: generate-gem-list
         name: Generate Gem List
         with:
           script: |
-            const globber = await glob.create('tmp/starter/local-core/*/*.gemspec')
+            const globber = await glob.create('tmp/starter/local/bullet_train-core/*/*.gemspec')
             const gems = []
             for await (const file of globber.globGenerator()) {
               console.log(file)
@@ -68,13 +68,13 @@ jobs:
 
     defaults:
       run:
-        working-directory: tmp/starter/local-core/${{ matrix.gem }}
+        working-directory: tmp/starter/local/bullet_train-core/${{ matrix.gem }}
 
     steps:
       - name: Checkout Core Repo
         uses: "actions/checkout@v4"
         with:
-          path: tmp/starter/local-core
+          path: tmp/starter/local/bullet_train-core
 
       - name: Copy .ruby-version
         run: cp ../.ruby-version ./
@@ -84,7 +84,7 @@ jobs:
           rubygems: latest
           bundler: latest
           bundler-cache: true
-          working-directory: tmp/starter/local-core/${{ matrix.gem }} # setup-ruby does't pick up the job default.
+          working-directory: tmp/starter/local/bullet_train-core/${{ matrix.gem }} # setup-ruby does't pick up the job default.
 
       # TODO: Sometimes the step above complains about the lockfile being fronzen.
       # When that happens you can get things moving again by chaning the bundler-cache
@@ -98,7 +98,7 @@ jobs:
       #- run: git diff Gemfile.lock
 
       - run: bin/rails db:setup
-        if: ${{ hashFiles(format('tmp/starter/local-core/{0}/test/dummy/db/schema.rb', matrix.gem)) != '' }}
+        if: ${{ hashFiles(format('tmp/starter/local/bullet_train-core/{0}/test/dummy/db/schema.rb', matrix.gem)) != '' }}
 
       - name: Run Tests
         run: bin/rails test
@@ -107,14 +107,14 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test_coverage_${{ matrix.gem }}.log
-          path: tmp/starter/local-core/${{ matrix.gem }}/coverage/.resultset.json
+          path: tmp/starter/local/bullet_train-core/${{ matrix.gem }}/coverage/.resultset.json
           include-hidden-files: true
 
       - name: Upload Test Summary Logs
         uses: actions/upload-artifact@v4
         with:
           name: test_summary_${{ matrix.gem }}.log
-          path: ${{ format('tmp/starter/local-core/{0}/test/reports/**/TEST-*.xml', matrix.gem) }}
+          path: ${{ format('tmp/starter/local/bullet_train-core/{0}/test/reports/**/TEST-*.xml', matrix.gem) }}
         if: always()
 
       #- name: Test Summary

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -40,25 +40,6 @@ jobs:
       fail-fast: false
       matrix:
         gem: ${{ fromJson(needs.calculate_matrix.outputs.gems) }}
-        #gem:
-          #- "bullet_train"
-          #- "bullet_train-api"
-          #- "bullet_train-fields"
-          #- "bullet_train-has_uuid"
-          #- "bullet_train-incoming_webhooks"
-          #- "bullet_train-integrations"
-          #- "bullet_train-integrations-stripe"
-          #- "bullet_train-obfuscates_id"
-          #- "bullet_train-outgoing_webhooks"
-          #- "bullet_train-roles"
-          #- "bullet_train-scope_questions"
-          #- "bullet_train-scope_validator"
-          #- "bullet_train-sortable"
-          #- "bullet_train-super_load_and_authorize_resource"
-          #- "bullet_train-super_scaffolding"
-          #- "bullet_train-themes"
-          #- "bullet_train-themes-light"
-          #- "bullet_train-themes-tailwind_css"
 
     name: ${{ format('{0}', matrix.gem) }}
 

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -27,7 +27,7 @@ jobs:
               console.log(file)
               var fileParts = file.split("/")
               var gemspecFileName = fileParts[fileParts.length];
-              var gemname = fileParts[fileParts.length - 1];
+              var gemname = fileParts[fileParts.length - 2];
               console.log("gemname =", gemname)
               gems.push(gemname)
             }
@@ -39,25 +39,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gem:
-          - "bullet_train"
-          - "bullet_train-api"
-          - "bullet_train-fields"
-          - "bullet_train-has_uuid"
-          - "bullet_train-incoming_webhooks"
-          - "bullet_train-integrations"
-          - "bullet_train-integrations-stripe"
-          - "bullet_train-obfuscates_id"
-          - "bullet_train-outgoing_webhooks"
-          - "bullet_train-roles"
-          - "bullet_train-scope_questions"
-          - "bullet_train-scope_validator"
-          - "bullet_train-sortable"
-          - "bullet_train-super_load_and_authorize_resource"
-          - "bullet_train-super_scaffolding"
-          - "bullet_train-themes"
-          - "bullet_train-themes-light"
-          - "bullet_train-themes-tailwind_css"
+        gem: ${{ fromJson(needs.calculate_matrix.outputs.gems) }}
+        #gem:
+          #- "bullet_train"
+          #- "bullet_train-api"
+          #- "bullet_train-fields"
+          #- "bullet_train-has_uuid"
+          #- "bullet_train-incoming_webhooks"
+          #- "bullet_train-integrations"
+          #- "bullet_train-integrations-stripe"
+          #- "bullet_train-obfuscates_id"
+          #- "bullet_train-outgoing_webhooks"
+          #- "bullet_train-roles"
+          #- "bullet_train-scope_questions"
+          #- "bullet_train-scope_validator"
+          #- "bullet_train-sortable"
+          #- "bullet_train-super_load_and_authorize_resource"
+          #- "bullet_train-super_scaffolding"
+          #- "bullet_train-themes"
+          #- "bullet_train-themes-light"
+          #- "bullet_train-themes-tailwind_css"
 
     name: ${{ format('{0}', matrix.gem) }}
 

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -87,7 +87,7 @@ jobs:
           working-directory: tmp/starter/local/bullet_train-core/${{ matrix.gem }} # setup-ruby does't pick up the job default.
 
       # TODO: Sometimes the step above complains about the lockfile being fronzen.
-      # When that happens you can get things moving again by chaning the bundler-cache
+      # When that happens you can get things moving again by changing the bundler-cache
       # option above to false. Then you _must_ uncomment the line for `bundle install` and
       # you can also uncomment the following lines to find out what changed unexpectedly.
       # I _think_ I've got things set up so that this shouldn't be an issue any more, but

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -105,6 +105,7 @@ jobs:
 
       - name: Upload Test Coverage Data
         uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: test_coverage_${{ matrix.gem }}.log
           path: tmp/starter/local/bullet_train-core/${{ matrix.gem }}/coverage/.resultset.json
@@ -112,10 +113,10 @@ jobs:
 
       - name: Upload Test Summary Logs
         uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: test_summary_${{ matrix.gem }}.log
           path: ${{ format('tmp/starter/local/bullet_train-core/{0}/test/reports/**/TEST-*.xml', matrix.gem) }}
-        if: always()
 
       #- name: Test Summary
         #uses: test-summary/action@v2

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -94,5 +94,11 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test_summary_${{ matrix.gem }}.log
-          path: test/reports*/**/TEST-*.xml
+          path: ${{ format('{0}/test/reports/**/TEST-*.xml', matrix.gem) }}
         if: always()
+
+      #- name: Test Summary
+        #uses: test-summary/action@v2
+        #with:
+          #paths: ${{ format('{0}/test/reports/**/TEST-*.xml', matrix.gem) }}
+        #if: always()

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   calculate_matrix:
-    name: 🧮 Generate Gem List
+    name: 💎 Generate Gem List
     runs-on: ubuntu-latest
     outputs:
       gems: ${{ steps.generate-gem-list.outputs.result }}

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -15,13 +15,15 @@ jobs:
     steps:
       - name: Checkout Core Repo
         uses: "actions/checkout@v4"
+        with:
+          path: tmp/starter/core
 
       - uses: actions/github-script@v7
         id: generate-gem-list
         name: Generate Gem List
         with:
           script: |
-            const globber = await glob.create('*/*.gemspec')
+            const globber = await glob.create('tmp/starter/core/*/*.gemspec')
             const gems = []
             for await (const file of globber.globGenerator()) {
               console.log(file)
@@ -66,11 +68,13 @@ jobs:
 
     defaults:
       run:
-        working-directory: ${{ matrix.gem }}
+        working-directory: tmp/starter/core/${{ matrix.gem }}
 
     steps:
       - name: Checkout Core Repo
         uses: "actions/checkout@v4"
+        with:
+          path: tmp/starter/core
 
       - name: Copy .ruby-version
         run: cp ../.ruby-version ./
@@ -80,7 +84,7 @@ jobs:
           rubygems: latest
           bundler: latest
           bundler-cache: true
-          working-directory: ${{ matrix.gem }} # setup-ruby does't pick up the job default.
+          working-directory: tmp/starter/core/${{ matrix.gem }} # setup-ruby does't pick up the job default.
 
       # TODO: Sometimes the step above complains about the lockfile being fronzen.
       # When that happens you can get things moving again by chaning the bundler-cache
@@ -103,14 +107,14 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test_coverage_${{ matrix.gem }}.log
-          path: ${{ matrix.gem }}/coverage/.resultset.json
+          path: tmp/starter/core/${{ matrix.gem }}/coverage/.resultset.json
           include-hidden-files: true
 
       - name: Upload Test Summary Logs
         uses: actions/upload-artifact@v4
         with:
           name: test_summary_${{ matrix.gem }}.log
-          path: ${{ format('{0}/test/reports/**/TEST-*.xml', matrix.gem) }}
+          path: ${{ format('tmp/starter/core/{0}/test/reports/**/TEST-*.xml', matrix.gem) }}
         if: always()
 
       #- name: Test Summary

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -8,21 +8,24 @@ on:
 
 jobs:
   calculate_matrix:
-    name: 🧮 Calculate Dynamic Matrix
+    name: 🧮 Generate Gem List
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.dynamic-matrix.outputs.matrix }}
-      totalRunners: ${{ steps.dynamic-matrix.outputs.totalRunners }}
-      testRunnersPerNode: ${{ steps.dynamic-matrix.outputs.testRunnersPerNode }}
+      gems: ${{ steps.generate-gem-list.outputs.result }}
     steps:
-      - name: Dynamic Matrix
-        id: dynamic-matrix
-        uses: bullet-train-co/parallel-test-dynamic-matrix@v1
+      - name: Checkout Core Repo
+        uses: "actions/checkout@v4"
+
+      - uses: actions/github-script@v7
+        id: generate-gem-list
+        name: Generate Gem List
         with:
-          # You can explicitly set the number of test nodes, or it will default to 4
-          numberOfTestNodes: 4
-          # You can explicitly set the number of runners per node, or it will default to 4 for public repos and 2 for private
-          # testRunnersPerNode: 2
+          script: |
+            const globber = await glob.create('*/*.gemspec')
+            for await (const file of globber.globGenerator()) {
+              console.log(file)
+            }
+
   test:
     runs-on: ubuntu-latest
     needs: calculate_matrix

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -99,6 +99,13 @@ jobs:
       - name: Run Tests
         run: bin/rails test
 
+      - name: Upload Test Coverage Data
+        uses: actions/upload-artifact@v4
+        with:
+          name: test_coverage_${{ matrix.gem }}.log
+          path: ${{ matrix.gem }}/coverage/.resultset.json
+          include-hidden-files: true
+
       - name: Upload Test Summary Logs
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -22,9 +22,16 @@ jobs:
         with:
           script: |
             const globber = await glob.create('*/*.gemspec')
+            const gems = []
             for await (const file of globber.globGenerator()) {
               console.log(file)
+              var fileParts = file.split("/")
+              var gemspecFileName = fileParts[fileParts.length];
+              var gemname = fileParts[fileParts.length - 1];
+              console.log("gemname =", gemname)
+              gems.push(gemname)
             }
+            return gems
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -88,7 +88,7 @@ jobs:
 
       # TODO: Sometimes the step above complains about the lockfile being fronzen.
       # When that happens you can get things moving again by chaning the bundler-cache
-      # option above to false. Then _must_ uncomment the line for `bundle install` and
+      # option above to false. Then you _must_ uncomment the line for `bundle install` and
       # you can also uncomment the following lines to find out what changed unexpectedly.
       # I _think_ I've got things set up so that this shouldn't be an issue any more, but
       # I'm leaving this stuff here in case it comes in handy in the near future.
@@ -117,9 +117,3 @@ jobs:
         with:
           name: test_summary_${{ matrix.gem }}.log
           path: ${{ format('tmp/starter/local/bullet_train-core/{0}/test/reports/**/TEST-*.xml', matrix.gem) }}
-
-      #- name: Test Summary
-        #uses: test-summary/action@v2
-        #with:
-          #paths: ${{ format('{0}/test/reports/**/TEST-*.xml', matrix.gem) }}
-        #if: always()

--- a/.github/workflows/_standardrb.yml
+++ b/.github/workflows/_standardrb.yml
@@ -8,21 +8,18 @@ on:
 
 jobs:
   lint:
-    name: Lint
     runs-on: ubuntu-latest
     env:
       RAILS_ENV: test
+      # Manually export your local RAILS_MASTER_KEY if using the credentials system.
+      # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
       BUNDLE_JOBS: 2
       BUNDLE_RETRY: 3
+    permissions:
+      checks: write
+      contents: read
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install Ruby and gems
-        uses: ruby/setup-ruby@v1
+      - name: Standard Ruby
+        uses: standardrb/standard-ruby-action@v1
         with:
-          bundler-cache: true
-
-      - name: Run Standardrb
-        id: run-standardrb
-        run : bundle exec standardrb
+          autofix: false

--- a/.github/workflows/_starter_repo_tests.yml
+++ b/.github/workflows/_starter_repo_tests.yml
@@ -132,7 +132,6 @@ jobs:
         id: run-tests
         env:
           PARALLEL_TESTS_RECORD_RUNTIME: true
-          MINITEST_JUNIT_REPORTER: yes
         continue-on-error: false
         run: |
           bundle exec parallel_test test \

--- a/.github/workflows/_starter_repo_tests.yml
+++ b/.github/workflows/_starter_repo_tests.yml
@@ -90,7 +90,7 @@ jobs:
           cache-dependency-path: tmp/starter/yarn.lock
 
       - name: Link Core Repo
-        uses: bullet-train-co/link-core-gems@beta
+        uses: bullet-train-co/link-core-gems@v1
         with:
           application_dir: tmp/starter
           core_dir: tmp/starter/local/bullet_train-core

--- a/.github/workflows/_starter_repo_tests.yml
+++ b/.github/workflows/_starter_repo_tests.yml
@@ -4,26 +4,33 @@
 name: "🧪 ~ Run gem tests"
 on:
   workflow_call:
-    inputs:
-      matrix:
-        required: true
-        type: string
-      totalRunners:
-        required: true
-        type: string
-      testRunnersPerNode:
-        required: true
-        type: string
   workflow_dispatch:
 
 jobs:
+  calculate_matrix:
+    name: 🧮 Calculate Dynamic Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.dynamic-matrix.outputs.matrix }}
+      totalRunners: ${{ steps.dynamic-matrix.outputs.totalRunners }}
+      testRunnersPerNode: ${{ steps.dynamic-matrix.outputs.testRunnersPerNode }}
+    steps:
+      - name: Dynamic Matrix
+        id: dynamic-matrix
+        uses: bullet-train-co/parallel-test-dynamic-matrix@v1
+        with:
+          # You can explicitly set the number of test nodes, or it will default to 4
+          numberOfTestNodes: 4
+          # You can explicitly set the number of runners per node, or it will default to 4 for public repos and 2 for private
+          # testRunnersPerNode: 2
   starter_repo:
     runs-on: ubuntu-latest
     name: "🧪"
+    needs: calculate_matrix
     strategy:
       fail-fast: false
       matrix:
-        parallel_test_groups: ${{ fromJson(inputs.matrix) }}
+        parallel_test_groups: ${{ fromJson(needs.calculate_matrix.outputs.matrix) }}
     services:
       postgres:
         image: postgres:11-alpine
@@ -107,7 +114,7 @@ jobs:
         working-directory: tmp/starter
 
       - name: Set up database schema
-        run: bin/rake parallel:setup[${{ fromJson(inputs.testRunnersPerNode) }}]
+        run: bin/rake parallel:setup[${{ fromJson(needs.calculate_matrix.outputs.testRunnersPerNode) }}]
         working-directory: tmp/starter
 
       # We touch this file so that parallel_tests doesn't complain about it not being there.
@@ -129,7 +136,7 @@ jobs:
         continue-on-error: false
         run: |
           bundle exec parallel_test test \
-          -n ${{ fromJson(inputs.totalRunners) }} \
+          -n ${{ fromJson(needs.calculate_matrix.outputs.totalRunners) }} \
           --only-group ${{ matrix.parallel_test_groups }} \
           --group-by runtime \
           --allowed-missing 100 \

--- a/.github/workflows/_starter_repo_tests.yml
+++ b/.github/workflows/_starter_repo_tests.yml
@@ -90,7 +90,7 @@ jobs:
           cache-dependency-path: tmp/starter/yarn.lock
 
       - name: Link Core Repo
-        uses: bullet-train-co/link-core-gems@v1
+        uses: bullet-train-co/link-core-gems@beta
         with:
           application_dir: tmp/starter
           core_dir: tmp/starter/local/bullet_train-core

--- a/.github/workflows/_starter_repo_tests.yml
+++ b/.github/workflows/_starter_repo_tests.yml
@@ -81,6 +81,11 @@ jobs:
 
       - name: Enable corepack
         run: corepack enable
+        working-directory: tmp/starter
+
+      - name: Enable corepack
+        run: corepack enable
+        working-directory: tmp/starter/local/bullet_train-core
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/_starter_repo_tests.yml
+++ b/.github/workflows/_starter_repo_tests.yml
@@ -62,16 +62,16 @@ jobs:
       POSTGRES_USER: rails
       POSTGRES_PASSWORD: password
     steps:
-      - name: Checkout Core Repo
-        uses: actions/checkout@v4
-        with:
-          path: tmp/core
-
       - name: Checkout Starter Repo
         uses: bullet-train-co/checkout-repo-with-matching-branch@v1
         with:
           target_dir: tmp/starter
           repository: bullet-train-co/bullet_train
+
+      - name: Checkout Core Repo
+        uses: actions/checkout@v4
+        with:
+          path: tmp/starter/core
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -93,7 +93,7 @@ jobs:
         uses: bullet-train-co/link-core-gems@v1
         with:
           application_dir: tmp/starter
-          core_dir: tmp/core
+          core_dir: tmp/starter/core
 
       - name: runtime log cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/_starter_repo_tests.yml
+++ b/.github/workflows/_starter_repo_tests.yml
@@ -146,12 +146,14 @@ jobs:
 
       - name: Upload Parallel Test Runtime Log
         uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: parallel_runtime_test_${{ matrix.parallel_test_groups }}.log
           path: tmp/starter/tmp/parallel_runtime_test.log
 
       - name: Upload Test Coverage Data
         uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: test_coverage_${{ matrix.parallel_test_groups }}.log
           path: tmp/starter/coverage/.resultset.json
@@ -159,10 +161,10 @@ jobs:
 
       - name: Upload Test Summary Logs
         uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: test_summary_${{ matrix.parallel_test_groups }}.log
           path: tmp/starter/test/reports*/**/TEST-*.xml
-        if: always()
 
 
 

--- a/.github/workflows/_starter_repo_tests.yml
+++ b/.github/workflows/_starter_repo_tests.yml
@@ -10,10 +10,10 @@ on:
         type: string
       totalRunners:
         required: true
-        type: number
+        type: string
       testRunnersPerNode:
         required: true
-        type: number
+        type: string
   workflow_dispatch:
 
 jobs:
@@ -107,7 +107,7 @@ jobs:
         working-directory: tmp/starter
 
       - name: Set up database schema
-        run: bin/rake parallel:setup[${{ inputs.testRunnersPerNode }}]
+        run: bin/rake parallel:setup[${{ fromJson(inputs.testRunnersPerNode) }}]
         working-directory: tmp/starter
 
       # We touch this file so that parallel_tests doesn't complain about it not being there.
@@ -129,7 +129,7 @@ jobs:
         continue-on-error: false
         run: |
           bundle exec parallel_test test \
-          -n ${{ inputs.totalRunners }} \
+          -n ${{ fromJson(inputs.totalRunners) }} \
           --only-group ${{ matrix.parallel_test_groups }} \
           --group-by runtime \
           --allowed-missing 100 \

--- a/.github/workflows/_starter_repo_tests.yml
+++ b/.github/workflows/_starter_repo_tests.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Checkout Core Repo
         uses: actions/checkout@v4
         with:
-          path: tmp/starter/local-core
+          path: tmp/starter/local/bullet_train-core
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -93,7 +93,7 @@ jobs:
         uses: bullet-train-co/link-core-gems@v1
         with:
           application_dir: tmp/starter
-          core_dir: tmp/starter/local-core
+          core_dir: tmp/starter/local/bullet_train-core
 
       - name: runtime log cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/_starter_repo_tests.yml
+++ b/.github/workflows/_starter_repo_tests.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Checkout Core Repo
         uses: actions/checkout@v4
         with:
-          path: tmp/starter/local/bullet_train-core
+          path: tmp/starter/core
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -81,11 +81,6 @@ jobs:
 
       - name: Enable corepack
         run: corepack enable
-        working-directory: tmp/starter
-
-      #- name: Enable corepack
-        #run: corepack enable
-        #working-directory: tmp/starter/local/bullet_train-core
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -98,7 +93,7 @@ jobs:
         uses: bullet-train-co/link-core-gems@v1
         with:
           application_dir: tmp/starter
-          core_dir: tmp/starter/local/bullet_train-core
+          core_dir: tmp/starter/core
 
       - name: runtime log cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/_starter_repo_tests.yml
+++ b/.github/workflows/_starter_repo_tests.yml
@@ -79,13 +79,13 @@ jobs:
           working-directory: tmp/starter
           bundler-cache: true
 
-      - name: Enable corepack
-        run: corepack enable
-        working-directory: tmp/starter
+      #- name: Enable corepack
+        #run: corepack enable
+        #working-directory: tmp/starter
 
-      - name: Enable corepack
-        run: corepack enable
-        working-directory: tmp/starter/local/bullet_train-core
+      #- name: Enable corepack
+        #run: corepack enable
+        #working-directory: tmp/starter/local/bullet_train-core
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/_starter_repo_tests.yml
+++ b/.github/workflows/_starter_repo_tests.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Checkout Core Repo
         uses: actions/checkout@v4
         with:
-          path: tmp/starter/core
+          path: tmp/starter/local-core
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -93,7 +93,7 @@ jobs:
         uses: bullet-train-co/link-core-gems@v1
         with:
           application_dir: tmp/starter
-          core_dir: tmp/starter/core
+          core_dir: tmp/starter/local-core
 
       - name: runtime log cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/_starter_repo_tests.yml
+++ b/.github/workflows/_starter_repo_tests.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Checkout Core Repo
         uses: actions/checkout@v4
         with:
-          path: tmp/starter/core
+          path: tmp/core
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -93,7 +93,7 @@ jobs:
         uses: bullet-train-co/link-core-gems@v1
         with:
           application_dir: tmp/starter
-          core_dir: tmp/starter/core
+          core_dir: tmp/core
 
       - name: runtime log cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/_starter_repo_tests.yml
+++ b/.github/workflows/_starter_repo_tests.yml
@@ -17,15 +17,13 @@ on:
   workflow_dispatch:
 
 jobs:
-
-
   starter_repo:
     runs-on: ubuntu-latest
     name: "🧪"
     strategy:
       fail-fast: false
       matrix:
-        parallel_test_groups: ${{ inputs.matrix }}
+        parallel_test_groups: ${{ fromJson(inputs.matrix) }}
     services:
       postgres:
         image: postgres:11-alpine

--- a/.github/workflows/_starter_repo_tests.yml
+++ b/.github/workflows/_starter_repo_tests.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Checkout Core Repo
         uses: actions/checkout@v4
         with:
-          path: tmp/core
+          path: tmp/starter/local/bullet_train-core
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -93,7 +93,7 @@ jobs:
         uses: bullet-train-co/link-core-gems@v1
         with:
           application_dir: tmp/starter
-          core_dir: tmp/core
+          core_dir: tmp/starter/local/bullet_train-core
 
       - name: runtime log cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/_starter_repo_tests.yml
+++ b/.github/workflows/_starter_repo_tests.yml
@@ -7,10 +7,13 @@ on:
     inputs:
       matrix:
         required: true
+        type: string
       totalRunners:
         required: true
+        type: number
       testRunnersPerNode:
         required: true
+        type: number
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/_starter_repo_tests.yml
+++ b/.github/workflows/_starter_repo_tests.yml
@@ -4,34 +4,25 @@
 name: "🧪 ~ Run gem tests"
 on:
   workflow_call:
+    inputs:
+      matrix:
+        required: true
+      totalRunners:
+        required: true
+      testRunnersPerNode:
+        required: true
   workflow_dispatch:
 
 jobs:
-  calculate_matrix:
-    name: 🧮 Calculate Dynamic Matrix
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.dynamic-matrix.outputs.matrix }}
-      totalRunners: ${{ steps.dynamic-matrix.outputs.totalRunners }}
-      testRunnersPerNode: ${{ steps.dynamic-matrix.outputs.testRunnersPerNode }}
-    steps:
-      - name: Dynamic Matrix
-        id: dynamic-matrix
-        uses: bullet-train-co/parallel-test-dynamic-matrix@v1
-        with:
-          # You can explicitly set the number of test nodes, or it will default to 4
-          numberOfTestNodes: 4
-          # You can explicitly set the number of runners per node, or it will default to 4 for public repos and 2 for private
-          # testRunnersPerNode: 2
+
 
   starter_repo:
     runs-on: ubuntu-latest
     name: "🧪"
-    needs: calculate_matrix
     strategy:
       fail-fast: false
       matrix:
-        parallel_test_groups: ${{ fromJson(needs.calculate_matrix.outputs.matrix) }}
+        parallel_test_groups: ${{ inputs.matrix }}
     services:
       postgres:
         image: postgres:11-alpine
@@ -115,7 +106,7 @@ jobs:
         working-directory: tmp/starter
 
       - name: Set up database schema
-        run: bin/rake parallel:setup[${{ fromJson(needs.calculate_matrix.outputs.testRunnersPerNode) }}]
+        run: bin/rake parallel:setup[${{ inputs.testRunnersPerNode }}]
         working-directory: tmp/starter
 
       # We touch this file so that parallel_tests doesn't complain about it not being there.
@@ -137,7 +128,7 @@ jobs:
         continue-on-error: false
         run: |
           bundle exec parallel_test test \
-          -n ${{ fromJson(needs.calculate_matrix.outputs.totalRunners) }} \
+          -n ${{ inputs.totalRunners }} \
           --only-group ${{ matrix.parallel_test_groups }} \
           --group-by runtime \
           --allowed-missing 100 \

--- a/.github/workflows/_starter_repo_tests.yml
+++ b/.github/workflows/_starter_repo_tests.yml
@@ -79,9 +79,9 @@ jobs:
           working-directory: tmp/starter
           bundler-cache: true
 
-      #- name: Enable corepack
-        #run: corepack enable
-        #working-directory: tmp/starter
+      - name: Enable corepack
+        run: corepack enable
+        working-directory: tmp/starter
 
       #- name: Enable corepack
         #run: corepack enable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,18 +7,41 @@ on:
     branches: [ "main" ]
 
 jobs:
+  calculate_matrix:
+    name: 🧮 Calculate Dynamic Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.dynamic-matrix.outputs.matrix }}
+      totalRunners: ${{ steps.dynamic-matrix.outputs.totalRunners }}
+      testRunnersPerNode: ${{ steps.dynamic-matrix.outputs.testRunnersPerNode }}
+    steps:
+      - name: Dynamic Matrix
+        id: dynamic-matrix
+        uses: bullet-train-co/parallel-test-dynamic-matrix@v1
+        with:
+          # You can explicitly set the number of test nodes, or it will default to 4
+          numberOfTestNodes: 4
+          # You can explicitly set the number of runners per node, or it will default to 4 for public repos and 2 for private
+          # testRunnersPerNode: 2
   minitest:
     name: 🧪 Starter Repo Minitest
     uses: ./.github/workflows/_starter_repo_tests.yml
     secrets: inherit
+    needs: calculate_matrix
+    with:
+      matrix: ${{ fromJson(needs.calculate_matrix.outputs.matrix) }}
+      testRunnersPerNode: ${{ fromJson(needs.calculate_matrix.outputs.testRunnersPerNode) }}
+      totalRunners: ${{ fromJson(needs.calculate_matrix.outputs.totalRunners) }}
   super_scaffolding:
     name: 🧪 Starter Repo Super Scaffolding Tests
     uses: ./.github/workflows/_run_super_scaffolding_tests.yml
     secrets: inherit
+    needs: calculate_matrix
   gem_tests:
     name: 🧪 Gem Tests
     uses: ./.github/workflows/_run_tests.yml
     secrets: inherit
+    needs: calculate_matrix
   standardrb:
     name: 🔬 Standardrb
     uses: ./.github/workflows/_standardrb.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,28 +30,16 @@ jobs:
     # NOTE: This one really only _needs_ minitest, but we include the others
     # so that the workflow visualization layous out a little better.
     needs: [minitest,super_scaffolding,gem_tests]
+    if: ${{ always() }}
   combine_coverage_data:
     name: 🫣 SimpleCov
     uses: ./.github/workflows/_combine_coverage_data.yml
     secrets: inherit
     needs: [minitest,super_scaffolding,gem_tests]
+    if: ${{ always() }}
   combine_summary_logs:
     name: 📊 Test Results
     uses: ./.github/workflows/_combine_summary_logs.yml
     secrets: inherit
     needs: [minitest,super_scaffolding,gem_tests]
     if: ${{ always() }}
-  cleanup:
-    name: 🧹 Clean Up
-    runs-on: ubuntu-latest
-    needs: [combine_runtime_logs, combine_coverage_data, combine_summary_logs]
-    if: ${{ always() }}
-    steps:
-      - name: Delete artifacts
-        uses: geekyeggo/delete-artifact@v5
-        with:
-          name: |
-            test_coverage_*.log
-            parallel_runtime_test_*.log
-            test_summary_*.log
-          failOnError: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     needs: [minitest,super_scaffolding,gem_tests]
     if: ${{ always() }}
   combine_coverage_data:
-    name: 🫣 SimpleCov
+    name: ♻️  SimpleCov
     uses: ./.github/workflows/_combine_coverage_data.yml
     secrets: inherit
     needs: [minitest,super_scaffolding,gem_tests]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate_matrix
     steps:
-      - run: echo "${{ fromJson(needs.calculate_matrix.outputs.matrix) }}"
+      - run: echo "${{ needs.calculate_matrix.outputs.matrix }}"
         shell: bash
-      - run: echo "${{ fromJson(needs.calculate_matrix.outputs.totalRunners) }}"
+      - run: echo "${{ needs.calculate_matrix.outputs.totalRunners }}"
         shell: bash
-      - run: echo "${{ fromJson(needs.calculate_matrix.outputs.testRunnersPerNode) }}"
+      - run: echo "${{ needs.calculate_matrix.outputs.testRunnersPerNode }}"
         shell: bash
   minitest:
     name: 🧪 Starter Repo Minitest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,17 @@ jobs:
     secrets: inherit
     needs: [minitest,super_scaffolding,gem_tests]
     if: ${{ always() }}
+  cleanup:
+    name: 🧹 Clean Up
+    runs-on: ubuntu-latest
+    needs: [combine_runtime_logs, combine_coverage_data, combine_summary_logs]
+    if: ${{ always() }}
+    steps:
+      - name: Delete artifacts
+        uses: geekyeggo/delete-artifact@v5
+        with:
+          name: |
+            test_coverage_*.log
+            parallel_runtime_test_*.log
+            test_summary_*.log
+          failOnError: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
     uses: ./.github/workflows/_starter_repo_tests.yml
     secrets: inherit
   super_scaffolding:
-    name: 🧪 Starter Repo Super Scaffolding Tests
+    name: 🏗️ Starter Repo Super Scaffolding Tests
     uses: ./.github/workflows/_run_super_scaffolding_tests.yml
     secrets: inherit
   gem_tests:
-    name: 🧪 Gem Tests
+    name: 💎 Gem Tests
     uses: ./.github/workflows/_run_tests.yml
     secrets: inherit
   standardrb:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,9 @@ jobs:
     name: 🪵 Combine Runtime Logs
     uses: ./.github/workflows/_combine_runtime_logs.yml
     secrets: inherit
-    needs: [minitest]
+    # NOTE: This one really only _needs_ minitest, but we include the others
+    # so that the workflow visualization layous out a little better.
+    needs: [minitest,super_scaffolding,gem_tests]
   combine_coverage_data:
     name: 🫣 SimpleCov
     uses: ./.github/workflows/_combine_coverage_data.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,15 +23,26 @@ jobs:
           numberOfTestNodes: 4
           # You can explicitly set the number of runners per node, or it will default to 4 for public repos and 2 for private
           # testRunnersPerNode: 2
+  show_matrix:
+    name: Debug Matrix Calculations
+    runs-on: ubuntu-latest
+    needs: calculate_matrix
+    steps:
+      - run: echo "${{ fromJson(needs.calculate_matrix.outputs.matrix) }}"
+        shell: bash
+      - run: echo "${{ fromJson(needs.calculate_matrix.outputs.totalRunners) }}"
+        shell: bash
+      - run: echo "${{ fromJson(needs.calculate_matrix.outputs.testRunnersPerNode) }}"
+        shell: bash
   minitest:
     name: 🧪 Starter Repo Minitest
     uses: ./.github/workflows/_starter_repo_tests.yml
     secrets: inherit
     needs: calculate_matrix
     with:
-      matrix: ${{ fromJson(needs.calculate_matrix.outputs.matrix) }}
-      testRunnersPerNode: ${{ fromJson(needs.calculate_matrix.outputs.testRunnersPerNode) }}
-      totalRunners: ${{ fromJson(needs.calculate_matrix.outputs.totalRunners) }}
+      matrix: ${{ needs.calculate_matrix.outputs.matrix }}
+      testRunnersPerNode: ${{ needs.calculate_matrix.outputs.testRunnersPerNode }}
+      totalRunners: ${{ needs.calculate_matrix.outputs.totalRunners }}
   super_scaffolding:
     name: 🧪 Starter Repo Super Scaffolding Tests
     uses: ./.github/workflows/_run_super_scaffolding_tests.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,52 +7,18 @@ on:
     branches: [ "main" ]
 
 jobs:
-  calculate_matrix:
-    name: 🧮 Calculate Dynamic Matrix
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.dynamic-matrix.outputs.matrix }}
-      totalRunners: ${{ steps.dynamic-matrix.outputs.totalRunners }}
-      testRunnersPerNode: ${{ steps.dynamic-matrix.outputs.testRunnersPerNode }}
-    steps:
-      - name: Dynamic Matrix
-        id: dynamic-matrix
-        uses: bullet-train-co/parallel-test-dynamic-matrix@v1
-        with:
-          # You can explicitly set the number of test nodes, or it will default to 4
-          numberOfTestNodes: 4
-          # You can explicitly set the number of runners per node, or it will default to 4 for public repos and 2 for private
-          # testRunnersPerNode: 2
-  show_matrix:
-    name: Debug Matrix Calculations
-    runs-on: ubuntu-latest
-    needs: calculate_matrix
-    steps:
-      - run: echo "${{ needs.calculate_matrix.outputs.matrix }}"
-        shell: bash
-      - run: echo "${{ needs.calculate_matrix.outputs.totalRunners }}"
-        shell: bash
-      - run: echo "${{ needs.calculate_matrix.outputs.testRunnersPerNode }}"
-        shell: bash
   minitest:
     name: 🧪 Starter Repo Minitest
     uses: ./.github/workflows/_starter_repo_tests.yml
     secrets: inherit
-    needs: calculate_matrix
-    with:
-      matrix: ${{ needs.calculate_matrix.outputs.matrix }}
-      testRunnersPerNode: ${{ needs.calculate_matrix.outputs.testRunnersPerNode }}
-      totalRunners: ${{ needs.calculate_matrix.outputs.totalRunners }}
   super_scaffolding:
     name: 🧪 Starter Repo Super Scaffolding Tests
     uses: ./.github/workflows/_run_super_scaffolding_tests.yml
     secrets: inherit
-    needs: calculate_matrix
   gem_tests:
     name: 🧪 Gem Tests
     uses: ./.github/workflows/_run_tests.yml
     secrets: inherit
-    needs: calculate_matrix
   standardrb:
     name: 🔬 Standardrb
     uses: ./.github/workflows/_standardrb.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,10 @@ jobs:
     name: 🫣 SimpleCov
     uses: ./.github/workflows/_combine_coverage_data.yml
     secrets: inherit
-    needs: [minitest]
+    needs: [minitest,super_scaffolding,gem_tests]
   combine_summary_logs:
     name: 📊 Test Results
     uses: ./.github/workflows/_combine_summary_logs.yml
     secrets: inherit
-    needs: [minitest]
+    needs: [minitest,super_scaffolding,gem_tests]
     if: ${{ always() }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 
 */test/reports
+*/coverage

--- a/bullet_train-api/Gemfile.lock
+++ b/bullet_train-api/Gemfile.lock
@@ -212,6 +212,7 @@ GEM
     devise-pwned_password (0.1.10)
       devise (~> 4)
       pwned (~> 2.0.0)
+    docile (1.4.1)
     domain_name (0.6.20231109)
     doorkeeper (5.6.6)
       railties (>= 5)
@@ -413,6 +414,12 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.14.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
     sprockets (4.2.1)
@@ -476,6 +483,7 @@ DEPENDENCIES
   bullet_train-super_scaffolding!
   bullet_train-themes!
   minitest-reporters
+  simplecov
   sprockets-rails
   sqlite3 (< 2)
   standard

--- a/bullet_train-api/bullet_train-api.gemspec
+++ b/bullet_train-api/bullet_train-api.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_development_dependency "standard"
+  spec.add_development_dependency "simplecov"
 
   spec.add_dependency "bullet_train-super_scaffolding"
   spec.add_dependency "bullet_train"

--- a/bullet_train-api/test/test_helper.rb
+++ b/bullet_train-api/test/test_helper.rb
@@ -1,7 +1,7 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
-require 'simplecov'
+require "simplecov"
 SimpleCov.start
 
 require_relative "../test/dummy/config/environment"

--- a/bullet_train-api/test/test_helper.rb
+++ b/bullet_train-api/test/test_helper.rb
@@ -1,6 +1,9 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
+require 'simplecov'
+SimpleCov.start
+
 require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
 require "rails/test_help"

--- a/bullet_train-fields/Gemfile.lock
+++ b/bullet_train-fields/Gemfile.lock
@@ -217,6 +217,7 @@ GEM
     devise-pwned_password (0.1.12)
       devise (~> 4)
       pwned (~> 2.4)
+    docile (1.4.1)
     doorkeeper (5.8.0)
       railties (>= 5)
     email_reply_parser (0.5.11)
@@ -413,6 +414,12 @@ GEM
       logger
       rack (>= 2.2.4)
       redis-client (>= 0.22.2)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     simpleidn (0.2.3)
     sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
@@ -469,6 +476,7 @@ DEPENDENCIES
   bullet_train-super_scaffolding!
   bullet_train-themes!
   minitest-reporters
+  simplecov
   sprockets-rails
   sqlite3 (< 2)
   standard

--- a/bullet_train-fields/bullet_train-fields.gemspec
+++ b/bullet_train-fields/bullet_train-fields.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_development_dependency "standard"
+  spec.add_development_dependency "simplecov"
 
   spec.add_dependency "rails", ">= 6.0.0"
 

--- a/bullet_train-fields/package.json
+++ b/bullet_train-fields/package.json
@@ -65,5 +65,6 @@
     "tributejs": "^5.1.3",
     "trix": "^2.0.1",
     "zxcvbn": "^4.4.2"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }

--- a/bullet_train-fields/test/test_helper.rb
+++ b/bullet_train-fields/test/test_helper.rb
@@ -1,7 +1,7 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
-require 'simplecov'
+require "simplecov"
 SimpleCov.start
 
 require_relative "../test/dummy/config/environment"

--- a/bullet_train-fields/test/test_helper.rb
+++ b/bullet_train-fields/test/test_helper.rb
@@ -1,6 +1,9 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
+require 'simplecov'
+SimpleCov.start
+
 require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
 require "rails/test_help"

--- a/bullet_train-has_uuid/Gemfile.lock
+++ b/bullet_train-has_uuid/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
     connection_pool (2.4.1)
     crass (1.0.6)
     date (3.3.4)
+    docile (1.4.1)
     drb (2.2.0)
       ruby2_keywords
     erubi (1.12.0)
@@ -178,6 +179,12 @@ GEM
       io-console (~> 0.5)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -206,6 +213,7 @@ PLATFORMS
 DEPENDENCIES
   bullet_train-has_uuid!
   minitest-reporters
+  simplecov
   sprockets-rails
   sqlite3 (< 2)
 

--- a/bullet_train-has_uuid/bullet_train-has_uuid.gemspec
+++ b/bullet_train-has_uuid/bullet_train-has_uuid.gemspec
@@ -23,4 +23,6 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "rails", ">= 6.0.0"
+
+  spec.add_development_dependency "simplecov"
 end

--- a/bullet_train-has_uuid/test/test_helper.rb
+++ b/bullet_train-has_uuid/test/test_helper.rb
@@ -1,7 +1,7 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
-require 'simplecov'
+require "simplecov"
 SimpleCov.start
 
 require_relative "../test/dummy/config/environment"

--- a/bullet_train-has_uuid/test/test_helper.rb
+++ b/bullet_train-has_uuid/test/test_helper.rb
@@ -1,6 +1,9 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
+require 'simplecov'
+SimpleCov.start
+
 require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
 require "rails/test_help"

--- a/bullet_train-incoming_webhooks/Gemfile.lock
+++ b/bullet_train-incoming_webhooks/Gemfile.lock
@@ -230,6 +230,7 @@ GEM
     devise-pwned_password (0.1.10)
       devise (~> 4)
       pwned (~> 2.0.0)
+    docile (1.4.1)
     domain_name (0.6.20231109)
     doorkeeper (5.6.6)
       railties (>= 5)
@@ -429,6 +430,12 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.14.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
     sprockets (4.2.1)
@@ -484,6 +491,7 @@ DEPENDENCIES
   factory_bot_rails
   minitest-reporters
   pg (~> 1.3)
+  simplecov
   sprockets-rails
   sqlite3 (< 2)
 

--- a/bullet_train-incoming_webhooks/bullet_train-incoming_webhooks.gemspec
+++ b/bullet_train-incoming_webhooks/bullet_train-incoming_webhooks.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "factory_bot_rails"
   spec.add_development_dependency "pg", "~> 1.3"
+  spec.add_development_dependency "simplecov"
 end

--- a/bullet_train-incoming_webhooks/test/test_helper.rb
+++ b/bullet_train-incoming_webhooks/test/test_helper.rb
@@ -1,7 +1,7 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
-require 'simplecov'
+require "simplecov"
 SimpleCov.start
 
 require_relative "../test/dummy/config/environment"

--- a/bullet_train-incoming_webhooks/test/test_helper.rb
+++ b/bullet_train-incoming_webhooks/test/test_helper.rb
@@ -1,6 +1,9 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
+require 'simplecov'
+SimpleCov.start
+
 require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
 require "rails/test_help"

--- a/bullet_train-integrations-stripe/Gemfile.lock
+++ b/bullet_train-integrations-stripe/Gemfile.lock
@@ -240,6 +240,7 @@ GEM
     devise-pwned_password (0.1.10)
       devise (~> 4)
       pwned (~> 2.0.0)
+    docile (1.4.1)
     domain_name (0.6.20231109)
     doorkeeper (5.6.6)
       railties (>= 5)
@@ -450,6 +451,12 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.14.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
     snaky_hash (2.0.1)
@@ -509,6 +516,7 @@ DEPENDENCIES
   bullet_train-super_scaffolding!
   bullet_train-themes!
   minitest-reporters
+  simplecov
   sprockets-rails
   sqlite3 (< 2)
 

--- a/bullet_train-integrations-stripe/bullet_train-integrations-stripe.gemspec
+++ b/bullet_train-integrations-stripe/bullet_train-integrations-stripe.gemspec
@@ -30,4 +30,6 @@ Gem::Specification.new do |spec|
   # TODO Remove when we're able to properly upgrade Omniauth.
   # https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284
   spec.add_dependency "omniauth-rails_csrf_protection"
+
+  spec.add_development_dependency "simplecov"
 end

--- a/bullet_train-integrations-stripe/test/test_helper.rb
+++ b/bullet_train-integrations-stripe/test/test_helper.rb
@@ -1,7 +1,7 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
-require 'simplecov'
+require "simplecov"
 SimpleCov.start
 
 require_relative "../test/dummy/config/environment"

--- a/bullet_train-integrations-stripe/test/test_helper.rb
+++ b/bullet_train-integrations-stripe/test/test_helper.rb
@@ -1,6 +1,9 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
+require 'simplecov'
+SimpleCov.start
+
 require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
 require "rails/test_help"

--- a/bullet_train-integrations/Gemfile.lock
+++ b/bullet_train-integrations/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
     connection_pool (2.4.1)
     crass (1.0.6)
     date (3.3.4)
+    docile (1.4.1)
     drb (2.2.0)
       ruby2_keywords
     erubi (1.12.0)
@@ -178,6 +179,12 @@ GEM
       io-console (~> 0.5)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -206,6 +213,7 @@ PLATFORMS
 DEPENDENCIES
   bullet_train-integrations!
   minitest-reporters
+  simplecov
   sprockets-rails
   sqlite3 (< 2)
 

--- a/bullet_train-integrations/bullet_train-integrations.gemspec
+++ b/bullet_train-integrations/bullet_train-integrations.gemspec
@@ -23,4 +23,6 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "rails", ">= 6.0.0"
+
+  spec.add_development_dependency "simplecov"
 end

--- a/bullet_train-integrations/test/test_helper.rb
+++ b/bullet_train-integrations/test/test_helper.rb
@@ -1,7 +1,7 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
-require 'simplecov'
+require "simplecov"
 SimpleCov.start
 
 require_relative "../test/dummy/config/environment"

--- a/bullet_train-integrations/test/test_helper.rb
+++ b/bullet_train-integrations/test/test_helper.rb
@@ -1,6 +1,9 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
+require 'simplecov'
+SimpleCov.start
+
 require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
 require "rails/test_help"

--- a/bullet_train-obfuscates_id/Gemfile.lock
+++ b/bullet_train-obfuscates_id/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
     connection_pool (2.4.1)
     crass (1.0.6)
     date (3.3.4)
+    docile (1.4.1)
     drb (2.2.0)
       ruby2_keywords
     erubi (1.12.0)
@@ -180,6 +181,12 @@ GEM
       io-console (~> 0.5)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -208,6 +215,7 @@ PLATFORMS
 DEPENDENCIES
   bullet_train-obfuscates_id!
   minitest-reporters
+  simplecov
   sprockets-rails
   sqlite3 (< 2)
 

--- a/bullet_train-obfuscates_id/bullet_train-obfuscates_id.gemspec
+++ b/bullet_train-obfuscates_id/bullet_train-obfuscates_id.gemspec
@@ -24,4 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails", ">= 6.0.0"
   spec.add_dependency "hashids"
+
+  spec.add_development_dependency "simplecov"
 end

--- a/bullet_train-obfuscates_id/test/test_helper.rb
+++ b/bullet_train-obfuscates_id/test/test_helper.rb
@@ -1,7 +1,7 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
-require 'simplecov'
+require "simplecov"
 SimpleCov.start
 
 require_relative "../test/dummy/config/environment"

--- a/bullet_train-obfuscates_id/test/test_helper.rb
+++ b/bullet_train-obfuscates_id/test/test_helper.rb
@@ -1,6 +1,9 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
+require 'simplecov'
+SimpleCov.start
+
 require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
 require "rails/test_help"

--- a/bullet_train-outgoing_webhooks/Gemfile.lock
+++ b/bullet_train-outgoing_webhooks/Gemfile.lock
@@ -219,6 +219,7 @@ GEM
     devise-pwned_password (0.1.10)
       devise (~> 4)
       pwned (~> 2.0.0)
+    docile (1.4.1)
     domain_name (0.6.20231109)
     doorkeeper (5.6.6)
       railties (>= 5)
@@ -423,6 +424,12 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.14.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
     sprockets (4.2.1)
@@ -489,6 +496,7 @@ DEPENDENCIES
   jbuilder
   minitest-reporters
   pg (~> 1.3)
+  simplecov
   sprockets-rails
   sqlite3 (< 2)
   standard

--- a/bullet_train-outgoing_webhooks/bullet_train-outgoing_webhooks.gemspec
+++ b/bullet_train-outgoing_webhooks/bullet_train-outgoing_webhooks.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "standard"
   spec.add_development_dependency "pg", "~> 1.3"
+  spec.add_development_dependency "simplecov"
 
   spec.add_dependency "rails", ">= 6.0.0"
   spec.add_dependency "public_suffix"

--- a/bullet_train-outgoing_webhooks/test/test_helper.rb
+++ b/bullet_train-outgoing_webhooks/test/test_helper.rb
@@ -1,7 +1,7 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
-require 'simplecov'
+require "simplecov"
 SimpleCov.start
 
 require_relative "../test/dummy/config/environment"

--- a/bullet_train-outgoing_webhooks/test/test_helper.rb
+++ b/bullet_train-outgoing_webhooks/test/test_helper.rb
@@ -1,6 +1,9 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
+require 'simplecov'
+SimpleCov.start
+
 require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
 require "rails/test_help"

--- a/bullet_train-roles/Gemfile.lock
+++ b/bullet_train-roles/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.3)
+    docile (1.4.1)
     erubi (1.12.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -186,6 +187,12 @@ GEM
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.13.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     standard (1.5.0)
       rubocop (= 1.23.0)
       rubocop-performance (= 1.12.0)
@@ -217,6 +224,7 @@ DEPENDENCIES
   pg (~> 1.3)
   rails (~> 7.0.0)
   rake (~> 13.0)
+  simplecov
   standard (~> 1.5.0)
 
 BUNDLED WITH

--- a/bullet_train-roles/bullet_train-roles.gemspec
+++ b/bullet_train-roles/bullet_train-roles.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rails", "~> 7.0.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "standard", "~> 1.5.0"
+  spec.add_development_dependency "simplecov"
 
   spec.add_runtime_dependency "active_hash"
   spec.add_runtime_dependency "activesupport"

--- a/bullet_train-roles/test/lib/models/permit_test.rb
+++ b/bullet_train-roles/test/lib/models/permit_test.rb
@@ -19,6 +19,7 @@ class PermitTest < ActiveSupport::TestCase
       can_count = @admin_ability.permissions[:can].count
       @admin_ability.assign_permissions(permissions)
       assert_equal @admin_ability.permissions[:can].count, can_count + 1
+      assert_equal @admin_ability.permissions[:can].count, 10
     end
 
     test "Permit#build_permissions returns an array of Hashes" do

--- a/bullet_train-roles/test/lib/models/permit_test.rb
+++ b/bullet_train-roles/test/lib/models/permit_test.rb
@@ -19,7 +19,6 @@ class PermitTest < ActiveSupport::TestCase
       can_count = @admin_ability.permissions[:can].count
       @admin_ability.assign_permissions(permissions)
       assert_equal @admin_ability.permissions[:can].count, can_count + 1
-      assert_equal @admin_ability.permissions[:can].count, 10
     end
 
     test "Permit#build_permissions returns an array of Hashes" do

--- a/bullet_train-roles/test/test_helper.rb
+++ b/bullet_train-roles/test/test_helper.rb
@@ -3,7 +3,7 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
-require 'simplecov'
+require "simplecov"
 SimpleCov.start
 
 require_relative "../test/dummy/config/environment"

--- a/bullet_train-roles/test/test_helper.rb
+++ b/bullet_train-roles/test/test_helper.rb
@@ -3,6 +3,9 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
+require 'simplecov'
+SimpleCov.start
+
 require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
 require "rails/test_help"

--- a/bullet_train-scope_questions/Gemfile.lock
+++ b/bullet_train-scope_questions/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
     connection_pool (2.4.1)
     crass (1.0.6)
     date (3.3.4)
+    docile (1.4.1)
     drb (2.2.0)
       ruby2_keywords
     erubi (1.12.0)
@@ -178,6 +179,12 @@ GEM
       io-console (~> 0.5)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -206,6 +213,7 @@ PLATFORMS
 DEPENDENCIES
   bullet_train-scope_questions!
   minitest-reporters
+  simplecov
   sprockets-rails
   sqlite3 (< 2)
 

--- a/bullet_train-scope_questions/bullet_train-scope_questions.gemspec
+++ b/bullet_train-scope_questions/bullet_train-scope_questions.gemspec
@@ -23,4 +23,6 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "rails", ">= 6.0.0"
+
+  spec.add_development_dependency "simplecov"
 end

--- a/bullet_train-scope_questions/test/test_helper.rb
+++ b/bullet_train-scope_questions/test/test_helper.rb
@@ -1,7 +1,7 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
-require 'simplecov'
+require "simplecov"
 SimpleCov.start
 
 require_relative "../test/dummy/config/environment"

--- a/bullet_train-scope_questions/test/test_helper.rb
+++ b/bullet_train-scope_questions/test/test_helper.rb
@@ -1,6 +1,9 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
+require 'simplecov'
+SimpleCov.start
+
 require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
 require "rails/test_help"

--- a/bullet_train-scope_validator/Gemfile.lock
+++ b/bullet_train-scope_validator/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
     connection_pool (2.4.1)
     crass (1.0.6)
     date (3.4.0)
+    docile (1.4.1)
     drb (2.2.1)
     erubi (1.13.0)
     globalid (1.2.1)
@@ -195,6 +196,12 @@ GEM
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.11.0)
     securerandom (0.3.2)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     standard (1.6.0)
       rubocop (= 1.24.1)
       rubocop-performance (= 1.13.1)
@@ -223,6 +230,7 @@ DEPENDENCIES
   minitest (~> 5.0)
   minitest-reporters
   rake (~> 13.0)
+  simplecov
   standard (~> 1.3)
 
 BUNDLED WITH

--- a/bullet_train-scope_validator/bullet_train-scope_validator.gemspec
+++ b/bullet_train-scope_validator/bullet_train-scope_validator.gemspec
@@ -35,4 +35,6 @@ Gem::Specification.new do |spec|
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html
+
+  spec.add_development_dependency "simplecov"
 end

--- a/bullet_train-scope_validator/test/test_helper.rb
+++ b/bullet_train-scope_validator/test/test_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'simplecov'
+require "simplecov"
 SimpleCov.start
 
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)

--- a/bullet_train-scope_validator/test/test_helper.rb
+++ b/bullet_train-scope_validator/test/test_helper.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'simplecov'
+SimpleCov.start
+
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "bullet_train/scope_validator"
 

--- a/bullet_train-sortable/Gemfile.lock
+++ b/bullet_train-sortable/Gemfile.lock
@@ -228,6 +228,7 @@ GEM
     devise-pwned_password (0.1.10)
       devise (~> 4)
       pwned (~> 2.0.0)
+    docile (1.4.1)
     domain_name (0.6.20231109)
     doorkeeper (5.6.6)
       railties (>= 5)
@@ -449,6 +450,12 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.14.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
     sprockets (4.2.1)
@@ -515,6 +522,7 @@ DEPENDENCIES
   bullet_train-super_scaffolding!
   bullet_train-themes!
   minitest-reporters
+  simplecov
   sprockets-rails
   sqlite3 (< 2)
   standard

--- a/bullet_train-sortable/bullet_train-sortable.gemspec
+++ b/bullet_train-sortable/bullet_train-sortable.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_development_dependency "standard"
+  spec.add_development_dependency "simplecov"
 
   spec.add_dependency "rails", ">= 6.0.0"
 end

--- a/bullet_train-sortable/package.json
+++ b/bullet_train-sortable/package.json
@@ -56,5 +56,6 @@
     "@rails/request.js": "^0.0.6",
     "dragula": "^3.7.3",
     "jquery": "^3.7.1"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }

--- a/bullet_train-sortable/test/test_helper.rb
+++ b/bullet_train-sortable/test/test_helper.rb
@@ -1,7 +1,7 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
-require 'simplecov'
+require "simplecov"
 SimpleCov.start
 
 require_relative "../test/dummy/config/environment"

--- a/bullet_train-sortable/test/test_helper.rb
+++ b/bullet_train-sortable/test/test_helper.rb
@@ -1,6 +1,9 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
+require 'simplecov'
+SimpleCov.start
+
 require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
 require "rails/test_help"

--- a/bullet_train-super_load_and_authorize_resource/Gemfile.lock
+++ b/bullet_train-super_load_and_authorize_resource/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
     connection_pool (2.4.1)
     crass (1.0.6)
     date (3.3.4)
+    docile (1.4.1)
     drb (2.2.0)
       ruby2_keywords
     erubi (1.12.0)
@@ -185,6 +186,12 @@ GEM
       io-console (~> 0.5)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -214,6 +221,7 @@ DEPENDENCIES
   bullet_train-super_load_and_authorize_resource!
   minitest-reporters
   pry
+  simplecov
   sprockets-rails
   sqlite3 (< 2)
 

--- a/bullet_train-super_load_and_authorize_resource/bullet_train-super_load_and_authorize_resource.gemspec
+++ b/bullet_train-super_load_and_authorize_resource/bullet_train-super_load_and_authorize_resource.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rails", ">= 6.0.0"
 
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "simplecov"
 end

--- a/bullet_train-super_load_and_authorize_resource/test/test_helper.rb
+++ b/bullet_train-super_load_and_authorize_resource/test/test_helper.rb
@@ -1,7 +1,7 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
-require 'simplecov'
+require "simplecov"
 SimpleCov.start
 
 require_relative "../test/dummy/config/environment"

--- a/bullet_train-super_load_and_authorize_resource/test/test_helper.rb
+++ b/bullet_train-super_load_and_authorize_resource/test/test_helper.rb
@@ -1,6 +1,9 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
+require 'simplecov'
+SimpleCov.start
+
 require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
 require "rails/test_help"

--- a/bullet_train-super_scaffolding/Gemfile.lock
+++ b/bullet_train-super_scaffolding/Gemfile.lock
@@ -212,6 +212,7 @@ GEM
     devise-pwned_password (0.1.10)
       devise (~> 4)
       pwned (~> 2.0.0)
+    docile (1.4.1)
     domain_name (0.6.20231109)
     doorkeeper (5.6.6)
       railties (>= 5)
@@ -415,6 +416,12 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.14.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
     sprockets (4.2.1)
@@ -478,6 +485,7 @@ DEPENDENCIES
   bullet_train-super_scaffolding!
   bullet_train-themes!
   minitest-reporters
+  simplecov
   sprockets-rails
   sqlite3 (< 2)
   standard

--- a/bullet_train-super_scaffolding/bullet_train-super_scaffolding.gemspec
+++ b/bullet_train-super_scaffolding/bullet_train-super_scaffolding.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_development_dependency "standard"
+  spec.add_development_dependency "simplecov"
 
   spec.add_dependency "rails", ">= 6.0.0"
   spec.add_dependency "masamune-ast", "~> 2.0.2"

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -482,7 +482,6 @@ class Scaffolding::Transformer
   end
 
   def add_ability_line_to_roles_yml(class_names = nil)
-    raise "intentional failure"
     model_names = class_names || [child]
     role_file = "#{Rails.root}/config/models/roles.yml"
     roles_hash = YAML.load_file(role_file)

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -482,6 +482,7 @@ class Scaffolding::Transformer
   end
 
   def add_ability_line_to_roles_yml(class_names = nil)
+    raise "intentional failure"
     model_names = class_names || [child]
     role_file = "#{Rails.root}/config/models/roles.yml"
     roles_hash = YAML.load_file(role_file)

--- a/bullet_train-super_scaffolding/test/test_helper.rb
+++ b/bullet_train-super_scaffolding/test/test_helper.rb
@@ -1,7 +1,7 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
-require 'simplecov'
+require "simplecov"
 SimpleCov.start
 
 require_relative "../test/dummy/config/environment"

--- a/bullet_train-super_scaffolding/test/test_helper.rb
+++ b/bullet_train-super_scaffolding/test/test_helper.rb
@@ -1,6 +1,9 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
+require 'simplecov'
+SimpleCov.start
+
 require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
 require "rails/test_help"

--- a/bullet_train-themes-light/Gemfile.lock
+++ b/bullet_train-themes-light/Gemfile.lock
@@ -237,6 +237,7 @@ GEM
     devise-pwned_password (0.1.10)
       devise (~> 4)
       pwned (~> 2.0.0)
+    docile (1.4.1)
     domain_name (0.6.20231109)
     doorkeeper (5.6.6)
       railties (>= 5)
@@ -458,6 +459,12 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.14.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
     sprockets (4.2.1)
@@ -525,6 +532,7 @@ DEPENDENCIES
   bullet_train-themes-light!
   bullet_train-themes-tailwind_css!
   minitest-reporters
+  simplecov
   sprockets-rails
   sqlite3 (< 2)
   standard

--- a/bullet_train-themes-light/bullet_train-themes-light.gemspec
+++ b/bullet_train-themes-light/bullet_train-themes-light.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_development_dependency "standard"
+  spec.add_development_dependency "simplecov"
 
   spec.add_dependency "rails", ">= 6.0.0"
   spec.add_dependency "bullet_train-themes-tailwind_css"

--- a/bullet_train-themes-light/test/test_helper.rb
+++ b/bullet_train-themes-light/test/test_helper.rb
@@ -1,7 +1,7 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
-require 'simplecov'
+require "simplecov"
 SimpleCov.start
 
 require_relative "../test/dummy/config/environment"

--- a/bullet_train-themes-light/test/test_helper.rb
+++ b/bullet_train-themes-light/test/test_helper.rb
@@ -1,6 +1,9 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
+require 'simplecov'
+SimpleCov.start
+
 require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
 require "rails/test_help"

--- a/bullet_train-themes-tailwind_css/Gemfile.lock
+++ b/bullet_train-themes-tailwind_css/Gemfile.lock
@@ -229,6 +229,7 @@ GEM
     devise-pwned_password (0.1.10)
       devise (~> 4)
       pwned (~> 2.0.0)
+    docile (1.4.1)
     domain_name (0.6.20231109)
     doorkeeper (5.6.6)
       railties (>= 5)
@@ -450,6 +451,12 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.14.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
     sprockets (4.2.1)
@@ -516,6 +523,7 @@ DEPENDENCIES
   bullet_train-themes!
   bullet_train-themes-tailwind_css!
   minitest-reporters
+  simplecov
   sprockets-rails
   sqlite3 (< 2)
   standard

--- a/bullet_train-themes-tailwind_css/bullet_train-themes-tailwind_css.gemspec
+++ b/bullet_train-themes-tailwind_css/bullet_train-themes-tailwind_css.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_development_dependency "standard"
+  spec.add_development_dependency "simplecov"
 
   spec.add_dependency "rails", ">= 6.0.0"
   spec.add_dependency "bullet_train-themes"

--- a/bullet_train-themes-tailwind_css/test/test_helper.rb
+++ b/bullet_train-themes-tailwind_css/test/test_helper.rb
@@ -1,7 +1,7 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
-require 'simplecov'
+require "simplecov"
 SimpleCov.start
 
 require_relative "../test/dummy/config/environment"

--- a/bullet_train-themes-tailwind_css/test/test_helper.rb
+++ b/bullet_train-themes-tailwind_css/test/test_helper.rb
@@ -1,6 +1,9 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
+require 'simplecov'
+SimpleCov.start
+
 require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
 require "rails/test_help"

--- a/bullet_train-themes/Gemfile.lock
+++ b/bullet_train-themes/Gemfile.lock
@@ -215,6 +215,7 @@ GEM
     devise-pwned_password (0.1.12)
       devise (~> 4)
       pwned (~> 2.4)
+    docile (1.4.1)
     doorkeeper (5.8.0)
       railties (>= 5)
     email_reply_parser (0.5.11)
@@ -410,6 +411,12 @@ GEM
       logger
       rack (>= 2.2.4)
       redis-client (>= 0.22.2)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     simpleidn (0.2.3)
     sprockets (4.2.0)
       concurrent-ruby (~> 1.0)
@@ -462,6 +469,7 @@ DEPENDENCIES
   bullet_train-super_scaffolding!
   bullet_train-themes!
   minitest-reporters
+  simplecov
   sprockets-rails
   sqlite3 (< 2)
   standard

--- a/bullet_train-themes/bullet_train-themes.gemspec
+++ b/bullet_train-themes/bullet_train-themes.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_development_dependency "standard"
+  spec.add_development_dependency "simplecov"
 
   spec.add_dependency "rails", ">= 6.0.0"
   spec.add_dependency "nice_partials", "~> 0.9"

--- a/bullet_train-themes/test/test_helper.rb
+++ b/bullet_train-themes/test/test_helper.rb
@@ -1,7 +1,7 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
-require 'simplecov'
+require "simplecov"
 SimpleCov.start
 
 require_relative "../test/dummy/config/environment"

--- a/bullet_train-themes/test/test_helper.rb
+++ b/bullet_train-themes/test/test_helper.rb
@@ -1,6 +1,9 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
+require 'simplecov'
+SimpleCov.start
+
 require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
 require "rails/test_help"

--- a/bullet_train/Gemfile.lock
+++ b/bullet_train/Gemfile.lock
@@ -238,6 +238,7 @@ GEM
     devise-pwned_password (0.1.10)
       devise (~> 4)
       pwned (~> 2.0.0)
+    docile (1.4.1)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     doorkeeper (5.6.6)
@@ -446,6 +447,12 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.14.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
     sprockets (4.1.1)
@@ -509,6 +516,7 @@ DEPENDENCIES
   pg (~> 1.3)
   pry
   pry-stack_explorer
+  simplecov
   sprockets-rails
   sqlite3 (< 2)
   standard

--- a/bullet_train/bullet_train.gemspec
+++ b/bullet_train/bullet_train.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   MESSAGE
 
   spec.add_development_dependency "standard"
+  spec.add_development_dependency "simplecov"
 
   spec.add_dependency "rails", ">= 6.0.0"
   spec.add_dependency "bullet_train-roles"

--- a/bullet_train/package.json
+++ b/bullet_train/package.json
@@ -53,5 +53,6 @@
   },
   "dependencies": {
     "@hotwired/stimulus": "^3.0.1"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }

--- a/bullet_train/test/models/team_test.rb
+++ b/bullet_train/test/models/team_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class TeamTest < ActiveSupport::TestCase
   test "a new team defaults time_zone to UTC" do
     team = Team.new
+    team.wat
     assert_equal "UTC", team.time_zone
   end
 

--- a/bullet_train/test/models/team_test.rb
+++ b/bullet_train/test/models/team_test.rb
@@ -3,7 +3,6 @@ require "test_helper"
 class TeamTest < ActiveSupport::TestCase
   test "a new team defaults time_zone to UTC" do
     team = Team.new
-    team.wat
     assert_equal "UTC", team.time_zone
   end
 

--- a/bullet_train/test/models/team_test.rb
+++ b/bullet_train/test/models/team_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class TeamTest < ActiveSupport::TestCase
   test "a new team defaults time_zone to UTC" do
     team = Team.new
+    team.do_fake_thing
     assert_equal "UTC", team.time_zone
   end
 

--- a/bullet_train/test/models/team_test.rb
+++ b/bullet_train/test/models/team_test.rb
@@ -3,7 +3,6 @@ require "test_helper"
 class TeamTest < ActiveSupport::TestCase
   test "a new team defaults time_zone to UTC" do
     team = Team.new
-    team.do_fake_thing
     assert_equal "UTC", team.time_zone
   end
 

--- a/bullet_train/test/test_helper.rb
+++ b/bullet_train/test/test_helper.rb
@@ -1,7 +1,7 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
-require 'simplecov'
+require "simplecov"
 SimpleCov.start
 
 require_relative "../test/dummy/config/environment"

--- a/bullet_train/test/test_helper.rb
+++ b/bullet_train/test/test_helper.rb
@@ -1,6 +1,9 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
+require 'simplecov'
+SimpleCov.start
+
 require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
 require "rails/test_help"


### PR DESCRIPTION
This is very similar to the [joint PR in the starter repo](https://github.com/bullet-train-co/bullet_train/pull/1787). Both PRs improve the CI workflow in their respective repos.

* Uses `parallel_tests` (installed in the starter repo) to not only split tests (starter repo minitest) across "physical" nodes, but also parallelize test runs on each node. We're using 4 nodes, with 4 runners per node, for a total of 16 individual runners.
* Uses the `runtime` grouping option of `parallel_tests` to create test groups that _should_ run in about the same amount of time. Previously we used random grouping and so sometimes one runner would end up with a bunch of slow tests and run times would be fairly uneven.
* We use workflow artifacts to store runtime info about each test, and then in a later workflow we combine that data and store it in a cache, which is then used by subsequent test runs to optimize test grouping.
* Uses `bullet-train-co/parallel-test-dynamic-matrix` action to dynamically construct the matrix of test runners based on the configuration (or defaults) mentioned above. This makes it much less fiddly and error prone to configure whatever parallelization you want.
* Use a custom job to calculate the "gem matrix" for running individual gem tests. Previously we had hard-coded the list of gems into the workflow. The dynamic matrix means that when new gems are added in the future they'll be automatically picked up by the CI workflow.
* Uses `standardrb/standard-ruby-action` instead of running `standardrb` manually. Using the official action makes it so that any linting failures are added as annotations to the workflow.
* Instead of summarizing test status for each individual test node we now use workflow artifacts to store test status for each node and then we use a later workflow to combine the status data from all nodes into a single report.

Before we would show dozens of different summaries:

![CleanShot 2024-12-10 at 11 24 51](https://github.com/user-attachments/assets/843a6998-fd58-42ad-8580-67d49c246fc2)

Now we show a single summary that includes all tests (starter repo minitest, starter repo super scaffolding test, and individual test inside each gem):

![CleanShot 2024-12-10 at 11 18 11](https://github.com/user-attachments/assets/3a0d91a1-ea4a-458a-8ae9-04abdc1f804b)

When there are test failures they are collected and all reported together instead of being spread across the different summaries:

![CleanShot 2024-12-10 at 11 34 26](https://github.com/user-attachments/assets/f61f401b-16ef-4808-b474-d9d7b048fbb4)

* Use `simplecov` to generate data about test coverage. We use workflow artifacts to save coverage data from each test node, and then a later workflow combines the coverage data and generates a summary.

![CleanShot 2024-12-10 at 11 22 35](https://github.com/user-attachments/assets/7a03ada7-24ae-4687-904b-0dd451b608bc)

The summary includes expandable sections. One that shows coverage data for the top 10 least covered files, and another that show coverage by groups. In the `core` repo the grouping is for the individual gems and the starter repo.

![CleanShot 2024-12-10 at 11 19 24](https://github.com/user-attachments/assets/3108faed-fa32-47dc-84ca-42862fd6c0c6)

The summary also includes a link to a downloadable coverage report. After downloading the report you can open it in your browser to get the full picture of the coverage situation.

![CleanShot 2024-12-10 at 11 56 31](https://github.com/user-attachments/assets/4af86a0e-33bb-48be-bfa8-c1c86f850398)
