### PR TITLE
Remove the `image_processing` gem

### DIFF
--- a/bullet_train-api/Gemfile.lock
+++ b/bullet_train-api/Gemfile.lock
@@ -72,7 +72,6 @@ PATH
       figaro
       hiredis
       http_accept_language
-      image_processing
       nice_partials (~> 0.9)
       omniauth (~> 2.0)
       pagy (~> 8)
@@ -236,7 +235,6 @@ GEM
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
     fastimage (2.3.1)
-    ffi (1.17.0)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
     globalid (1.2.1)
@@ -247,9 +245,6 @@ GEM
     http_accept_language (2.1.1)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    image_processing (1.13.0)
-      mini_magick (>= 4.9.5, < 5)
-      ruby-vips (>= 2.0.17, < 3)
     indefinite_article (0.2.5)
       activesupport
     io-console (0.8.0)
@@ -280,7 +275,6 @@ GEM
       activesupport
       prism (>= 0.14.0)
     method_source (1.1.0)
-    mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.25.4)
     minitest-reporters (1.7.1)
@@ -409,9 +403,6 @@ GEM
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
-    ruby-vips (2.2.2)
-      ffi (~> 1.12)
-      logger
     securerandom (0.4.1)
     showcase-rails (0.4.6)
       rails (>= 6.1.0)

--- a/bullet_train-fields/Gemfile.lock
+++ b/bullet_train-fields/Gemfile.lock
@@ -78,7 +78,6 @@ PATH
       figaro
       hiredis
       http_accept_language
-      image_processing
       nice_partials (~> 0.9)
       omniauth (~> 2.0)
       pagy (~> 8)
@@ -239,7 +238,6 @@ GEM
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
     fastimage (2.3.1)
-    ffi (1.17.0)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
     globalid (1.2.1)
@@ -250,9 +248,6 @@ GEM
     http_accept_language (2.1.1)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    image_processing (1.13.0)
-      mini_magick (>= 4.9.5, < 5)
-      ruby-vips (>= 2.0.17, < 3)
     indefinite_article (0.2.5)
       activesupport
     io-console (0.8.0)
@@ -283,7 +278,6 @@ GEM
       activesupport
       prism (>= 0.14.0)
     method_source (1.1.0)
-    mini_magick (4.13.2)
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
     minitest (5.25.4)
@@ -419,9 +413,6 @@ GEM
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
-    ruby-vips (2.2.2)
-      ffi (~> 1.12)
-      logger
     securerandom (0.4.1)
     showcase-rails (0.4.6)
       rails (>= 6.1.0)

--- a/bullet_train-incoming_webhooks/Gemfile.lock
+++ b/bullet_train-incoming_webhooks/Gemfile.lock
@@ -87,7 +87,6 @@ PATH
       figaro
       hiredis
       http_accept_language
-      image_processing
       nice_partials (~> 0.9)
       omniauth (~> 2.0)
       pagy (~> 8)
@@ -247,7 +246,6 @@ GEM
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
     fastimage (2.3.1)
-    ffi (1.17.0)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
     globalid (1.2.1)
@@ -258,9 +256,6 @@ GEM
     http_accept_language (2.1.1)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    image_processing (1.13.0)
-      mini_magick (>= 4.9.5, < 5)
-      ruby-vips (>= 2.0.17, < 3)
     indefinite_article (0.2.5)
       activesupport
     io-console (0.8.0)
@@ -289,7 +284,6 @@ GEM
       activesupport
       prism (>= 0.14.0)
     method_source (1.1.0)
-    mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.25.4)
     minitest-reporters (1.7.1)
@@ -398,9 +392,6 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     ruby-progressbar (1.13.0)
-    ruby-vips (2.2.2)
-      ffi (~> 1.12)
-      logger
     securerandom (0.4.1)
     showcase-rails (0.4.6)
       rails (>= 6.1.0)

--- a/bullet_train-integrations-stripe/Gemfile.lock
+++ b/bullet_train-integrations-stripe/Gemfile.lock
@@ -96,7 +96,6 @@ PATH
       figaro
       hiredis
       http_accept_language
-      image_processing
       nice_partials (~> 0.9)
       omniauth (~> 2.0)
       pagy (~> 8)
@@ -254,7 +253,6 @@ GEM
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
     fastimage (2.3.1)
-    ffi (1.17.0)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
     globalid (1.2.1)
@@ -265,9 +263,6 @@ GEM
     http_accept_language (2.1.1)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    image_processing (1.13.0)
-      mini_magick (>= 4.9.5, < 5)
-      ruby-vips (>= 2.0.17, < 3)
     indefinite_article (0.2.5)
       activesupport
     io-console (0.8.0)
@@ -298,7 +293,6 @@ GEM
       activesupport
       prism (>= 0.14.0)
     method_source (1.1.0)
-    mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.25.4)
     minitest-reporters (1.7.1)
