### PR TITLE
fix unlock email body rendering

### DIFF
--- a/bullet_train/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/bullet_train/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,4 +1,4 @@
-<p><% t('.hello', email: @resource.email) %></p>
+<p><%= t('.hello', email: @resource.email) %></p>
 
 <p><%= t('.account_blocked') %></p>
 


### PR DESCRIPTION
missing `=` to render the text