### PR TITLE
Remove pins of `active_hash` that point to a fork

### DIFF
--- a/bullet_train-api/Gemfile.lock
+++ b/bullet_train-api/Gemfile.lock
@@ -17,7 +17,7 @@ PATH
   remote: ../bullet_train-roles
   specs:
     bullet_train-roles (1.15.0)
-      active_hash
+      active_hash (>= 3.3.1)
       activesupport
       cancancan
 

--- a/bullet_train-api/Gemfile.lock
+++ b/bullet_train-api/Gemfile.lock
@@ -304,7 +304,8 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
+      net-protocol
     nice_partials (0.10.1)
       actionview (>= 4.2.6)
     nio4r (2.7.4)

--- a/bullet_train-fields/Gemfile.lock
+++ b/bullet_train-fields/Gemfile.lock
@@ -23,7 +23,7 @@ PATH
   remote: ../bullet_train-roles
   specs:
     bullet_train-roles (1.15.0)
-      active_hash
+      active_hash (>= 3.3.1)
       activesupport
       cancancan
 

--- a/bullet_train-has_uuid/Gemfile.lock
+++ b/bullet_train-has_uuid/Gemfile.lock
@@ -122,7 +122,8 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
+      net-protocol
     nio4r (2.7.4)
     nokogiri (1.18.1-arm64-darwin)
       racc (~> 1.4)

--- a/bullet_train-incoming_webhooks/Gemfile.lock
+++ b/bullet_train-incoming_webhooks/Gemfile.lock
@@ -32,7 +32,7 @@ PATH
   remote: ../bullet_train-roles
   specs:
     bullet_train-roles (1.15.0)
-      active_hash
+      active_hash (>= 3.3.1)
       activesupport
       cancancan
 

--- a/bullet_train-incoming_webhooks/Gemfile.lock
+++ b/bullet_train-incoming_webhooks/Gemfile.lock
@@ -313,7 +313,8 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
+      net-protocol
     nice_partials (0.10.1)
       actionview (>= 4.2.6)
     nio4r (2.7.4)

--- a/bullet_train-integrations-stripe/Gemfile.lock
+++ b/bullet_train-integrations-stripe/Gemfile.lock
@@ -41,7 +41,7 @@ PATH
   remote: ../bullet_train-roles
   specs:
     bullet_train-roles (1.15.0)
-      active_hash
+      active_hash (>= 3.3.1)
       activesupport
       cancancan
 

--- a/bullet_train-integrations-stripe/Gemfile.lock
+++ b/bullet_train-integrations-stripe/Gemfile.lock
@@ -324,7 +324,8 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
+      net-protocol
     nice_partials (0.10.1)
       actionview (>= 4.2.6)
     nio4r (2.7.4)

--- a/bullet_train-integrations/Gemfile.lock
+++ b/bullet_train-integrations/Gemfile.lock
@@ -122,7 +122,8 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
+      net-protocol
     nio4r (2.7.4)
     nokogiri (1.18.1-arm64-darwin)
       racc (~> 1.4)

--- a/bullet_train-obfuscates_id/Gemfile.lock
+++ b/bullet_train-obfuscates_id/Gemfile.lock
@@ -124,7 +124,8 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
+      net-protocol
     nio4r (2.7.4)
     nokogiri (1.18.1-arm64-darwin)
       racc (~> 1.4)

--- a/bullet_train-outgoing_webhooks/Gemfile.lock
+++ b/bullet_train-outgoing_webhooks/Gemfile.lock
@@ -32,7 +32,7 @@ PATH
   remote: ../bullet_train-roles
   specs:
     bullet_train-roles (1.15.0)
-      active_hash
+      active_hash (>= 3.3.1)
       activesupport
       cancancan
 

--- a/bullet_train-outgoing_webhooks/Gemfile.lock
+++ b/bullet_train-outgoing_webhooks/Gemfile.lock
@@ -311,7 +311,8 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
+      net-protocol
     nice_partials (0.10.1)
       actionview (>= 4.2.6)
     nio4r (2.7.4)

--- a/bullet_train-roles/Gemfile
+++ b/bullet_train-roles/Gemfile
@@ -5,9 +5,6 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in bullet_train-roles.gemspec
 gemspec
 