@@ -424,9 +418,6 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     ruby-progressbar (1.13.0)
-    ruby-vips (2.2.2)
-      ffi (~> 1.12)
-      logger
     securerandom (0.4.1)
     showcase-rails (0.4.6)
       rails (>= 6.1.0)

--- a/bullet_train-outgoing_webhooks/Gemfile.lock
+++ b/bullet_train-outgoing_webhooks/Gemfile.lock
@@ -87,7 +87,6 @@ PATH
       figaro
       hiredis
       http_accept_language
-      image_processing
       nice_partials (~> 0.9)
       omniauth (~> 2.0)
       pagy (~> 8)
@@ -243,7 +242,6 @@ GEM
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
     fastimage (2.3.1)
-    ffi (1.17.0)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
     globalid (1.2.1)
@@ -254,9 +252,6 @@ GEM
     http_accept_language (2.1.1)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    image_processing (1.13.0)
-      mini_magick (>= 4.9.5, < 5)
-      ruby-vips (>= 2.0.17, < 3)
     indefinite_article (0.2.5)
       activesupport
     io-console (0.8.0)
@@ -287,7 +282,6 @@ GEM
       activesupport
       prism (>= 0.14.0)
     method_source (1.1.0)
-    mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.25.4)
     minitest-reporters (1.7.1)
@@ -417,9 +411,6 @@ GEM
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
-    ruby-vips (2.2.2)
-      ffi (~> 1.12)
-      logger
     securerandom (0.4.1)
     showcase-rails (0.4.6)
       rails (>= 6.1.0)

--- a/bullet_train-sortable/Gemfile.lock
+++ b/bullet_train-sortable/Gemfile.lock
@@ -87,7 +87,6 @@ PATH
       figaro
       hiredis
       http_accept_language
-      image_processing
       nice_partials (~> 0.9)
       omniauth (~> 2.0)
       pagy (~> 8)
@@ -242,7 +241,6 @@ GEM
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
     fastimage (2.3.1)
-    ffi (1.17.0)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
     globalid (1.2.1)
@@ -253,9 +251,6 @@ GEM
     http_accept_language (2.1.1)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    image_processing (1.13.0)
-      mini_magick (>= 4.9.5, < 5)
-      ruby-vips (>= 2.0.17, < 3)
     indefinite_article (0.2.5)
       activesupport
     io-console (0.8.0)
@@ -286,7 +281,6 @@ GEM
       activesupport
       prism (>= 0.14.0)
     method_source (1.1.0)
-    mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.25.4)
     minitest-reporters (1.7.1)
@@ -415,9 +409,6 @@ GEM
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
-    ruby-vips (2.2.2)
-      ffi (~> 1.12)
-      logger
     securerandom (0.4.1)
     showcase-rails (0.4.6)
       rails (>= 6.1.0)

--- a/bullet_train-super_scaffolding/Gemfile.lock
+++ b/bullet_train-super_scaffolding/Gemfile.lock
@@ -78,7 +78,6 @@ PATH
       figaro
       hiredis
       http_accept_language
-      image_processing
       nice_partials (~> 0.9)
       omniauth (~> 2.0)
       pagy (~> 8)
@@ -236,7 +235,6 @@ GEM
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
     fastimage (2.3.1)
-    ffi (1.17.0)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
     globalid (1.2.1)
@@ -247,9 +245,6 @@ GEM
     http_accept_language (2.1.1)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    image_processing (1.13.0)
-      mini_magick (>= 4.9.5, < 5)
-      ruby-vips (>= 2.0.17, < 3)
     indefinite_article (0.2.5)
       activesupport
     io-console (0.8.0)
@@ -280,7 +275,6 @@ GEM
       activesupport
       prism (>= 0.14.0)
     method_source (1.1.0)
-    mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.25.4)
     minitest-reporters (1.7.1)
@@ -409,9 +403,6 @@ GEM
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
-    ruby-vips (2.2.2)
-      ffi (~> 1.12)
-      logger
     securerandom (0.4.1)
     showcase-rails (0.4.6)
       rails (>= 6.1.0)

--- a/bullet_train-themes-light/Gemfile.lock
+++ b/bullet_train-themes-light/Gemfile.lock
@@ -94,7 +94,6 @@ PATH
       figaro
       hiredis
       http_accept_language
-      image_processing
       nice_partials (~> 0.9)
       omniauth (~> 2.0)
       pagy (~> 8)
@@ -251,7 +250,6 @@ GEM
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
     fastimage (2.3.1)
-    ffi (1.17.0)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
     globalid (1.2.1)
@@ -262,9 +260,6 @@ GEM
     http_accept_language (2.1.1)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    image_processing (1.13.0)
-      mini_magick (>= 4.9.5, < 5)
-      ruby-vips (>= 2.0.17, < 3)
     indefinite_article (0.2.5)
       activesupport
     io-console (0.8.0)
@@ -295,7 +290,6 @@ GEM
       activesupport
       prism (>= 0.14.0)
     method_source (1.1.0)
