### PR TITLE
Add more template methods

### DIFF
--- a/bullet_train-api/app/controllers/api/v1/platform/access_tokens_controller.rb
+++ b/bullet_train-api/app/controllers/api/v1/platform/access_tokens_controller.rb
@@ -1,6 +1,10 @@
 class Api::V1::Platform::AccessTokensController < Api::V1::ApplicationController
   account_load_and_authorize_resource :access_token, through: :application, through_association: :access_tokens
 
+  # GET /api/v1/platform/access_tokens
+  def index
+  end
+
   # GET /api/v1/platform/access_tokens/:id
   def show
   end

--- a/bullet_train-outgoing_webhooks/test/models/concerns/webhooks/outgoing/uri_filtering_test.rb
+++ b/bullet_train-outgoing_webhooks/test/models/concerns/webhooks/outgoing/uri_filtering_test.rb
@@ -28,8 +28,20 @@ class Webhooks::Outgoing::UriFilteringTest < ActiveSupport::TestCase
   end
 
   test "allowed_uri?" do
-    assert_allowed_uri("http://www.example.com")
-    assert_allowed_uri("https://www.example.com")
+    # TODO: Can we switch back to www.example.com at some point?
+    # It seems like something changed in late 2024 or early 2025 about
+    # the example.com domain. When using www.example.com this test is failing with this error:
+    #
+    # Resolv::ResolvError: DNS result has no information for www.example.com
+    # /Users/jgreen/.asdf/installs/ruby/3.4.1/lib/ruby/3.4.0/resolv.rb:502:in 'Resolv::DNS#getresource'
+    # app/models/concerns/webhooks/outgoing/uri_filtering.rb:81:in 'Webhooks::Outgoing::UriFiltering#resolve_ip_from_authoritative'
+    #
+    # So, for now, instead of using www.example.com we're using bullettrain.co
+    #
+    # assert_allowed_uri("http://www.example.com")
+    # assert_allowed_uri("https://www.example.com")
+    assert_allowed_uri("http://bullettrain.co")
+    assert_allowed_uri("https://bullettrain.co")
     assert_allowed_uri("http://104.16.16.194")
 
     refute_allowed_uri("http://localhost")

--- a/bullet_train-super_load_and_authorize_resource/app/controllers/concerns/bullet_train/loads_and_authorizes_resource.rb
+++ b/bullet_train-super_load_and_authorize_resource/app/controllers/concerns/bullet_train/loads_and_authorizes_resource.rb
@@ -185,6 +185,14 @@ module BulletTrain::LoadsAndAuthorizesResource
     raise "This is a template method that needs to be implemented by controllers including LoadsAndAuthorizesResource."
   end
 
+  def index
+    raise "This is a template method that needs to be implemented by controllers including LoadsAndAuthorizesResource."
+  end
+
+  def show
+    raise "This is a template method that needs to be implemented by controllers including LoadsAndAuthorizesResource."
+  end
+
   def new
     raise "This is a template method that needs to be implemented by controllers including LoadsAndAuthorizesResource."
   end


### PR DESCRIPTION
Some of the billing gems don't have an `index` or `show` method, but they use `account_load_and_authorize_resource`, which assumes that all CRUD methods are always present on controllers that ues it.

This adds those template methods so that we don't throw an error when accessing those controller in dev and test environments.

Related to: https://github.com/bullet-train-co/bullet_train-core/pull/930