### PR TITLE
Override a template method

### DIFF
--- a/bullet_train/app/controllers/concerns/account/onboarding/user_details/controller_base.rb
+++ b/bullet_train/app/controllers/concerns/account/onboarding/user_details/controller_base.rb
@@ -11,6 +11,10 @@ module Account::Onboarding::UserDetails::ControllerBase
     end
   end
 
+  def show
+    redirect_to root_path
+  end
+
   # GET /users/1/edit
   def edit
     flash[:notice] = nil


### PR DESCRIPTION
This prevents an error caused by `load_and_authorize_resource` assuming that all controllers that use it implement certain methods.

Fixes https://github.com/bullet-train-co/bullet_train-core/issues/1066