-    mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.25.4)
     minitest-reporters (1.7.1)
@@ -424,9 +418,6 @@ GEM
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
-    ruby-vips (2.2.2)
-      ffi (~> 1.12)
-      logger
     securerandom (0.4.1)
     showcase-rails (0.4.6)
       rails (>= 6.1.0)

--- a/bullet_train-themes-tailwind_css/Gemfile.lock
+++ b/bullet_train-themes-tailwind_css/Gemfile.lock
@@ -87,7 +87,6 @@ PATH
       figaro
       hiredis
       http_accept_language
-      image_processing
       nice_partials (~> 0.9)
       omniauth (~> 2.0)
       pagy (~> 8)
@@ -243,7 +242,6 @@ GEM
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
     fastimage (2.3.1)
-    ffi (1.17.0)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
     globalid (1.2.1)
@@ -254,9 +252,6 @@ GEM
     http_accept_language (2.1.1)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    image_processing (1.13.0)
-      mini_magick (>= 4.9.5, < 5)
-      ruby-vips (>= 2.0.17, < 3)
     indefinite_article (0.2.5)
       activesupport
     io-console (0.8.0)
@@ -287,7 +282,6 @@ GEM
       activesupport
       prism (>= 0.14.0)
     method_source (1.1.0)
-    mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.25.4)
     minitest-reporters (1.7.1)
@@ -416,9 +410,6 @@ GEM
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
-    ruby-vips (2.2.2)
-      ffi (~> 1.12)
-      logger
     securerandom (0.4.1)
     showcase-rails (0.4.6)
       rails (>= 6.1.0)

--- a/bullet_train-themes/Gemfile.lock
+++ b/bullet_train-themes/Gemfile.lock
@@ -79,7 +79,6 @@ PATH
       figaro
       hiredis
       http_accept_language
-      image_processing
       nice_partials (~> 0.9)
       omniauth (~> 2.0)
       pagy (~> 8)
@@ -237,7 +236,6 @@ GEM
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
     fastimage (2.3.1)
-    ffi (1.17.0)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
     globalid (1.2.1)
@@ -248,9 +246,6 @@ GEM
     http_accept_language (2.1.1)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    image_processing (1.13.0)
-      mini_magick (>= 4.9.5, < 5)
-      ruby-vips (>= 2.0.17, < 3)
     indefinite_article (0.2.5)
       activesupport
     io-console (0.8.0)
@@ -281,7 +276,6 @@ GEM
       activesupport
       prism (>= 0.14.0)
     method_source (1.1.0)
-    mini_magick (4.13.2)
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
     minitest (5.25.4)
@@ -413,9 +407,6 @@ GEM
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
-    ruby-vips (2.2.2)
-      ffi (~> 1.12)
-      logger
     securerandom (0.4.1)
     showcase-rails (0.4.6)
       rails (>= 6.1.0)

--- a/bullet_train/Gemfile.lock
+++ b/bullet_train/Gemfile.lock
@@ -102,7 +102,6 @@ PATH
       figaro
       hiredis
       http_accept_language
-      image_processing
       nice_partials (~> 0.9)
       omniauth (~> 2.0)
       pagy (~> 8)
@@ -257,7 +256,6 @@ GEM
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
     fastimage (2.3.1)
-    ffi (1.17.0)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
     globalid (1.2.1)
@@ -268,9 +266,6 @@ GEM
     http_accept_language (2.1.1)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    image_processing (1.13.0)
-      mini_magick (>= 4.9.5, < 5)
-      ruby-vips (>= 2.0.17, < 3)
     indefinite_article (0.2.5)
       activesupport
     io-console (0.8.0)
@@ -301,7 +296,6 @@ GEM
       activesupport
       prism (>= 0.14.0)
     method_source (1.1.0)
-    mini_magick (4.13.2)
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
     minitest (5.25.4)
@@ -442,9 +436,6 @@ GEM
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
-    ruby-vips (2.2.2)
-      ffi (~> 1.12)
-      logger
     securerandom (0.4.1)
     showcase-rails (0.4.6)
       rails (>= 6.1.0)

--- a/bullet_train/bullet_train.gemspec
+++ b/bullet_train/bullet_train.gemspec
@@ -45,8 +45,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "xxhash"
   spec.add_dependency "omniauth", "~> 2.0"
 
-  spec.add_dependency "image_processing"
-
   spec.add_dependency "cancancan"
 
   # We use this to add "'s" as appropriate in certain headings.


### PR DESCRIPTION
We used to include `image_processing` as a hard dependency in the `bullet_train` gem, but we don't use it directly (or even `require` it).

We recommend that people use Cloudinary for handling images, which means that they don't need `image_processing` which is used for handling images with `ActiveStorage`.

If you want to use `image_processing` then you should uncomment the line for it in the `Gemfile` of your Bullet Train application.

Fixes: https://github.com/bullet-train-co/bullet_train-core/issues/1040