### PR TITLE
Remove the `ruby-openai` gem

### DIFF
--- a/bullet_train-api/Gemfile.lock
+++ b/bullet_train-api/Gemfile.lock
@@ -79,7 +79,6 @@ PATH
       possessive
       premailer-rails
       rails (>= 6.0.0)
-      ruby-openai
       showcase-rails
       sidekiq
       unicode-emoji
@@ -224,7 +223,6 @@ GEM
       railties (>= 5)
     drb (2.2.1)
     erubi (1.13.1)
-    event_stream_parser (1.0.0)
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
     faraday (2.12.2)
@@ -410,10 +408,6 @@ GEM
     rubocop-performance (1.23.0)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
-    ruby-openai (7.3.1)
-      event_stream_parser (>= 0.3.0, < 2.0.0)
-      faraday (>= 1)
-      faraday-multipart (>= 1)
     ruby-progressbar (1.13.0)
     ruby-vips (2.2.2)
       ffi (~> 1.12)

--- a/bullet_train-fields/Gemfile.lock
+++ b/bullet_train-fields/Gemfile.lock
@@ -85,7 +85,6 @@ PATH
       possessive
       premailer-rails
       rails (>= 6.0.0)
-      ruby-openai
       showcase-rails
       sidekiq
       unicode-emoji
@@ -227,7 +226,6 @@ GEM
       railties (>= 5)
     drb (2.2.1)
     erubi (1.13.1)
-    event_stream_parser (1.0.0)
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
     faraday (2.12.2)
@@ -420,10 +418,6 @@ GEM
     rubocop-performance (1.23.0)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
-    ruby-openai (7.3.1)
-      event_stream_parser (>= 0.3.0, < 2.0.0)
-      faraday (>= 1)
-      faraday-multipart (>= 1)
     ruby-progressbar (1.13.0)
     ruby-vips (2.2.2)
       ffi (~> 1.12)

--- a/bullet_train-incoming_webhooks/Gemfile.lock
+++ b/bullet_train-incoming_webhooks/Gemfile.lock
@@ -94,7 +94,6 @@ PATH
       possessive
       premailer-rails
       rails (>= 6.0.0)
-      ruby-openai
       showcase-rails
       sidekiq
       unicode-emoji
@@ -232,7 +231,6 @@ GEM
       railties (>= 5)
     drb (2.2.1)
     erubi (1.13.1)
-    event_stream_parser (1.0.0)
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.4.4)
@@ -399,10 +397,6 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    ruby-openai (7.3.1)
-      event_stream_parser (>= 0.3.0, < 2.0.0)
-      faraday (>= 1)
-      faraday-multipart (>= 1)
     ruby-progressbar (1.13.0)
     ruby-vips (2.2.2)
       ffi (~> 1.12)

--- a/bullet_train-integrations-stripe/Gemfile.lock
+++ b/bullet_train-integrations-stripe/Gemfile.lock
@@ -103,7 +103,6 @@ PATH
       possessive
       premailer-rails
       rails (>= 6.0.0)
-      ruby-openai
       showcase-rails
       sidekiq
       unicode-emoji
@@ -242,7 +241,6 @@ GEM
       railties (>= 5)
     drb (2.2.1)
     erubi (1.13.1)
-    event_stream_parser (1.0.0)
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
     faraday (2.12.2)
@@ -425,10 +423,6 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    ruby-openai (7.3.1)
-      event_stream_parser (>= 0.3.0, < 2.0.0)
-      faraday (>= 1)
-      faraday-multipart (>= 1)
     ruby-progressbar (1.13.0)
     ruby-vips (2.2.2)
       ffi (~> 1.12)

--- a/bullet_train-outgoing_webhooks/Gemfile.lock
+++ b/bullet_train-outgoing_webhooks/Gemfile.lock
@@ -94,7 +94,6 @@ PATH
       possessive
       premailer-rails
       rails (>= 6.0.0)
-      ruby-openai
       showcase-rails
       sidekiq
       unicode-emoji
@@ -231,7 +230,6 @@ GEM
       railties (>= 5)
     drb (2.2.1)
     erubi (1.13.1)
-    event_stream_parser (1.0.0)
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
     faraday (2.12.2)
@@ -418,10 +416,6 @@ GEM
     rubocop-performance (1.23.0)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
-    ruby-openai (7.3.1)
-      event_stream_parser (>= 0.3.0, < 2.0.0)
-      faraday (>= 1)
-      faraday-multipart (>= 1)
     ruby-progressbar (1.13.0)
     ruby-vips (2.2.2)
       ffi (~> 1.12)

--- a/bullet_train-sortable/Gemfile.lock
+++ b/bullet_train-sortable/Gemfile.lock
@@ -94,7 +94,6 @@ PATH
       possessive
       premailer-rails
       rails (>= 6.0.0)
-      ruby-openai
       showcase-rails
       sidekiq
       unicode-emoji
@@ -230,7 +229,6 @@ GEM
       railties (>= 5)
     drb (2.2.1)
     erubi (1.13.1)
-    event_stream_parser (1.0.0)
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
     faraday (2.12.2)
@@ -416,10 +414,6 @@ GEM
     rubocop-performance (1.23.0)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
-    ruby-openai (7.3.1)
-      event_stream_parser (>= 0.3.0, < 2.0.0)
-      faraday (>= 1)
-      faraday-multipart (>= 1)
     ruby-progressbar (1.13.0)
     ruby-vips (2.2.2)
       ffi (~> 1.12)

--- a/bullet_train-super_scaffolding/Gemfile.lock
+++ b/bullet_train-super_scaffolding/Gemfile.lock
@@ -85,7 +85,6 @@ PATH
       possessive
       premailer-rails
       rails (>= 6.0.0)
