### PR TITLE
Allow for non-existent event types in `Webhooks::Outgoing::Endpoint#event_types`

### DIFF
--- a/bullet_train-outgoing_webhooks/app/models/concerns/webhooks/outgoing/endpoint_support.rb
+++ b/bullet_train-outgoing_webhooks/app/models/concerns/webhooks/outgoing/endpoint_support.rb
@@ -34,7 +34,7 @@ module Webhooks::Outgoing::EndpointSupport
   end
 
   def event_types
-    event_type_ids.map { |id| Webhooks::Outgoing::EventType.find(id) }
+    Webhooks::Outgoing::EventType.where(id: event_type_ids)
   end
 
   def touch_parent

--- a/bullet_train-outgoing_webhooks/test/models/webhooks/outgoing/endpoint_test.rb
+++ b/bullet_train-outgoing_webhooks/test/models/webhooks/outgoing/endpoint_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class Webhooks::Outgoing::EndpointTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    @team = Team.create!(name: "test-team")
+    @endpoint = Webhooks::Outgoing::Endpoint.create!(url: "https://example.com/webhook", name: "test", team: @team)
+  end
+
+  test "#create should accept valid event_types" do
+    @endpoint = Webhooks::Outgoing::Endpoint.create!(
+      url: "https://example.com/webhook",
+      name: "test",
+      team: @team,
+      event_type_ids: [Webhooks::Outgoing::EventType.all.first]
+    )
+    assert @endpoint.persisted?
+  end
+
+  test "#create should accept non-existent event_types" do
+    @endpoint = Webhooks::Outgoing::Endpoint.create!(
+      url: "https://example.com/webhook",
+      name: "test",
+      team: @team,
+      event_type_ids: ["fake-thing.create"]
+    )
+    assert @endpoint.persisted?
+  end
+
+  test "#event_types should not raise an error for non-existent event_type_ids" do
+    @endpoint = Webhooks::Outgoing::Endpoint.create!(
+      url: "https://example.com/webhook",
+      name: "test",
+      team: @team,
+      event_type_ids: ["fake-thing.create"]
+    )
+    assert_equal [], @endpoint.event_types
+  end
+end

--- a/bullet_train-outgoing_webhooks/test/models/webhooks/outgoing/endpoint_test.rb
+++ b/bullet_train-outgoing_webhooks/test/models/webhooks/outgoing/endpoint_test.rb
@@ -13,7 +13,7 @@ class Webhooks::Outgoing::EndpointTest < ActiveSupport::TestCase
       url: "https://example.com/webhook",
       name: "test",
       team: @team,
-      event_type_ids: [Webhooks::Outgoing::EventType.all.first]
+      event_type_ids: [Webhooks::Outgoing::EventType.all.first.id]
     )
     assert @endpoint.persisted?
   end
@@ -26,6 +26,17 @@ class Webhooks::Outgoing::EndpointTest < ActiveSupport::TestCase
       event_type_ids: ["fake-thing.create"]
     )
     assert @endpoint.persisted?
+  end
+
+  test "#event_types should return existent EventTypes" do
+    valid_event_type = Webhooks::Outgoing::EventType.all.first
+    @endpoint = Webhooks::Outgoing::Endpoint.create!(
+      url: "https://example.com/webhook",
+      name: "test",
+      team: @team,
+      event_type_ids: [valid_event_type.id]
+    )
+    assert_equal [valid_event_type.id], @endpoint.event_types.map(&:id)
   end
 
   test "#event_types should not raise an error for non-existent event_type_ids" do


### PR DESCRIPTION
Fixes: https://github.com/bullet-train-co/bullet_train-core/issues/654

### The Set Up

Let's say you had created a `Widget` model, and had added `widget.*` events to `config/models/webhooks/outgoing/event_types.yml`:

```yaml
scaffolding/absolutely_abstract/creative_concept:
  # This automatically generates `created`, `updated`, and `deleted` webhook events.
  - crud
scaffolding/completely_concrete/tangible_thing:
  - crud
invitation:
  - crud
membership:
  - crud
widget:
  - crud
```

And then you (or one of your users) sets up an Outgoing Webhook using one of the widget events. Effectively this:

```ruby
  endpoint = Webhooks::Outgoing::Endpoint.create!(
    url: "https://example.com/webhook",
    name: "test",
    team: @team,
    event_type_ids: ["widget.created", "membership.created"]
  )
```

Then at a later time you decide that the `Widget` model was a bad idea, and so you remove it from `event_types.yml`.

### Old Behavior

Previously, if you then called `event_types` on that `endpoint` we'd raise an `ActiveHash::RecordNotFound` error:

```ruby
> endpoint.event_types
bullet_train-outgoing_webhooks (1.11.0)
  app/models/concerns/webhooks/outgoing/endpoint_support.rb:37:
  in `block in event_types':
  Couldn't find Webhooks::Outgoing::EventType with ID=widget.created
  (ActiveHash::RecordNotFound)
        from bullet_train-outgoing_webhooks (1.11.0) app/models/concerns/webhooks/outgoing/endpoint_support.rb:37:in `map'
        from bullet_train-outgoing_webhooks (1.11.0) app/models/concerns/webhooks/outgoing/endpoint_support.rb:37:in `event_types'
```

### New Behavior

Now if you call `event_types` on that `endpoint` we'll return an array of `Webhooks::Outgoing::EventType` objects for the still-good `event_type_ids` for the endpoint. Since `widget.created` is no longer a valid type, it won't show up in the `event_types` array _and_ we won't raise an error.

```ruby
> endpoint.event_types
=> [
      #<Webhooks::Outgoing::EventType:0x000000014dddc068 
        @attributes={:id=>"membership.created"}>
   ]
```