### PR TITLE
rm local: true from forms. it's old tech

### DIFF
--- a/bullet_train-api/app/views/account/platform/access_tokens/_form.html.erb
+++ b/bullet_train-api/app/views/account/platform/access_tokens/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: access_token, url: (access_token.persisted? ? [:account, access_token] : [:account, @application, :access_tokens]), local: true, class: 'form' do |form| %>
+<%= form_with model: access_token, url: (access_token.persisted? ? [:account, access_token] : [:account, @application, :access_tokens]), class: 'form' do |form| %>
   <%= render 'account/shared/forms/errors', form: form %>
 
   <% with_field_settings form: form do %>

--- a/bullet_train-api/app/views/account/platform/applications/_form.html.erb
+++ b/bullet_train-api/app/views/account/platform/applications/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: application, url: (application.persisted? ? [:account, application] : [:account, @team, :platform_applications]), local: true, class: 'form' do |form| %>
+<%= form_with model: application, url: (application.persisted? ? [:account, application] : [:account, @team, :platform_applications]), class: 'form' do |form| %>
   <%= render 'account/shared/forms/errors', form: form %>
 
   <% with_field_settings form: form do %>

--- a/bullet_train-integrations-stripe/app/views/account/integrations/stripe_installations/_form.html.erb
+++ b/bullet_train-integrations-stripe/app/views/account/integrations/stripe_installations/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: stripe_installation, url: (stripe_installation.persisted? ? [:account, stripe_installation] : [:account, @team, :integrations_stripe_installations]), local: true, class: 'form' do |form| %>
+<%= form_with model: stripe_installation, url: (stripe_installation.persisted? ? [:account, stripe_installation] : [:account, @team, :integrations_stripe_installations]), class: 'form' do |form| %>
   <%= render 'account/shared/forms/errors', form: form %>
 
   <% with_field_settings form: form do %>

--- a/bullet_train-integrations-stripe/app/views/account/oauth/stripe_accounts/_form.html.erb
+++ b/bullet_train-integrations-stripe/app/views/account/oauth/stripe_accounts/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: [:account, (@user unless stripe_account.persisted?), stripe_account], local: true, class: 'form' do |form| %>
+<%= form_with model: [:account, (@user unless stripe_account.persisted?), stripe_account], class: 'form' do |form| %>
   <%= render 'account/shared/forms/errors', form: form %>
 
   <%= render 'account/shared/alert' do %>

--- a/bullet_train-outgoing_webhooks/app/views/account/webhooks/outgoing/deliveries/_form.html.erb
+++ b/bullet_train-outgoing_webhooks/app/views/account/webhooks/outgoing/deliveries/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: delivery, url: (delivery.persisted? ? [:account, delivery] : [:account, @endpoint, :deliveries]), local: true, class: 'form' do |form| %>
+<%= form_with model: delivery, url: (delivery.persisted? ? [:account, delivery] : [:account, @endpoint, :deliveries]), class: 'form' do |form| %>
   <%= render 'account/shared/forms/errors', form: form %>
 
   <% with_field_settings form: form do %>

--- a/bullet_train-outgoing_webhooks/app/views/account/webhooks/outgoing/delivery_attempts/_form.html.erb
+++ b/bullet_train-outgoing_webhooks/app/views/account/webhooks/outgoing/delivery_attempts/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: delivery_attempt, url: (delivery_attempt.persisted? ? [:account, delivery_attempt] : [:account, @delivery, :delivery_attempts]), local: true, class: 'form' do |form| %>
+<%= form_with model: delivery_attempt, url: (delivery_attempt.persisted? ? [:account, delivery_attempt] : [:account, @delivery, :delivery_attempts]), class: 'form' do |form| %>
   <%= render 'account/shared/forms/errors', form: form %>
 
   <% with_field_settings form: form do %>

--- a/bullet_train-outgoing_webhooks/app/views/account/webhooks/outgoing/endpoints/_form.html.erb
+++ b/bullet_train-outgoing_webhooks/app/views/account/webhooks/outgoing/endpoints/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: endpoint, url: (endpoint.persisted? ? [:account, endpoint] : [:account, @parent, :webhooks_outgoing_endpoints]), local: true, class: 'form' do |form| %>
+<%= form_with model: endpoint, url: (endpoint.persisted? ? [:account, endpoint] : [:account, @parent, :webhooks_outgoing_endpoints]), class: 'form' do |form| %>
   <%= render 'account/shared/forms/errors', form: form %>
 
   <% with_field_settings form: form do %>

--- a/bullet_train-super_scaffolding/app/views/account/scaffolding/absolutely_abstract/creative_concepts/_form.html.erb
+++ b/bullet_train-super_scaffolding/app/views/account/scaffolding/absolutely_abstract/creative_concepts/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: [:account, (@team unless creative_concept.persisted?), creative_concept], local: true, class: 'form' do |form| %>
+<%= form_with model: [:account, (@team unless creative_concept.persisted?), creative_concept], class: 'form' do |form| %>
   <%= render "shared/limits/form", form: form, cancel_path: [:account, @team, :scaffolding, :absolutely_abstract, :creative_concepts] do %>
     <%= render 'account/shared/forms/errors', form: form %>
 

