### PR TITLE
Allow user menu to be closed after a click inside it

### DIFF
--- a/bullet_train/app/javascript/controllers/desktop_menu_controller.js
+++ b/bullet_train/app/javascript/controllers/desktop_menu_controller.js
@@ -3,6 +3,14 @@ import { Controller } from "@hotwired/stimulus";
 export default class extends Controller {
   static targets = [ "menuItemHeader", "menuItemGroup", "menuItemLink" ];
 
+  connect() {
+    document.addEventListener('click', this.handleClickOutside.bind(this))
+  }
+
+  disconnect() {
+    document.removeEventListener('click', this.handleClickOutside.bind(this))
+  }
+
   showSubmenu() {
     this.menuItemGroupTarget.classList.remove('invisible');
   }
@@ -22,5 +30,11 @@ export default class extends Controller {
     }
 
     if(hideMenu) { this.menuItemGroupTarget.classList.add('invisible'); }
+  }
+
+  handleClickOutside(event) {
+    if (!this.element.contains(event.target)) {
+      this.menuItemGroupTarget.classList.add('invisible')
+    }
   }
 }


### PR DESCRIPTION
Previously if you clicked somewhere inside the user menu, without clicking on an actual link it would effectively lock the menu into an open state with no way to close it.

This makes it so that a click outside the menu will close it.

Fixes https://github.com/bullet-train-co/bullet_train-core/issues/987