### PR TITLE
Warn the user if we can't find target hooks for super scaffolding

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -340,8 +340,6 @@ class Scaffolding::Transformer
         puts "-------------------------------".yellow
         puts
       end
-
-      return false
     else
 
       new_target_file_content = []

--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -330,10 +330,14 @@ class Scaffolding::Transformer
     elsif !target_file_content.include?(transform_hook)
       unless options[:suppress_could_not_find_hook]
         puts
+        puts "-------------------------------".yellow
         puts "Heads up! We weren't able to find a super scaffolding hook where we expected it to be.".yellow
         puts "In #{transformed_file_name}".yellow
         puts "We expected to find a line like this:".yellow
         puts transform_hook.yellow
+        puts
+        puts "See https://bullettrain.co/docs/super-scaffolding/targets for more details.".yellow
+        puts "-------------------------------".yellow
         puts
       end
 

--- a/bullet_train/docs/super-scaffolding.md
+++ b/bullet_train/docs/super-scaffolding.md
@@ -17,6 +17,8 @@ Here’s a list of what Super Scaffolding takes care of for you each time you ad
 
 When adding just one model, Super Scaffolding generates ~30 different files on your behalf.
 
+**NOTE** Super Scaffolding generates code that contains special "magic comments" that we use as targets for later Super Scaffolding operations. You shouldn't remove those comments. See [Targets for Super Scaffolding](/docs/super-scaffolding/targets.md) for more details.
+
 ## Living Templates
 
 Bullet Train's Super Scaffolding engine is a unique approach to code generation, based on template files that are functional code instead of obscure DSLs that are difficult to customize and maintain. Super Scaffolding automates the most repetitive and mundane aspects of building out your application's basic structure. Furthermore, it does this without leaning on the magic of libraries that force too high a level of abstraction. Instead, it generates standard Rails code that is both ready for prime time, but is also easy to customize and modify.

--- a/bullet_train/docs/super-scaffolding.md
+++ b/bullet_train/docs/super-scaffolding.md
@@ -299,3 +299,7 @@ HIDE_THINGS: true
  - [Super Scaffolding Options](/docs/super-scaffolding/options.md)
  - [Super Scaffolding with Delegated Types](/docs/super-scaffolding/delegated-types.md)
  - [Super Scaffolding with the `--sortable` option](/docs/super-scaffolding/sortable.md)
+
+## Additional Info
+
+ - [Targets for Super Scaffolding](/docs/super-scaffolding/targets.md)