-# TODO: move to gemspec when using this gem from rubygems, gemspec doesn't support git urls so it has to be here for now
-gem "active_hash", github: "bullet-train-co/active_hash", branch: "fixes/address-keyword-argument-issue"
-
 group :test do
   gem "minitest-reporters"
 end

--- a/bullet_train-roles/Gemfile.lock
+++ b/bullet_train-roles/Gemfile.lock
@@ -1,16 +1,8 @@
-GIT
-  remote: https://github.com/bullet-train-co/active_hash.git
-  revision: 25034270b31fec6ef48bba1e43be02760451d3c2
-  branch: fixes/address-keyword-argument-issue
-  specs:
-    active_hash (3.1.0)
-      activesupport (>= 5.0.0)
-
 PATH
   remote: .
   specs:
     bullet_train-roles (1.15.0)
-      active_hash
+      active_hash (>= 3.3.1)
       activesupport
       cancancan
 
@@ -60,6 +52,8 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    active_hash (3.3.1)
+      activesupport (>= 5.0.0)
     activejob (8.0.1)
       activesupport (= 8.0.1)
       globalid (>= 0.3.6)
@@ -249,7 +243,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  active_hash!
   bullet_train-roles!
   byebug (~> 11.1.0)
   factory_bot_rails

--- a/bullet_train-roles/README.md
+++ b/bullet_train-roles/README.md
@@ -24,11 +24,8 @@ You don't have to name your models the same thing in order to use this Ruby Gem,
 Add these lines to your application's Gemfile:
 
 ```ruby
-gem "active_hash", github: "bullet-train-co/active_hash"
 gem "bullet_train-roles"
 ```
-
-> We have to link to a specific downstream version of ActiveHash temporarily while working to merge certain fixes and updates upstream.
 
 And then execute the following in your shell:
 

--- a/bullet_train-roles/bullet_train-roles.gemspec
+++ b/bullet_train-roles/bullet_train-roles.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "standard", "~> 1.5.0"
   spec.add_development_dependency "simplecov"
 
-  spec.add_runtime_dependency "active_hash"
+  spec.add_runtime_dependency "active_hash", ">= 3.3.1"
   spec.add_runtime_dependency "activesupport"
   spec.add_runtime_dependency "cancancan"
   # For more information and examples about making a new gem, checkout our

--- a/bullet_train-scope_questions/Gemfile.lock
+++ b/bullet_train-scope_questions/Gemfile.lock
@@ -122,7 +122,8 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
+      net-protocol
     nio4r (2.7.4)
     nokogiri (1.18.1-arm64-darwin)
       racc (~> 1.4)

--- a/bullet_train-sortable/Gemfile.lock
+++ b/bullet_train-sortable/Gemfile.lock
@@ -32,7 +32,7 @@ PATH
   remote: ../bullet_train-roles
   specs:
     bullet_train-roles (1.15.0)
-      active_hash
+      active_hash (>= 3.3.1)
       activesupport
       cancancan
 

--- a/bullet_train-sortable/Gemfile.lock
+++ b/bullet_train-sortable/Gemfile.lock
@@ -310,7 +310,8 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
+      net-protocol
     nice_partials (0.10.1)
       actionview (>= 4.2.6)
     nio4r (2.7.4)

--- a/bullet_train-super_load_and_authorize_resource/Gemfile.lock
+++ b/bullet_train-super_load_and_authorize_resource/Gemfile.lock
@@ -126,7 +126,8 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
+      net-protocol
     nio4r (2.7.4)
     nokogiri (1.18.1-arm64-darwin)
       racc (~> 1.4)

--- a/bullet_train-super_scaffolding/Gemfile.lock
+++ b/bullet_train-super_scaffolding/Gemfile.lock
@@ -32,7 +32,7 @@ PATH
   remote: ../bullet_train-roles
   specs:
     bullet_train-roles (1.15.0)
-      active_hash
+      active_hash (>= 3.3.1)
       activesupport
       cancancan
 

--- a/bullet_train-super_scaffolding/Gemfile.lock
+++ b/bullet_train-super_scaffolding/Gemfile.lock
@@ -304,7 +304,8 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
+      net-protocol
     nice_partials (0.10.1)
       actionview (>= 4.2.6)
     nio4r (2.7.4)

