### PR TITLE
Update stripe connect and omniauth gems

### DIFF
--- a/bullet_train-api/Gemfile.lock
+++ b/bullet_train-api/Gemfile.lock
@@ -75,7 +75,7 @@ PATH
       image_processing
       microscope
       nice_partials (~> 0.9)
-      omniauth
+      omniauth (~> 2.0)
       pagy (~> 8)
       possessive
       premailer-rails

--- a/bullet_train-fields/Gemfile.lock
+++ b/bullet_train-fields/Gemfile.lock
@@ -81,7 +81,7 @@ PATH
       image_processing
       microscope
       nice_partials (~> 0.9)
-      omniauth
+      omniauth (~> 2.0)
       pagy (~> 8)
       possessive
       premailer-rails

--- a/bullet_train-incoming_webhooks/Gemfile.lock
+++ b/bullet_train-incoming_webhooks/Gemfile.lock
@@ -90,7 +90,7 @@ PATH
       image_processing
       microscope
       nice_partials (~> 0.9)
-      omniauth
+      omniauth (~> 2.0)
       pagy (~> 8)
       possessive
       premailer-rails

--- a/bullet_train-integrations-stripe/Gemfile.lock
+++ b/bullet_train-integrations-stripe/Gemfile.lock
@@ -115,9 +115,9 @@ PATH
   remote: .
   specs:
     bullet_train-integrations-stripe (1.14.2)
-      omniauth
-      omniauth-rails_csrf_protection
-      omniauth-stripe-connect
+      omniauth (~> 2.0)
+      omniauth-rails_csrf_protection (~> 1.0)
+      omniauth-stripe-connect-v2
       rails (>= 6.0.0)
       stripe
 
@@ -340,17 +340,18 @@ GEM
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
     observer (0.1.2)
-    omniauth (1.9.2)
+    omniauth (2.1.2)
       hashie (>= 3.4.6)
-      rack (>= 1.6.2, < 3)
-    omniauth-oauth2 (1.7.3)
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-oauth2 (1.8.0)
       oauth2 (>= 1.4, < 3)
-      omniauth (>= 1.9, < 3)
-    omniauth-rails_csrf_protection (0.1.2)
+      omniauth (~> 2.0)
+    omniauth-rails_csrf_protection (1.0.2)
       actionpack (>= 4.2)
-      omniauth (>= 1.3.1)
-    omniauth-stripe-connect (2.10.1)
-      omniauth (~> 1.3)
+      omniauth (~> 2.0)
+    omniauth-stripe-connect-v2 (1.0.4)
+      omniauth (~> 2.0)
       omniauth-oauth2 (~> 1.4)
     orm_adapter (0.5.0)
     ostruct (0.6.1)
@@ -378,6 +379,9 @@ GEM
     rack (2.2.10)
     rack-cors (2.0.2)
       rack (>= 2.0.0)
+    rack-protection (3.2.0)
+      base64 (>= 0.1.0)
+      rack (~> 2.2, >= 2.2.4)
     rack-session (1.0.2)
       rack (< 3)
     rack-test (2.2.0)

--- a/bullet_train-integrations-stripe/Gemfile.lock
+++ b/bullet_train-integrations-stripe/Gemfile.lock
@@ -99,7 +99,7 @@ PATH
       image_processing
       microscope
       nice_partials (~> 0.9)
-      omniauth
+      omniauth (~> 2.0)
       pagy (~> 8)
       possessive
       premailer-rails

--- a/bullet_train-integrations-stripe/bullet_train-integrations-stripe.gemspec
+++ b/bullet_train-integrations-stripe/bullet_train-integrations-stripe.gemspec
@@ -24,12 +24,12 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails", ">= 6.0.0"
   spec.add_dependency "stripe"
-  spec.add_dependency "omniauth"
-  spec.add_dependency "omniauth-stripe-connect"
+  spec.add_dependency "omniauth", "~> 2.0"
+  spec.add_dependency "omniauth-stripe-connect-v2"
 
   # TODO Remove when we're able to properly upgrade Omniauth.
   # https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284
-  spec.add_dependency "omniauth-rails_csrf_protection"
+  spec.add_dependency "omniauth-rails_csrf_protection", "~> 1.0"
 
   spec.add_development_dependency "simplecov"
 end

--- a/bullet_train-integrations-stripe/lib/bullet_train/integrations/stripe.rb
+++ b/bullet_train-integrations-stripe/lib/bullet_train/integrations/stripe.rb
@@ -5,9 +5,13 @@ require "stripe"
 require "omniauth"
 require "omniauth-stripe-connect-v2"
 
-# TODO Remove when we're able to properly upgrade Omniauth.
+# This helps to resolve this CVE:
 # https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284
-#require "omniauth/rails_csrf_protection"
+# It also just allows things to work as expected.
+# Initially it seemed like we could remove this gem after updating omniauth
+# to version > 2. But If we remove it the built-in TokenValidator from omniauth
+# throws an error when we try to connect.
+require "omniauth/rails_csrf_protection"
 
 module BulletTrain
   module Integrations

