### PR TITLE
Remove the `colorizer` gem

### DIFF
--- a/bullet_train-api/Gemfile.lock
+++ b/bullet_train-api/Gemfile.lock
@@ -38,7 +38,7 @@ PATH
   remote: ../bullet_train-super_scaffolding
   specs:
     bullet_train-super_scaffolding (1.16.0)
-      colorizer
+      colorize
       indefinite_article
       masamune-ast (~> 2.0.2)
       rails (>= 6.0.0)
@@ -63,7 +63,7 @@ PATH
       bullet_train-themes
       cable_ready (~> 5.0.0)
       cancancan
-      colorizer
+      colorize
       commonmarker (>= 1.0.0)
       devise
       devise-pwned_password
@@ -89,7 +89,6 @@ PATH
     bullet_train-api (1.16.0)
       bullet_train
       bullet_train-super_scaffolding
-      colorizer
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
@@ -197,7 +196,7 @@ GEM
       faraday-follow_redirects (~> 0.3.0)
       faraday-multipart (~> 1.0, >= 1.0.4)
       ostruct
-    colorizer (0.0.2)
+    colorize (1.1.0)
     commonmarker (2.0.2-arm64-darwin)
     commonmarker (2.0.2-x86_64-linux)
     concurrent-ruby (1.3.4)

--- a/bullet_train-api/bullet_train-api.gemspec
+++ b/bullet_train-api/bullet_train-api.gemspec
@@ -43,6 +43,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rack-cors"
   spec.add_dependency "doorkeeper"
   spec.add_dependency "jbuilder-schema", "~> 2.6.6"
-  spec.add_dependency "colorizer"
   spec.add_dependency "factory_bot"
 end

--- a/bullet_train-fields/Gemfile.lock
+++ b/bullet_train-fields/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     bullet_train-api (1.16.0)
       bullet_train
       bullet_train-super_scaffolding
-      colorizer
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
@@ -44,7 +43,7 @@ PATH
   remote: ../bullet_train-super_scaffolding
   specs:
     bullet_train-super_scaffolding (1.16.0)
-      colorizer
+      colorize
       indefinite_article
       masamune-ast (~> 2.0.2)
       rails (>= 6.0.0)
@@ -69,7 +68,7 @@ PATH
       bullet_train-themes
       cable_ready (~> 5.0.0)
       cancancan
-      colorizer
+      colorize
       commonmarker (>= 1.0.0)
       devise
       devise-pwned_password
@@ -197,7 +196,7 @@ GEM
       faraday-follow_redirects (~> 0.3.0)
       faraday-multipart (~> 1.0, >= 1.0.4)
       ostruct
-    colorizer (0.0.2)
+    colorize (1.1.0)
     commonmarker (2.0.2)
       rb_sys (~> 0.9)
     commonmarker (2.0.2-arm64-darwin)

--- a/bullet_train-incoming_webhooks/Gemfile.lock
+++ b/bullet_train-incoming_webhooks/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     bullet_train-api (1.16.0)
       bullet_train
       bullet_train-super_scaffolding
-      colorizer
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
@@ -53,7 +52,7 @@ PATH
   remote: ../bullet_train-super_scaffolding
   specs:
     bullet_train-super_scaffolding (1.16.0)
-      colorizer
+      colorize
       indefinite_article
       masamune-ast (~> 2.0.2)
       rails (>= 6.0.0)
@@ -78,7 +77,7 @@ PATH
       bullet_train-themes
       cable_ready (~> 5.0.0)
       cancancan
-      colorizer
+      colorize
       commonmarker (>= 1.0.0)
       devise
       devise-pwned_password
@@ -205,7 +204,7 @@ GEM
       faraday-follow_redirects (~> 0.3.0)
       faraday-multipart (~> 1.0, >= 1.0.4)
       ostruct
-    colorizer (0.0.2)
+    colorize (1.1.0)
     commonmarker (2.0.2-arm64-darwin)
     commonmarker (2.0.2-x86_64-linux)
     concurrent-ruby (1.3.4)