--- a/bullet_train-themes-light/Gemfile.lock
+++ b/bullet_train-themes-light/Gemfile.lock
@@ -32,7 +32,7 @@ PATH
   remote: ../bullet_train-roles
   specs:
     bullet_train-roles (1.15.0)
-      active_hash
+      active_hash (>= 3.3.1)
       activesupport
       cancancan
 

--- a/bullet_train-themes-light/Gemfile.lock
+++ b/bullet_train-themes-light/Gemfile.lock
@@ -319,7 +319,8 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
+      net-protocol
     nice_partials (0.10.1)
       actionview (>= 4.2.6)
     nio4r (2.7.4)

--- a/bullet_train-themes-tailwind_css/Gemfile.lock
+++ b/bullet_train-themes-tailwind_css/Gemfile.lock
@@ -32,7 +32,7 @@ PATH
   remote: ../bullet_train-roles
   specs:
     bullet_train-roles (1.15.0)
-      active_hash
+      active_hash (>= 3.3.1)
       activesupport
       cancancan
 

--- a/bullet_train-themes-tailwind_css/Gemfile.lock
+++ b/bullet_train-themes-tailwind_css/Gemfile.lock
@@ -311,7 +311,8 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
+      net-protocol
     nice_partials (0.10.1)
       actionview (>= 4.2.6)
     nio4r (2.7.4)

--- a/bullet_train-themes/Gemfile.lock
+++ b/bullet_train-themes/Gemfile.lock
@@ -32,7 +32,7 @@ PATH
   remote: ../bullet_train-roles
   specs:
     bullet_train-roles (1.15.0)
-      active_hash
+      active_hash (>= 3.3.1)
       activesupport
       cancancan
 

--- a/bullet_train-themes/Gemfile.lock
+++ b/bullet_train-themes/Gemfile.lock
@@ -306,7 +306,8 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
+      net-protocol
     nice_partials (0.10.1)
       actionview (>= 4.2.6)
     nio4r (2.7.4)

--- a/bullet_train/Gemfile
+++ b/bullet_train/Gemfile
@@ -8,9 +8,6 @@ gem "sqlite3"
 
 gem "sprockets-rails"
 
-# TODO Have to specify this dependency here until our changes are in the original package.
-gem "active_hash", github: "bullet-train-co/active_hash"
-
 gem "bullet_train-api", path: "../bullet_train-api"
 gem "bullet_train-fields", path: "../bullet_train-fields"
 gem "bullet_train-roles", path: "../bullet_train-roles"

--- a/bullet_train/Gemfile.lock
+++ b/bullet_train/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/bullet-train-co/active_hash.git
-  revision: a6628bc65e7c099ec9428c2bfe1e292ef01f1ef1
-  specs:
-    active_hash (3.1.0)
-      activesupport (>= 5.0.0)
-
 PATH
   remote: ../bullet_train-api
   specs:
@@ -39,7 +32,7 @@ PATH
   remote: ../bullet_train-roles
   specs:
     bullet_train-roles (1.15.0)
-      active_hash
+      active_hash (>= 3.3.1)
       activesupport
       cancancan
 
@@ -170,6 +163,8 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    active_hash (3.3.1)
+      activesupport (>= 5.0.0)
     activejob (8.0.1)
       activesupport (= 8.0.1)
       globalid (>= 0.3.6)
@@ -526,7 +521,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  active_hash!
   bullet_train!
   bullet_train-api!
   bullet_train-fields!

--- a/bullet_train/Gemfile.lock
+++ b/bullet_train/Gemfile.lock
@@ -326,7 +326,8 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
+      net-protocol
     nice_partials (0.10.1)
       actionview (>= 4.2.6)
     nio4r (2.7.4)


### PR DESCRIPTION
Previously we had pinned some of the gems to use a fork of `active_hash` via the `Gemfile` in the gem. But the `.gemspec` files pointed to a real, published version of the gem. The starter repo also points to the published version.

This PR removes the pins that point at the fork, and is sets an appropriate version constraint for `active_hash` in the appropriate `.gemspec`.

Fixes https://github.com/bullet-train-co/bullet_train-core/issues/1029