--- a/bullet_train-super_scaffolding/app/views/account/scaffolding/completely_concrete/tangible_things/_form.html.erb
+++ b/bullet_train-super_scaffolding/app/views/account/scaffolding/completely_concrete/tangible_things/_form.html.erb
@@ -1,6 +1,6 @@
 <% cancel_path ||= tangible_thing.persisted? ? [:account, tangible_thing] : [:account, @absolutely_abstract_creative_concept, :completely_concrete_tangible_things] %>
 
-<%= form_with model: tangible_thing, url: (tangible_thing.persisted? ? [:account, tangible_thing] : [:account, @absolutely_abstract_creative_concept, :completely_concrete_tangible_things]), local: true, class: 'form' do |form| %>
+<%= form_with model: tangible_thing, url: (tangible_thing.persisted? ? [:account, tangible_thing] : [:account, @absolutely_abstract_creative_concept, :completely_concrete_tangible_things]), class: 'form' do |form| %>
   <%= render "shared/limits/form", form: form, cancel_path: cancel_path do %>
     <%= render 'account/shared/forms/errors', form: form %>
 

--- a/bullet_train/app/views/account/invitations/_form.html.erb
+++ b/bullet_train/app/views/account/invitations/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: [:account, (@team unless invitation.persisted?), invitation], class: 'form', local: true) do |form| %>
+<%= form_with(model: [:account, (@team unless invitation.persisted?), invitation], class: 'form') do |form| %>
   <%= render "shared/limits/form", form: form, model: invitation.membership, cancel_path: @cancel_path || [:account, invitation] do %>
     <%= render 'account/shared/forms/errors', form: form %>
 

--- a/bullet_train/app/views/account/memberships/_form.html.erb
+++ b/bullet_train/app/views/account/memberships/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: [:account, (@team unless membership.persisted?), membership], class: 'form', local: true) do |form| %>
+<%= form_with(model: [:account, (@team unless membership.persisted?), membership], class: 'form') do |form| %>
   <%= render 'account/shared/forms/errors', form: form %>
 
 

--- a/bullet_train/app/views/account/onboarding/invitation_lists/new.html.erb
+++ b/bullet_train/app/views/account/onboarding/invitation_lists/new.html.erb
@@ -4,7 +4,7 @@
   <% box.title @title %>
   <% box.body do %>
     <% within_fields_namespace(:self) do %>
-      <%= form_with(model: @account_onboarding_invitation_list, class: 'form', local: true) do |f| %>
+      <%= form_with(model: @account_onboarding_invitation_list, class: 'form') do |f| %>
         <% f.object.errors.each do |error| %>
           <%= render 'account/shared/forms/errors', form: f, attributes: [error.attribute], resource: @account_onboarding_invitation_list %>
         <% end %>

--- a/bullet_train/app/views/account/teams/_form.html.erb
+++ b/bullet_train/app/views/account/teams/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: [:account, team], local: true, class: 'form' do |form| %>
+<%= form_with model: [:account, team], class: 'form' do |form| %>
   <%= render 'account/shared/forms/errors', form: form %>
 
   <% with_field_settings form: form do %>

--- a/bullet_train/app/views/account/teams/new.html.erb
+++ b/bullet_train/app/views/account/teams/new.html.erb
@@ -9,7 +9,7 @@ end
 <%= render 'account/shared/workflow/box' do |box| %>
   <% box.title @title %>
   <% box.body do %>
-    <%= form_with model: @team, url: [:account, @team], local: true, class: 'form' do |form| %>
+    <%= form_with model: @team, url: [:account, @team], class: 'form' do |form| %>
       <%= render 'account/shared/notices' %>
       <%= render 'account/shared/forms/errors', form: form %>
 

--- a/bullet_train/docs/super-scaffolding/delegated-types.md
+++ b/bullet_train/docs/super-scaffolding/delegated-types.md
@@ -107,7 +107,7 @@ The first of these two forms is actually not shared between `new.html.erb` and `
 <% if @entry.entryable_type %>
   <%= render 'form', entry: @entry %>
 <% else %>
-  <%= form_with model: @entry, url: [:new, :account, @team, :entry], method: :get, local: true, class: 'form' do |form| %>
+  <%= form_with model: @entry, url: [:new, :account, @team, :entry], method: :get, class: 'form' do |form| %>
     <%= render 'account/shared/forms/errors', form: form %>
     <% with_field_settings form: form do %>
       <%= render 'shared/fields/buttons', method: :entryable_type, html_options: {autofocus: true} %>


### PR DESCRIPTION
although I don't think it removes `local: true` from the super scaffold generator. I am not sure where the `_form.erb.tt` for super scaffold is declared.

<img width="1006" alt="Screenshot 2025-03-13 at 16 16 28" src="https://github.com/user-attachments/assets/cbcc66ec-72ab-4bb5-9dff-c6a18a06f545" />