--- a/bullet_train-integrations-stripe/Gemfile.lock
+++ b/bullet_train-integrations-stripe/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     bullet_train-api (1.16.0)
       bullet_train
       bullet_train-super_scaffolding
-      colorizer
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
@@ -62,7 +61,7 @@ PATH
   remote: ../bullet_train-super_scaffolding
   specs:
     bullet_train-super_scaffolding (1.16.0)
-      colorizer
+      colorize
       indefinite_article
       masamune-ast (~> 2.0.2)
       rails (>= 6.0.0)
@@ -87,7 +86,7 @@ PATH
       bullet_train-themes
       cable_ready (~> 5.0.0)
       cancancan
-      colorizer
+      colorize
       commonmarker (>= 1.0.0)
       devise
       devise-pwned_password
@@ -215,7 +214,7 @@ GEM
       faraday-follow_redirects (~> 0.3.0)
       faraday-multipart (~> 1.0, >= 1.0.4)
       ostruct
-    colorizer (0.0.2)
+    colorize (1.1.0)
     commonmarker (2.0.2-arm64-darwin)
     commonmarker (2.0.2-x86_64-linux)
     concurrent-ruby (1.3.4)

--- a/bullet_train-outgoing_webhooks/Gemfile.lock
+++ b/bullet_train-outgoing_webhooks/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     bullet_train-api (1.16.0)
       bullet_train
       bullet_train-super_scaffolding
-      colorizer
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
@@ -53,7 +52,7 @@ PATH
   remote: ../bullet_train-super_scaffolding
   specs:
     bullet_train-super_scaffolding (1.16.0)
-      colorizer
+      colorize
       indefinite_article
       masamune-ast (~> 2.0.2)
       rails (>= 6.0.0)
@@ -78,7 +77,7 @@ PATH
       bullet_train-themes
       cable_ready (~> 5.0.0)
       cancancan
-      colorizer
+      colorize
       commonmarker (>= 1.0.0)
       devise
       devise-pwned_password
@@ -204,7 +203,7 @@ GEM
       faraday-follow_redirects (~> 0.3.0)
       faraday-multipart (~> 1.0, >= 1.0.4)
       ostruct
-    colorizer (0.0.2)
+    colorize (1.1.0)
     commonmarker (2.0.2-arm64-darwin)
     commonmarker (2.0.2-x86_64-linux)
     concurrent-ruby (1.3.4)

--- a/bullet_train-sortable/Gemfile.lock
+++ b/bullet_train-sortable/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     bullet_train-api (1.16.0)
       bullet_train
       bullet_train-super_scaffolding
-      colorizer
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
@@ -53,7 +52,7 @@ PATH
   remote: ../bullet_train-super_scaffolding
   specs:
     bullet_train-super_scaffolding (1.16.0)
-      colorizer
+      colorize
       indefinite_article
       masamune-ast (~> 2.0.2)
       rails (>= 6.0.0)
@@ -78,7 +77,7 @@ PATH
       bullet_train-themes
       cable_ready (~> 5.0.0)
       cancancan
-      colorizer
+      colorize
       commonmarker (>= 1.0.0)
       devise
       devise-pwned_password
@@ -203,7 +202,7 @@ GEM
       faraday-follow_redirects (~> 0.3.0)
       faraday-multipart (~> 1.0, >= 1.0.4)
       ostruct
-    colorizer (0.0.2)
+    colorize (1.1.0)
     commonmarker (2.0.2-arm64-darwin)
     commonmarker (2.0.2-x86_64-linux)
     concurrent-ruby (1.3.4)

--- a/bullet_train-super_scaffolding/Gemfile.lock
+++ b/bullet_train-super_scaffolding/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     bullet_train-api (1.16.0)
       bullet_train
       bullet_train-super_scaffolding
-      colorizer
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
@@ -69,7 +68,7 @@ PATH
       bullet_train-themes
       cable_ready (~> 5.0.0)
       cancancan
-      colorizer
+      colorize
       commonmarker (>= 1.0.0)
       devise
       devise-pwned_password
