### PR TITLE
Fix expected parameter for action_models.scheduled_for

### DIFF
--- a/bullet_train-themes-light/app/views/themes/light/actions/_action.html.erb
+++ b/bullet_train-themes-light/app/views/themes/light/actions/_action.html.erb
@@ -49,7 +49,7 @@
 
       <% elsif action.is_a?(Actions::SupportsScheduling) && action.scheduled_for && !action.started? %>
         <div class="uppercase text-xs text-slate-400">
-          <%= t('action_models.scheduled_for', at: display_date_and_time(action.scheduled_for)) %>
+          <%= t('action_models.scheduled_for', for: display_date_and_time(action.scheduled_for)) %>
         </div>
 
       <% elsif action.is_a?(Actions::HasProgress) && action.started? %>


### PR DESCRIPTION
**Error it fixes:**
action_models.scheduled_for shows the following error: missing interpolation argument :for in "Scheduled for %{for}" ({:post_name=>"Post", :posts_possessive=>"Post’s", :team_name=>"dev", :teams_possessive=>"dev’s", :at=>"December 28 at 12:00 AM"} given)

**When:**
An action with SupportScheduling concern and at when an explicit scheduled_for datetime is set in the future at action creation time.

**Reproduce:**
rails generate super_scaffold Post Team scheduled_at:date_and_time_field
rails generate super_scaffold:action_models:targets_one ScheduledPost Post Team 

Then on the UI:
- create a new Post
- create a scheduled action with a date in the future
