### PR TITLE
Allow a subset of roles to be passed to permit

### DIFF
--- a/bullet_train-roles/README.md
+++ b/bullet_train-roles/README.md
@@ -165,6 +165,12 @@ To access the array of all roles available for a particular model, use the `assi
 <% end %>
 ```
 
+You may want to restrict the roles considered at runtime too. To do this you can use the `included_roles` keyword of `permit`:
+
+```ruby
+permit user, through: :memberships, parent: :team, included_roles: Membership.assignable_roles
+```
+
 ## Checking user permissions
 
 Generally the CanCanCan helper method (`account_load_and_authorize_resource`) at the top of each controller will handle checking user permissions and will only load resources appropriate for the current user.

--- a/bullet_train-roles/test/lib/models/permit_test.rb
+++ b/bullet_train-roles/test/lib/models/permit_test.rb
@@ -1,12 +1,21 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "cancan"
 
 class PermitTest < ActiveSupport::TestCase
   class ClassMethodsTest < ActiveSupport::TestCase
+    class TestAbility
+      include ::CanCan::Ability
+      include ::Roles::Permit
+      def initialize(user)
+      end
+    end
+
     setup do
       @admin_user = FactoryBot.create :onboarded_user
-      @admin_ability = Ability.new(@admin_user)
+      @admin_user.memberships.first.update!(role_ids: ["admin", "editor"])
+      @test_ability = TestAbility.new(@admin_user)
     end
 
     test "Permit#assign_permissions assigns a new permission" do
@@ -16,21 +25,21 @@ class PermitTest < ActiveSupport::TestCase
         model: "User",
         condition: :all
       }
-      can_count = @admin_ability.permissions[:can].count
-      @admin_ability.assign_permissions(permissions)
-      assert_equal @admin_ability.permissions[:can].count, can_count + 1
+      can_count = @test_ability.permissions[:can].count
+      @test_ability.assign_permissions(permissions)
+      assert_equal @test_ability.permissions[:can].count, can_count + 1
     end
 
     test "Permit#build_permissions returns an array of Hashes" do
-      assert @admin_ability.build_permissions(@admin_user, :memberships, :team, nil).is_a?(Array)
-      assert @admin_ability.build_permissions(@admin_user, :memberships, :team, nil).first.is_a?(Hash)
+      assert @test_ability.build_permissions(@admin_user, :memberships, :team, nil, []).is_a?(Array)
+      assert @test_ability.build_permissions(@admin_user, :memberships, :team, nil, []).first.is_a?(Hash)
     end
 
     test "When providing a cache_key the permissions are stored in the cache" do
       Rails.cache = ActiveSupport::Cache.lookup_store(:memory_store)
       Rails.cache.clear
       assert Rails.cache.instance_variable_get(:@data).keys.none?
-      @admin_ability.permit(@admin_user, through: :memberships, parent: :team, rails_cache_key: "my_cache_key")
+      @test_ability.permit(@admin_user, through: :memberships, parent: :team, rails_cache_key: "my_cache_key")
       assert Rails.cache.fetch("my_cache_key").present?
       assert_equal 1, Rails.cache.instance_variable_get(:@data).keys.count
     end
@@ -39,8 +48,21 @@ class PermitTest < ActiveSupport::TestCase
       Rails.cache = ActiveSupport::Cache.lookup_store(:memory_store)
       Rails.cache.clear
       assert Rails.cache.instance_variable_get(:@data).keys.none?
-      @admin_ability.permit(@admin_user, through: :memberships, parent: :team, rails_cache_key: nil)
+      @test_ability.permit(@admin_user, through: :memberships, parent: :team, rails_cache_key: nil)
       assert Rails.cache.instance_variable_get(:@data).keys.none?
+    end
+
+    test "When included_roles are provided, only those roles are included in the permissions" do
+      @test_ability.permit(@admin_user, through: :memberships, parent: :team, included_roles: [Role.find_by_key("editor")])
+
+      refute @test_ability.can?(:manage, Team)
+      assert @test_ability.can?(:update, Scaffolding::AbsolutelyAbstract::CreativeConcept)
+    end
+
+    test "When included_roles is not provided, all roles are included in the permissions" do
+      @test_ability.permit(@admin_user, through: :memberships, parent: :team)
+
+      assert @test_ability.can?(:manage, Team)
     end
   end
 end


### PR DESCRIPTION
This allows a call to `permit` to only create permissions for some of the Roles in the Roles.yml file.