@@ -93,7 +92,7 @@ PATH
   remote: .
   specs:
     bullet_train-super_scaffolding (1.16.0)
-      colorizer
+      colorize
       indefinite_article
       masamune-ast (~> 2.0.2)
       rails (>= 6.0.0)
@@ -197,7 +196,7 @@ GEM
       faraday-follow_redirects (~> 0.3.0)
       faraday-multipart (~> 1.0, >= 1.0.4)
       ostruct
-    colorizer (0.0.2)
+    colorize (1.1.0)
     commonmarker (2.0.2-arm64-darwin)
     commonmarker (2.0.2-x86_64-linux)
     concurrent-ruby (1.3.4)

--- a/bullet_train-super_scaffolding/bullet_train-super_scaffolding.gemspec
+++ b/bullet_train-super_scaffolding/bullet_train-super_scaffolding.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails", ">= 6.0.0"
   spec.add_dependency "masamune-ast", "~> 2.0.2"
-  spec.add_dependency "colorizer"
+  spec.add_dependency "colorize"
 
   # For Super Scaffolding: "select *a* team member" vs. "select *an* option".
   spec.add_dependency "indefinite_article"

--- a/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding.rb
+++ b/bullet_train-super_scaffolding/lib/bullet_train/super_scaffolding.rb
@@ -8,7 +8,7 @@ require "bullet_train/super_scaffolding/scaffolders/join_model_scaffolder"
 require "bullet_train/super_scaffolding/scaffolders/oauth_provider_scaffolder"
 
 require "indefinite_article"
-require "colorizer"
+require "colorize"
 
 module BulletTrain
   module SuperScaffolding

--- a/bullet_train-themes-light/Gemfile.lock
+++ b/bullet_train-themes-light/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     bullet_train-api (1.16.0)
       bullet_train
       bullet_train-super_scaffolding
-      colorizer
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
@@ -53,7 +52,7 @@ PATH
   remote: ../bullet_train-super_scaffolding
   specs:
     bullet_train-super_scaffolding (1.16.0)
-      colorizer
+      colorize
       indefinite_article
       masamune-ast (~> 2.0.2)
       rails (>= 6.0.0)
@@ -85,7 +84,7 @@ PATH
       bullet_train-themes
       cable_ready (~> 5.0.0)
       cancancan
-      colorizer
+      colorize
       commonmarker (>= 1.0.0)
       devise
       devise-pwned_password
@@ -212,7 +211,7 @@ GEM
       faraday-follow_redirects (~> 0.3.0)
       faraday-multipart (~> 1.0, >= 1.0.4)
       ostruct
-    colorizer (0.0.2)
+    colorize (1.1.0)
     commonmarker (2.0.2-arm64-darwin)
     commonmarker (2.0.2-x86_64-linux)
     concurrent-ruby (1.3.4)

--- a/bullet_train-themes-tailwind_css/Gemfile.lock
+++ b/bullet_train-themes-tailwind_css/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     bullet_train-api (1.16.0)
       bullet_train
       bullet_train-super_scaffolding
-      colorizer
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
@@ -53,7 +52,7 @@ PATH
   remote: ../bullet_train-super_scaffolding
   specs:
     bullet_train-super_scaffolding (1.16.0)
-      colorizer
+      colorize
       indefinite_article
       masamune-ast (~> 2.0.2)
       rails (>= 6.0.0)
@@ -78,7 +77,7 @@ PATH
       bullet_train-themes
       cable_ready (~> 5.0.0)
       cancancan
-      colorizer
+      colorize
       commonmarker (>= 1.0.0)
       devise
       devise-pwned_password
@@ -204,7 +203,7 @@ GEM
       faraday-follow_redirects (~> 0.3.0)
       faraday-multipart (~> 1.0, >= 1.0.4)
       ostruct
-    colorizer (0.0.2)
+    colorize (1.1.0)
     commonmarker (2.0.2-arm64-darwin)
     commonmarker (2.0.2-x86_64-linux)
     concurrent-ruby (1.3.4)