-      ruby-openai
       showcase-rails
       sidekiq
       unicode-emoji
@@ -224,7 +223,6 @@ GEM
       railties (>= 5)
     drb (2.2.1)
     erubi (1.13.1)
-    event_stream_parser (1.0.0)
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
     faraday (2.12.2)
@@ -410,10 +408,6 @@ GEM
     rubocop-performance (1.23.0)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
-    ruby-openai (7.3.1)
-      event_stream_parser (>= 0.3.0, < 2.0.0)
-      faraday (>= 1)
-      faraday-multipart (>= 1)
     ruby-progressbar (1.13.0)
     ruby-vips (2.2.2)
       ffi (~> 1.12)

--- a/bullet_train-themes-light/Gemfile.lock
+++ b/bullet_train-themes-light/Gemfile.lock
@@ -101,7 +101,6 @@ PATH
       possessive
       premailer-rails
       rails (>= 6.0.0)
-      ruby-openai
       showcase-rails
       sidekiq
       unicode-emoji
@@ -239,7 +238,6 @@ GEM
       railties (>= 5)
     drb (2.2.1)
     erubi (1.13.1)
-    event_stream_parser (1.0.0)
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
     faraday (2.12.2)
@@ -425,10 +423,6 @@ GEM
     rubocop-performance (1.23.0)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
-    ruby-openai (7.3.1)
-      event_stream_parser (>= 0.3.0, < 2.0.0)
-      faraday (>= 1)
-      faraday-multipart (>= 1)
     ruby-progressbar (1.13.0)
     ruby-vips (2.2.2)
       ffi (~> 1.12)

--- a/bullet_train-themes-tailwind_css/Gemfile.lock
+++ b/bullet_train-themes-tailwind_css/Gemfile.lock
@@ -94,7 +94,6 @@ PATH
       possessive
       premailer-rails
       rails (>= 6.0.0)
-      ruby-openai
       showcase-rails
       sidekiq
       unicode-emoji
@@ -231,7 +230,6 @@ GEM
       railties (>= 5)
     drb (2.2.1)
     erubi (1.13.1)
-    event_stream_parser (1.0.0)
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
     faraday (2.12.2)
@@ -417,10 +415,6 @@ GEM
     rubocop-performance (1.23.0)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
-    ruby-openai (7.3.1)
-      event_stream_parser (>= 0.3.0, < 2.0.0)
-      faraday (>= 1)
-      faraday-multipart (>= 1)
     ruby-progressbar (1.13.0)
     ruby-vips (2.2.2)
       ffi (~> 1.12)

--- a/bullet_train-themes/Gemfile.lock
+++ b/bullet_train-themes/Gemfile.lock
@@ -86,7 +86,6 @@ PATH
       possessive
       premailer-rails
       rails (>= 6.0.0)
-      ruby-openai
       showcase-rails
       sidekiq
       unicode-emoji
@@ -225,7 +224,6 @@ GEM
       railties (>= 5)
     drb (2.2.1)
     erubi (1.13.1)
-    event_stream_parser (1.0.0)
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
     faraday (2.12.2)
@@ -414,10 +412,6 @@ GEM
     rubocop-performance (1.23.0)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
-    ruby-openai (7.3.1)
-      event_stream_parser (>= 0.3.0, < 2.0.0)
-      faraday (>= 1)
-      faraday-multipart (>= 1)
     ruby-progressbar (1.13.0)
     ruby-vips (2.2.2)
       ffi (~> 1.12)

--- a/bullet_train/Gemfile.lock
+++ b/bullet_train/Gemfile.lock
@@ -109,7 +109,6 @@ PATH
       possessive
       premailer-rails
       rails (>= 6.0.0)
-      ruby-openai
       showcase-rails
       sidekiq
       unicode-emoji
@@ -245,7 +244,6 @@ GEM
       railties (>= 5)
     drb (2.2.1)
     erubi (1.13.1)
-    event_stream_parser (1.0.0)
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
     faraday (2.12.2)
@@ -443,10 +441,6 @@ GEM
     rubocop-performance (1.23.0)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
-    ruby-openai (7.3.1)
-      event_stream_parser (>= 0.3.0, < 2.0.0)
-      faraday (>= 1)
-      faraday-multipart (>= 1)
     ruby-progressbar (1.13.0)
     ruby-vips (2.2.2)
       ffi (~> 1.12)

--- a/bullet_train/bullet_train.gemspec
+++ b/bullet_train/bullet_train.gemspec
@@ -87,9 +87,6 @@ Gem::Specification.new do |spec|
   # Allow users to supply content with markdown formatting. Powers our markdown() view helper.
   spec.add_dependency "commonmarker", ">= 1.0.0"
 
-  # OpenAI
-  spec.add_dependency "ruby-openai"
-
   # Conversations.
   spec.add_runtime_dependency "unicode-emoji"
 


### PR DESCRIPTION
**NOTE** This PR is currently pointing into the `jeremy/remove-microscope` branch because it builds off of that branch/PR. Before merging this PR we should merge https://github.com/bullet-train-co/bullet_train-core/pull/1035 and then re-target the PR at `main`.

We included it as a dependency, and `require`d it, but we don't
actually use it anywhere other than in the `bullet_train-action_models`
gem. We should list it as a dependency there so that we don't force
literally every BT app to have it.

If you use `ruby-openai` in your app you can add it back by adding this line to the bottom of your `Gemfile`:

```
gem "ruby-openai"
```

Fixes https://github.com/bullet-train-co/bullet_train-core/issues/1036