--- a/bullet_train/docs/super-scaffolding/targets.md
+++ b/bullet_train/docs/super-scaffolding/targets.md
@@ -99,4 +99,10 @@ See https://bullettrain.co/docs/super-scaffolding/targets for more details.
 -------------------------------
 ```
 
+## How to Replace Missing Targets
 
+If you've removed some targets and need to get them back you have a few options:
+
+1. If the removal of the targets hasn't been committed to source control yet, you can use `git checkout` to restore the files to their previous state.
+2. If the removal has been committed you could revert the commit that removed them.
+3. You could use Super Scaffolding to generate a new resource and then copy &amp; paste the targets from your new resource into the existing one.

--- a/bullet_train/docs/super-scaffolding/targets.md
+++ b/bullet_train/docs/super-scaffolding/targets.md
@@ -1,0 +1,102 @@
+# Targets for Super Scaffolding
+
+Super Scaffolding relies on "magic comments" that we use as targets (also known as hooks)
+that help us put newly generated code in the right place.
+
+For instance if you Super Scaffold a `Project` resource your model file will look like this:
+
+```ruby
+class Project < ApplicationRecord
+  # 🚅 add concerns above.
+
+  # 🚅 add attribute accessors above.
+
+  belongs_to :team
+  # 🚅 add belongs_to associations above.
+
+  # 🚅 add has_many associations above.
+
+  # 🚅 add has_one associations above.
+
+  # 🚅 add scopes above.
+
+  validates :name, presence: true
+  # 🚅 add validations above.
+
+  # 🚅 add callbacks above.
+
+  # 🚅 add delegations above.
+
+  # 🚅 add methods above.
+end
+```
+
+All of those comments are used by the Super Scaffolder to put things in the right place.
+
+**DON'T REMOVE THEM!**
+
+If you remove them then we won't be able to make modifications to that file, and subsequent
+super scaffolding commands won't work correctly.
+
+If you do remove them then you should see a warning the next time you try to add a field
+that requires modifications that model. (Not all attribute types do. File and Image fields
+are examples of ones that do.)
+
+```
+$ rails generate super_scaffold:field Project documents:file_field{multiple}
+Adding new fields to Project with 'bin/rails generate migration add_documents_to_projects documents:attachments'
+
+Updating './app/views/account/projects/_form.html.erb'.
+Updating './app/views/account/projects/show.html.erb'.
+Updating './app/views/account/projects/_index.html.erb'.
+Replacing in './app/views/account/projects/_index.html.erb'.
+Updating './app/views/account/projects/_project.html.erb'.
+Updating './config/locales/en/projects.en.yml'.
+Updating './config/locales/en/projects.en.yml'.
+Updating './app/controllers/api/v1/projects_controller.rb'.
+Updating './app/controllers/api/v1/projects_controller.rb'.
+Updating './test/controllers/api/v1/projects_controller_test.rb'.
+Updating './app/views/api/v1/projects/_project.json.jbuilder'.
+Updating './test/controllers/api/v1/projects_controller_test.rb'.
+
+-------------------------------
+Heads up! We weren't able to find a super scaffolding hook where we expected it to be.
+In ./app/models/project.rb
+We expected to find a line like this:
+# 🚅 add has_many associations above.
+
+See https://bullettrain.co/docs/super-scaffolding/targets for more details.
+-------------------------------
+
+
+-------------------------------
+Heads up! We weren't able to find a super scaffolding hook where we expected it to be.
+In ./app/models/project.rb
+We expected to find a line like this:
+# 🚅 add attribute accessors above.
+
+See https://bullettrain.co/docs/super-scaffolding/targets for more details.
+-------------------------------
+
+
+-------------------------------
+Heads up! We weren't able to find a super scaffolding hook where we expected it to be.
+In ./app/models/project.rb
+We expected to find a line like this:
+# 🚅 add methods above.
+
+See https://bullettrain.co/docs/super-scaffolding/targets for more details.
+-------------------------------
+
+
+-------------------------------
+Heads up! We weren't able to find a super scaffolding hook where we expected it to be.
+In ./app/models/project.rb
+We expected to find a line like this:
+# 🚅 add callbacks above.
+
+See https://bullettrain.co/docs/super-scaffolding/targets for more details.
+-------------------------------
+```
+
+

--- a/bullet_train/docs/super-scaffolding/targets.md
+++ b/bullet_train/docs/super-scaffolding/targets.md
@@ -1,7 +1,6 @@
 # Targets for Super Scaffolding
 
-Super Scaffolding relies on "magic comments" that we use as targets (also known as hooks)
-that help us put newly generated code in the right place.
+Super Scaffolding relies on "magic comments" that we use as targets (also known as hooks) that help us put newly generated code in the right place.
 
 For instance if you Super Scaffold a `Project` resource your model file will look like this:
 
@@ -35,12 +34,9 @@ All of those comments are used by the Super Scaffolder to put things in the righ
 
 **DON'T REMOVE THEM!**
 
-If you remove them then we won't be able to make modifications to that file, and subsequent
-super scaffolding commands won't work correctly.
+If you remove them then we won't be able to make modifications to that file, and subsequent super scaffolding commands won't work correctly.
 
-If you do remove them then you should see a warning the next time you try to add a field
-that requires modifications that model. (Not all attribute types do. File and Image fields
-are examples of ones that do.)
+If you do remove them then you should see a warning the next time you try to add a field that requires modifications that model. (Not all attribute types do. File and Image fields are examples of ones that do.)
 
 ```
 $ rails generate super_scaffold:field Project documents:file_field{multiple}


