### PR TITLE
Remove lingering references to `bullet_train-scope_questions`

### DIFF
--- a/bin/test-core-gems
+++ b/bin/test-core-gems
@@ -12,7 +12,6 @@ packages=(
   "bullet_train-obfuscates_id"
   # "bullet_train-outgoing_webhooks"
   # "bullet_train-roles"
-  "bullet_train-scope_questions"
   "bullet_train-scope_validator"
   "bullet_train-sortable"
   "bullet_train-super_load_and_authorize_resource"

--- a/bullet_train/config/locales/en/framework_packages.yml
+++ b/bullet_train/config/locales/en/framework_packages.yml
@@ -22,8 +22,6 @@ en:
       git: "bullet-train-co/bullet_train-core"
     bullet_train-roles:
       git: "bullet-train-co/bullet_train-core"
-    bullet_train-scope_questions:
-      git: "bullet-train-co/bullet_train-core"
     bullet_train-scope_validator:
       git: "bullet-train-co/bullet_train-core"
     bullet_train-sortable:

--- a/bullet_train/docs/upgrades/yolo-130.md
+++ b/bullet_train/docs/upgrades/yolo-130.md
@@ -92,7 +92,6 @@ gem "bullet_train-integrations-stripe"
 
 # Optional support packages.
 gem "bullet_train-sortable"
-gem "bullet_train-scope_questions"
 gem "bullet_train-obfuscates_id"
 ```
 
@@ -119,7 +118,6 @@ gem "bullet_train-integrations-stripe", BULLET_TRAIN_VERSION
 
 # Optional support packages.
 gem "bullet_train-sortable", BULLET_TRAIN_VERSION
-gem "bullet_train-scope_questions", BULLET_TRAIN_VERSION
 gem "bullet_train-obfuscates_id", BULLET_TRAIN_VERSION
 
 # Core gems that are dependencies of gems listed above. Technically they


### PR DESCRIPTION
We removed the empty gem in https://github.com/bullet-train-co/bullet_train-core/pull/1031 but there were still a few references to it that we missed. This removes them.