### PR TITLE
Allow applications to declare their own root routes

### DIFF
--- a/bullet_train/config/routes.rb
+++ b/bullet_train/config/routes.rb
@@ -4,7 +4,16 @@ Rails.application.routes.draw do
   end
 
   scope module: "public" do
-    root to: "home#index"
+    begin
+      root to: "home#index"
+    rescue ArgumentError => argument_error
+      if argument_error.message.match?("Invalid route name, already in use: 'root'")
+        # This means that a public root route has been declared by the application.
+      else
+        raise
+      end
+    end
+
     get "invitation" => "home#invitation", :as => "invitation"
 
     if Rails.env.development?
@@ -15,8 +24,16 @@ Rails.application.routes.draw do
 
   namespace :account do
     shallow do
-      # TODO we need to either implement a dashboard or deprecate this.
-      root to: "dashboard#index", as: "dashboard"
+      begin
+        # TODO we need to either implement a dashboard or deprecate this.
+        root to: "dashboard#index", as: "dashboard"
+      rescue ArgumentError => argument_error
+        if argument_error.message.match?("Invalid route name, already in use: 'account_dashboard'")
+          # This means that an account scoped root/dashboard route has been declared by the application.
+        else
+          raise
+        end
+      end
 
       resource :two_factor, only: [:create, :destroy] do
         post :verify


### PR DESCRIPTION
Previously if you tried to declare a public root route (without a unique `as:` reference) you'd get an `ArgumentError` saying:

```
Invalid route name, already in use: 'root'
```

Similary if you tried to declare an account scoped dashboard route (with an `as: 'dashboard'` reference) you'd get an `ArgumentError` saying:

```
Invalid route name, already in use: 'account_dashboard'
```

Both of these errors were happening when we tried to draw default routes after the application had already declared them.

Now we resuce the `ArgumentError` and check the message to see if it's a complaint about a duplicate route. If so, we do nothing and let the app use the route defined in the primary `config/routes.rb` file.

Fixes https://github.com/bullet-train-co/bullet_train/issues/1656