### PR TITLE
Remove `unicode-emoji` as a hard dependency

### DIFF
--- a/bullet_train-api/Gemfile.lock
+++ b/bullet_train-api/Gemfile.lock
@@ -78,7 +78,6 @@ PATH
       rails (>= 6.0.0)
       showcase-rails
       sidekiq
-      unicode-emoji
 
 PATH
   remote: .

--- a/bullet_train-fields/Gemfile.lock
+++ b/bullet_train-fields/Gemfile.lock
@@ -83,7 +83,6 @@ PATH
       rails (>= 6.0.0)
       showcase-rails
       sidekiq
-      unicode-emoji
 
 PATH
   remote: .

--- a/bullet_train-incoming_webhooks/Gemfile.lock
+++ b/bullet_train-incoming_webhooks/Gemfile.lock
@@ -92,7 +92,6 @@ PATH
       rails (>= 6.0.0)
       showcase-rails
       sidekiq
-      unicode-emoji
 
 PATH
   remote: .
@@ -414,7 +413,6 @@ GEM
     timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unicode-emoji (4.0.4)
     uri (1.0.2)
     useragent (0.16.11)
     warden (1.2.9)

--- a/bullet_train-integrations-stripe/Gemfile.lock
+++ b/bullet_train-integrations-stripe/Gemfile.lock
@@ -101,7 +101,6 @@ PATH
       rails (>= 6.0.0)
       showcase-rails
       sidekiq
-      unicode-emoji
 
 PATH
   remote: .
@@ -444,7 +443,6 @@ GEM
     timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unicode-emoji (4.0.4)
     uri (1.0.2)
     useragent (0.16.11)
     version_gem (1.1.4)

--- a/bullet_train-outgoing_webhooks/Gemfile.lock
+++ b/bullet_train-outgoing_webhooks/Gemfile.lock
@@ -92,7 +92,6 @@ PATH
       rails (>= 6.0.0)
       showcase-rails
       sidekiq
-      unicode-emoji
 
 PATH
   remote: .

--- a/bullet_train-sortable/Gemfile.lock
+++ b/bullet_train-sortable/Gemfile.lock
@@ -92,7 +92,6 @@ PATH
       rails (>= 6.0.0)
       showcase-rails
       sidekiq
-      unicode-emoji
 
 PATH
   remote: .

--- a/bullet_train-super_scaffolding/Gemfile.lock
+++ b/bullet_train-super_scaffolding/Gemfile.lock
@@ -83,7 +83,6 @@ PATH
       rails (>= 6.0.0)
       showcase-rails
       sidekiq
-      unicode-emoji
 
 PATH
   remote: .

--- a/bullet_train-themes-light/Gemfile.lock
+++ b/bullet_train-themes-light/Gemfile.lock
@@ -99,7 +99,6 @@ PATH
       rails (>= 6.0.0)
       showcase-rails
       sidekiq
-      unicode-emoji
 
 PATH
   remote: .

--- a/bullet_train-themes-tailwind_css/Gemfile.lock
+++ b/bullet_train-themes-tailwind_css/Gemfile.lock
@@ -92,7 +92,6 @@ PATH
       rails (>= 6.0.0)
       showcase-rails
       sidekiq
-      unicode-emoji
 
 PATH
   remote: .

--- a/bullet_train-themes/Gemfile.lock
+++ b/bullet_train-themes/Gemfile.lock
@@ -84,7 +84,6 @@ PATH
       rails (>= 6.0.0)
       showcase-rails
       sidekiq
-      unicode-emoji
 
 PATH
   remote: .

--- a/bullet_train/Gemfile
+++ b/bullet_train/Gemfile
@@ -19,6 +19,11 @@ gem "bullet_train-scope_validator", path: "../bullet_train-scope_validator"
 gem "bullet_train-themes", path: "../bullet_train-themes"
 gem "bullet_train-themes-tailwind_css", path: "../bullet_train-themes-tailwind_css"
 
+# NOTE: This is an optional dependency in the starter repo. We only use it in one method that we don't
+# actually ever call, either in the starter repo or in any of the core gems. We list it here so that it's
+# available for tests/CI
+gem "unicode-emoji", group: :test
+
 group :test do
   gem "minitest-reporters"
 end

--- a/bullet_train/Gemfile.lock
+++ b/bullet_train/Gemfile.lock
@@ -107,7 +107,6 @@ PATH
       rails (>= 6.0.0)
       showcase-rails
       sidekiq
-      unicode-emoji
 
 GEM
   remote: https://rubygems.org/

--- a/bullet_train/Gemfile.lock
+++ b/bullet_train/Gemfile.lock
@@ -508,6 +508,7 @@ DEPENDENCIES
   sprockets-rails
   sqlite3
   standard
+  unicode-emoji
 
 BUNDLED WITH
    2.6.2

--- a/bullet_train/bullet_train.gemspec
+++ b/bullet_train/bullet_train.gemspec
@@ -77,9 +77,6 @@ Gem::Specification.new do |spec|
   # Allow users to supply content with markdown formatting. Powers our markdown() view helper.
   spec.add_dependency "commonmarker", ">= 1.0.0"
 
-  # Conversations.
-  spec.add_runtime_dependency "unicode-emoji"
-
   # Pagination.
   spec.add_runtime_dependency "pagy", "~> 8"
 

--- a/bullet_train/lib/bullet_train/core_ext/string_emoji_helper.rb
+++ b/bullet_train/lib/bullet_train/core_ext/string_emoji_helper.rb
@@ -1,9 +1,10 @@
-require "unicode/emoji"
-
 module BulletTrain
   module CoreExt
     module StringEmojiHelper
       def strip_emojis
+        unless Object.const_defined?("Unicode::Emoji")
+          raise "Unicode::Emoji is not defined. If you want to use the strip_emoji and/or only_emoji? methods you need to add the `unicode-emoji` gem to your `Gemfile`."
+        end
         gsub(Unicode::Emoji::REGEX, "")
       end
 


### PR DESCRIPTION
We used to declare `unicode-emoji` as a dependency, but it's only used in one method that we don't seem to actually call anywhere.

That method has been updated to check if `unicode-emoji` is available. If so it will proceed as normal, if not it will raise an error saying that you should add `unicode-emoji` to your `Gemfile`.

We've added `unicode-emoji` to the "optional gems" section of the `Gemfile` in the starter repo, with it being commented out by default.

Fixes https://github.com/bullet-train-co/bullet_train-core/issues/1048