--- a/bullet_train-integrations-stripe/lib/bullet_train/integrations/stripe.rb
+++ b/bullet_train-integrations-stripe/lib/bullet_train/integrations/stripe.rb
@@ -3,11 +3,11 @@ require "bullet_train/integrations/stripe/engine"
 
 require "stripe"
 require "omniauth"
-require "omniauth-stripe-connect"
+require "omniauth-stripe-connect-v2"
 
 # TODO Remove when we're able to properly upgrade Omniauth.
 # https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284
-require "omniauth/rails_csrf_protection"
+#require "omniauth/rails_csrf_protection"
 
 module BulletTrain
   module Integrations

--- a/bullet_train-integrations/app/controllers/concerns/account/oauth/omniauth_callbacks/controller_base.rb
+++ b/bullet_train-integrations/app/controllers/concerns/account/oauth/omniauth_callbacks/controller_base.rb
@@ -6,6 +6,8 @@ module Account::Oauth::OmniauthCallbacks::ControllerBase
   end
 
   def failure
+    Rails.logger.error "OmniAuth Failure -------------------------------------"
+    Rails.logger.error request.env["omniauth.error"]
     flash[:danger] = "Failed to sign in"
     redirect_to root_path
   end

--- a/bullet_train-outgoing_webhooks/Gemfile.lock
+++ b/bullet_train-outgoing_webhooks/Gemfile.lock
@@ -90,7 +90,7 @@ PATH
       image_processing
       microscope
       nice_partials (~> 0.9)
-      omniauth
+      omniauth (~> 2.0)
       pagy (~> 8)
       possessive
       premailer-rails

--- a/bullet_train-sortable/Gemfile.lock
+++ b/bullet_train-sortable/Gemfile.lock
@@ -90,7 +90,7 @@ PATH
       image_processing
       microscope
       nice_partials (~> 0.9)
-      omniauth
+      omniauth (~> 2.0)
       pagy (~> 8)
       possessive
       premailer-rails

--- a/bullet_train-super_scaffolding/Gemfile.lock
+++ b/bullet_train-super_scaffolding/Gemfile.lock
@@ -81,7 +81,7 @@ PATH
       image_processing
       microscope
       nice_partials (~> 0.9)
-      omniauth
+      omniauth (~> 2.0)
       pagy (~> 8)
       possessive
       premailer-rails

--- a/bullet_train-themes-light/Gemfile.lock
+++ b/bullet_train-themes-light/Gemfile.lock
@@ -97,7 +97,7 @@ PATH
       image_processing
       microscope
       nice_partials (~> 0.9)
-      omniauth
+      omniauth (~> 2.0)
       pagy (~> 8)
       possessive
       premailer-rails

--- a/bullet_train-themes-tailwind_css/Gemfile.lock
+++ b/bullet_train-themes-tailwind_css/Gemfile.lock
@@ -90,7 +90,7 @@ PATH
       image_processing
       microscope
       nice_partials (~> 0.9)
-      omniauth
+      omniauth (~> 2.0)
       pagy (~> 8)
       possessive
       premailer-rails

--- a/bullet_train-themes/Gemfile.lock
+++ b/bullet_train-themes/Gemfile.lock
@@ -82,7 +82,7 @@ PATH
       image_processing
       microscope
       nice_partials (~> 0.9)
-      omniauth
+      omniauth (~> 2.0)
       pagy (~> 8)
       possessive
       premailer-rails

--- a/bullet_train/Gemfile.lock
+++ b/bullet_train/Gemfile.lock
@@ -112,7 +112,7 @@ PATH
       image_processing
       microscope
       nice_partials (~> 0.9)
-      omniauth
+      omniauth (~> 2.0)
       pagy (~> 8)
       possessive
       premailer-rails

--- a/bullet_train/bullet_train.gemspec
+++ b/bullet_train/bullet_train.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "colorizer"
   spec.add_dependency "devise"
   spec.add_dependency "xxhash"
-  spec.add_dependency "omniauth"
+  spec.add_dependency "omniauth", "~> 2.0"
 
   spec.add_dependency "image_processing"
 


### PR DESCRIPTION
This switches out a dependency for Stripe Connect.

We used to use `omniauth-stripe-connect` but it hasn't been updated in quite sometime and it's pegged to versions of `ominauth` on the `1.x` line. Unfortunately the `1.x` line of ominauth has some security vulnerabilities. In order to update `omniauth` to the `2.x` line we're moving to `omniauth-stripe-connect-v2` which is basically the same as `omniauth-stripe-connect` but with a `.gemspec` that allows `omniauth` versions `~> 2.0`.

This also bumps the version of `omniauth-rails_csrf_protection` to `~> 1.0` so that it works with the new stripe connect gem.

The docs for all of the new versions are the same as the docs for the old versions, so there shouldn't be any application changes required. I've tested these in my local starter repo and I can connect to Stripe accounts both for user sign in and for purposes of creating a Stripe Installation for marketplace scenarios.

Fixes https://github.com/bullet-train-co/bullet_train-core/issues/1007