### PR DESCRIPTION
## The Scenario

Imagine you Super Scaffold a `Project` resource:

```
rails generate super_scaffold Project Team name:text_field
```

And then you open the `Project` model, and remove all of the target comments:

```ruby
class Project < ApplicationRecord
  belongs_to :team

  validates :name, presence: true
end
```

And then you want to Super Scaffold a `file_field` onto `Project`.

```
rails generate super_scaffold:field Project documents:file_field{multiple}
```

## Previously

Previously we would act like everything had gone according to plan, but in reality we wouldn't have updated the `Project` model with some important changes.

```
rails generate super_scaffold:field Project documents:file_field{multiple}
Adding new fields to Project with 'bin/rails generate migration add_documents_to_projects documents:attachments'

Updating './app/views/account/projects/_form.html.erb'.
Updating './app/views/account/projects/show.html.erb'.
Updating './app/views/account/projects/_index.html.erb'.
Replacing in './app/views/account/projects/_index.html.erb'.
Updating './app/views/account/projects/_project.html.erb'.
Updating './config/locales/en/projects.en.yml'.
Updating './config/locales/en/projects.en.yml'.
Updating './app/controllers/account/projects_controller.rb'.
Updating './app/controllers/account/projects_controller.rb'.
Updating './app/controllers/api/v1/projects_controller.rb'.
Updating './app/controllers/api/v1/projects_controller.rb'.
Updating './test/controllers/api/v1/projects_controller_test.rb'.
Updating './app/views/api/v1/projects/_project.json.jbuilder'.
Updating './test/controllers/api/v1/projects_controller_test.rb'.
Updating './app/models/project.rb'.
Updating './app/models/project.rb'.
Updating './app/models/project.rb'.
Updating './app/models/project.rb'.
```

You, as the developer, would think that everything worked, but then when you went to use the new attribute things wouldn't work quite right.

## Now

Now we'll warn you that things did not go according to plan.

```
rails generate super_scaffold:field Project documents:file_field{multiple}
Adding new fields to Project with 'bin/rails generate migration add_documents_to_projects documents:attachments'

Updating './app/views/account/projects/_form.html.erb'.
Updating './app/views/account/projects/show.html.erb'.
Updating './app/views/account/projects/_index.html.erb'.
Replacing in './app/views/account/projects/_index.html.erb'.
Updating './app/views/account/projects/_project.html.erb'.
Updating './config/locales/en/projects.en.yml'.
Updating './config/locales/en/projects.en.yml'.
Updating './app/controllers/api/v1/projects_controller.rb'.
Updating './app/controllers/api/v1/projects_controller.rb'.
Updating './test/controllers/api/v1/projects_controller_test.rb'.
Updating './app/views/api/v1/projects/_project.json.jbuilder'.
Updating './test/controllers/api/v1/projects_controller_test.rb'.

-------------------------------
Heads up! We weren't able to find a super scaffolding hook where we expected it to be.
In ./app/models/project.rb
We expected to find a line like this:
# 🚅 add has_many associations above.

See https://bullettrain.co/docs/super-scaffolding/targets for more details.
-------------------------------


-------------------------------
Heads up! We weren't able to find a super scaffolding hook where we expected it to be.
In ./app/models/project.rb
We expected to find a line like this:
# 🚅 add attribute accessors above.

See https://bullettrain.co/docs/super-scaffolding/targets for more details.
-------------------------------


-------------------------------
Heads up! We weren't able to find a super scaffolding hook where we expected it to be.
In ./app/models/project.rb
We expected to find a line like this:
# 🚅 add methods above.

See https://bullettrain.co/docs/super-scaffolding/targets for more details.
-------------------------------


-------------------------------
Heads up! We weren't able to find a super scaffolding hook where we expected it to be.
In ./app/models/project.rb
We expected to find a line like this:
# 🚅 add callbacks above.

See https://bullettrain.co/docs/super-scaffolding/targets for more details.
-------------------------------
```

Fixes https://github.com/bullet-train-co/bullet_train/issues/1753