--- a/bullet_train-themes/Gemfile.lock
+++ b/bullet_train-themes/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     bullet_train-api (1.16.0)
       bullet_train
       bullet_train-super_scaffolding
-      colorizer
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
@@ -53,7 +52,7 @@ PATH
   remote: ../bullet_train-super_scaffolding
   specs:
     bullet_train-super_scaffolding (1.16.0)
-      colorizer
+      colorize
       indefinite_article
       masamune-ast (~> 2.0.2)
       rails (>= 6.0.0)
@@ -70,7 +69,7 @@ PATH
       bullet_train-themes
       cable_ready (~> 5.0.0)
       cancancan
-      colorizer
+      colorize
       commonmarker (>= 1.0.0)
       devise
       devise-pwned_password
@@ -197,7 +196,7 @@ GEM
       faraday-follow_redirects (~> 0.3.0)
       faraday-multipart (~> 1.0, >= 1.0.4)
       ostruct
-    colorizer (0.0.2)
+    colorize (1.1.0)
     commonmarker (2.0.2)
       rb_sys (~> 0.9)
     commonmarker (2.0.2-arm64-darwin)

--- a/bullet_train/Gemfile.lock
+++ b/bullet_train/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     bullet_train-api (1.16.0)
       bullet_train
       bullet_train-super_scaffolding
-      colorizer
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
@@ -53,7 +52,7 @@ PATH
   remote: ../bullet_train-super_scaffolding
   specs:
     bullet_train-super_scaffolding (1.16.0)
-      colorizer
+      colorize
       indefinite_article
       masamune-ast (~> 2.0.2)
       rails (>= 6.0.0)
@@ -93,7 +92,7 @@ PATH
       bullet_train-themes
       cable_ready (~> 5.0.0)
       cancancan
-      colorizer
+      colorize
       commonmarker (>= 1.0.0)
       devise
       devise-pwned_password
@@ -215,7 +214,7 @@ GEM
       faraday-multipart (~> 1.0, >= 1.0.4)
       ostruct
     coderay (1.1.3)
-    colorizer (0.0.2)
+    colorize (1.1.0)
     commonmarker (2.0.2)
       rb_sys (~> 0.9)
     commonmarker (2.0.2-arm64-darwin)

--- a/bullet_train/bullet_train.gemspec
+++ b/bullet_train/bullet_train.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bullet_train-scope_validator"
   spec.add_dependency "bullet_train-themes"
   spec.add_dependency "bullet_train-fields"
-  spec.add_dependency "colorizer"
+  spec.add_dependency "colorize"
   spec.add_dependency "devise"
   spec.add_dependency "xxhash"
   spec.add_dependency "omniauth", "~> 2.0"

--- a/bullet_train/lib/bullet_train.rb
+++ b/bullet_train/lib/bullet_train.rb
@@ -11,7 +11,8 @@ require "bullet_train/scope_validator"
 
 require "exceptions"
 
-require "colorizer"
+# TODO: Do we really need to require this here?
+require "colorize"
 require "bullet_train/core_ext/string_emoji_helper"
 
 require "devise"

--- a/bullet_train/lib/bullet_train.rb
+++ b/bullet_train/lib/bullet_train.rb
@@ -11,8 +11,8 @@ require "bullet_train/scope_validator"
 
 require "exceptions"
 
-# TODO: Do we really need to require this here?
-require "colorize"
+# NOTE: This is requiring the `colorizer.rb` file that lives in the same directory as this file. It looks like it's requiring a gem, but it's not.
+require "colorizer"
 require "bullet_train/core_ext/string_emoji_helper"
 
 require "devise"


### PR DESCRIPTION
We had been using both `colorize` and `colorizer` but they both do the same thing. `colorizer` hasn't been touched in 13 years and doesn't even have documentation available, so we're gonna standarize on `colorize`.

If you need to use `colorizer` for some reason you can add it to the `Gemfile` in your application.

Fixes https://github.com/bullet-train-co/bullet_train-core/issues/1043