### PR TITLE
Remove `xxhash` as a hard dependency

### DIFF
--- a/bullet_train-api/Gemfile.lock
+++ b/bullet_train-api/Gemfile.lock
@@ -81,7 +81,6 @@ PATH
       sidekiq
       unicode-emoji
       valid_email
-      xxhash
 
 PATH
   remote: .
@@ -456,7 +455,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    xxhash (0.6.0)
     zeitwerk (2.7.1)
 
 PLATFORMS

--- a/bullet_train-fields/Gemfile.lock
+++ b/bullet_train-fields/Gemfile.lock
@@ -86,7 +86,6 @@ PATH
       sidekiq
       unicode-emoji
       valid_email
-      xxhash
 
 PATH
   remote: .
@@ -469,7 +468,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    xxhash (0.6.0)
     zeitwerk (2.7.1)
 
 PLATFORMS

--- a/bullet_train-incoming_webhooks/Gemfile.lock
+++ b/bullet_train-incoming_webhooks/Gemfile.lock
@@ -95,7 +95,6 @@ PATH
       sidekiq
       unicode-emoji
       valid_email
-      xxhash
 
 PATH
   remote: .
@@ -431,7 +430,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    xxhash (0.6.0)
     zeitwerk (2.7.1)
 
 PLATFORMS

--- a/bullet_train-integrations-stripe/Gemfile.lock
+++ b/bullet_train-integrations-stripe/Gemfile.lock
@@ -104,7 +104,6 @@ PATH
       sidekiq
       unicode-emoji
       valid_email
-      xxhash
 
 PATH
   remote: .
@@ -463,7 +462,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    xxhash (0.6.0)
     zeitwerk (2.7.1)
 
 PLATFORMS

--- a/bullet_train-outgoing_webhooks/Gemfile.lock
+++ b/bullet_train-outgoing_webhooks/Gemfile.lock
@@ -95,7 +95,6 @@ PATH
       sidekiq
       unicode-emoji
       valid_email
-      xxhash
 
 PATH
   remote: .
@@ -464,7 +463,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    xxhash (0.6.0)
     zeitwerk (2.7.1)
 
 PLATFORMS

--- a/bullet_train-sortable/Gemfile.lock
+++ b/bullet_train-sortable/Gemfile.lock
@@ -95,7 +95,6 @@ PATH
       sidekiq
       unicode-emoji
       valid_email
-      xxhash
 
 PATH
   remote: .
@@ -462,7 +461,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    xxhash (0.6.0)
     zeitwerk (2.7.1)
 
 PLATFORMS

--- a/bullet_train-super_scaffolding/Gemfile.lock
+++ b/bullet_train-super_scaffolding/Gemfile.lock
@@ -86,7 +86,6 @@ PATH
       sidekiq
       unicode-emoji
       valid_email
-      xxhash
 
 PATH
   remote: .
@@ -456,7 +455,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    xxhash (0.6.0)
     zeitwerk (2.7.1)
 
 PLATFORMS

--- a/bullet_train-themes-light/Gemfile.lock
+++ b/bullet_train-themes-light/Gemfile.lock
@@ -102,7 +102,6 @@ PATH
       sidekiq
       unicode-emoji
       valid_email
-      xxhash
 
 PATH
   remote: .
@@ -471,7 +470,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    xxhash (0.6.0)
     zeitwerk (2.7.1)
 
 PLATFORMS

--- a/bullet_train-themes-tailwind_css/Gemfile.lock
+++ b/bullet_train-themes-tailwind_css/Gemfile.lock
@@ -95,7 +95,6 @@ PATH
       sidekiq
       unicode-emoji
       valid_email
-      xxhash
 
 PATH
   remote: .
@@ -463,7 +462,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    xxhash (0.6.0)
     zeitwerk (2.7.1)
 
 PLATFORMS

--- a/bullet_train-themes/Gemfile.lock
+++ b/bullet_train-themes/Gemfile.lock
@@ -87,7 +87,6 @@ PATH
       sidekiq
       unicode-emoji
       valid_email
-      xxhash
 
 PATH
   remote: .
@@ -461,7 +460,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    xxhash (0.6.0)
     zeitwerk (2.7.1)
 
 PLATFORMS

--- a/bullet_train/Gemfile.lock
+++ b/bullet_train/Gemfile.lock
@@ -110,7 +110,6 @@ PATH
       sidekiq
       unicode-emoji
       valid_email
-      xxhash
 
 GEM
   remote: https://rubygems.org/
@@ -491,7 +490,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    xxhash (0.6.0)
     zeitwerk (2.7.1)
 
 PLATFORMS

--- a/bullet_train/bullet_train.gemspec
+++ b/bullet_train/bullet_train.gemspec
@@ -42,7 +42,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bullet_train-fields"
   spec.add_dependency "colorize"
   spec.add_dependency "devise"
-  spec.add_dependency "xxhash"
   spec.add_dependency "omniauth", "~> 2.0"
 
   spec.add_dependency "cancancan"

--- a/bullet_train/lib/bullet_train.rb
+++ b/bullet_train/lib/bullet_train.rb
@@ -16,7 +16,6 @@ require "colorizer"
 require "bullet_train/core_ext/string_emoji_helper"
 
 require "devise"
-require "xxhash"
 # require "devise-two-factor"
 # require "rqrcode"
 require "cancancan"

--- a/bullet_train/lib/colorizer.rb
+++ b/bullet_train/lib/colorizer.rb
@@ -11,7 +11,17 @@ module Colorizer
   end
 
   def colorize_similarly(object, saturation, lightness)
-    rnd = ((XXhash.xxh64(object) * 7) % 100) * 0.01
+    # NOTE: We used to default to using XXhash and had it listed as a hard dependency for this gem.
+    # In an effort to slim down our dependencies we're making it so that this can work without XXhash.
+    # But since changing the way we calculate the seed _also_ changes the color that comes out the
+    # other end, we're making it so that people can add `gem "xxhash"` to their `Gemfile` to preserve
+    # the colors that were previously being generated.
+    seed = if Object.const_defined?("XXhash")
+             XXhash.xxh64(object)
+           else
+             Digest::MD5.hexdigest(object).to_i(16)
+           end
+    rnd = ((seed * 7) % 100) * 0.01
     hsl_to_rgb(rnd, saturation, lightness)
   end
 


### PR DESCRIPTION
We used to list `xxhash` as a hard dependency, but it was only used in the generation of random colors for user & team icons.

If you have an existing app **and** you need to preserve the random colors that used to be generated you can uncomment this gem and things will continue to work the way they always have.

If you don't care about preserving the same random colors then you don't need to include it.

Fixes https://github.com/bullet-train-co/bullet_train-core/issues/1049