### PR TITLE
turbo_confirm instead of confirm; button_to for non-GET requests

### DIFF
--- a/bullet_train-api/app/views/account/platform/access_tokens/_index.html.erb
+++ b/bullet_train-api/app/views/account/platform/access_tokens/_index.html.erb
@@ -43,7 +43,7 @@
                           <%= link_to t('.buttons.shorthand.edit'), [:edit, :account, access_token], class: 'button-secondary button-smaller' %>
                         <% end %>
                         <% if can? :destroy, access_token %>
-                          <%= button_to t('.buttons.shorthand.destroy'), [:account, access_token], method: :delete, data: { confirm: t('.buttons.confirmations.destroy', model_locales(access_token)) }, class: 'button-secondary button-smaller' %>
+                          <%= button_to t('.buttons.shorthand.destroy'), [:account, access_token], method: :delete, data: { turbo_confirm: t('.buttons.confirmations.destroy', model_locales(access_token)) }, class: 'button-secondary button-smaller' %>
                         <% end %>
                         <%# 🚅 super scaffolding will insert new action model buttons above this line. %>
                       <% end %>

--- a/bullet_train-api/app/views/account/platform/access_tokens/show.html.erb
+++ b/bullet_train-api/app/views/account/platform/access_tokens/show.html.erb
@@ -21,7 +21,7 @@
         <% box.actions do %>
           <%= link_to t('.buttons.edit'), [:edit, :account, @access_token], class: first_button_primary if can? :edit, @access_token %>
           <%# 🚅 super scaffolding will insert new action model buttons above this line. %>
-          <%= button_to t('.buttons.destroy'), [:account, @access_token], method: :delete, class: first_button_primary, data: { confirm: t('.buttons.confirmations.destroy', model_locales(@access_token)) } if can? :destroy, @access_token %>
+          <%= button_to t('.buttons.destroy'), [:account, @access_token], method: :delete, class: first_button_primary, data: { turbo_confirm: t('.buttons.confirmations.destroy', model_locales(@access_token)) } if can? :destroy, @access_token %>
           <%= link_to t('global.buttons.back'), [:account, @application, :access_tokens], class: first_button_primary %>
         <% end %>
 

--- a/bullet_train-api/app/views/account/platform/applications/_index.html.erb
+++ b/bullet_train-api/app/views/account/platform/applications/_index.html.erb
@@ -32,7 +32,7 @@
                       <%= link_to t('.buttons.shorthand.edit'), [:edit, :account, application], class: 'button-secondary button-smaller' %>
                     <% end %>
                     <% if can? :destroy, application %>
-                      <%= button_to t('.buttons.shorthand.destroy'), [:account, application], method: :delete, data: { confirm: t('.buttons.confirmations.destroy', model_locales(application)) }, class: 'button-secondary button-smaller' %>
+                      <%= button_to t('.buttons.shorthand.destroy'), [:account, application], method: :delete, data: { turbo_confirm: t('.buttons.confirmations.destroy', model_locales(application)) }, class: 'button-secondary button-smaller' %>
                     <% end %>
                   <% end %>
                 </td>

--- a/bullet_train-api/app/views/account/platform/applications/show.html.erb
+++ b/bullet_train-api/app/views/account/platform/applications/show.html.erb
@@ -16,7 +16,7 @@
 
       <% box.actions do %>
         <%= link_to t('.buttons.edit'), [:edit, :account, @application], class: first_button_primary if can? :edit, @application %>
-        <%= button_to t('.buttons.destroy'), [:account, @application], method: :delete, class: first_button_primary, data: { confirm: t('.buttons.confirmations.destroy', model_locales(@application)) } if can? :destroy, @application %>
+        <%= button_to t('.buttons.destroy'), [:account, @application], method: :delete, class: first_button_primary, data: { turbo_confirm: t('.buttons.confirmations.destroy', model_locales(@application)) } if can? :destroy, @application %>
         <%= link_to t('global.buttons.back'), [:account, @team, :platform_applications], class: first_button_primary %>
       <% end %>
     <% end %>

--- a/bullet_train-integrations-stripe/app/views/account/integrations/stripe_installations/_index.html.erb
+++ b/bullet_train-integrations-stripe/app/views/account/integrations/stripe_installations/_index.html.erb
@@ -22,7 +22,7 @@
               <% end %>
 
               <% if can? :destroy, stripe_installation %>
-                <%= link_to [:account, stripe_installation, return_to: request.path], method: :delete, data: { confirm: t('.buttons.confirmations.destroy_from_user', team_name: stripe_installation.team.label_string) }, class: 'inline-block text-slate-300 hover:text-slate-400 hover:no-underline text-lg' do %>
+                <%= link_to [:account, stripe_installation, return_to: request.path], method: :delete, data: { turbo_confirm: t('.buttons.confirmations.destroy_from_user', team_name: stripe_installation.team.label_string) }, class: 'inline-block text-slate-300 hover:text-slate-400 hover:no-underline text-lg' do %>
                   <i class="ti ti-close"></i>
                 <% end %>
               <% end %>

--- a/bullet_train-integrations-stripe/app/views/account/integrations/stripe_installations/_index.html.erb
+++ b/bullet_train-integrations-stripe/app/views/account/integrations/stripe_installations/_index.html.erb
@@ -22,7 +22,7 @@
               <% end %>
 
               <% if can? :destroy, stripe_installation %>
-                <%= link_to [:account, stripe_installation, return_to: request.path], method: :delete, data: { turbo_confirm: t('.buttons.confirmations.destroy_from_user', team_name: stripe_installation.team.label_string) }, class: 'inline-block text-slate-300 hover:text-slate-400 hover:no-underline text-lg' do %>
+                <%= button_to [:account, stripe_installation, return_to: request.path], method: :delete, data: { turbo_confirm: t('.buttons.confirmations.destroy_from_user', team_name: stripe_installation.team.label_string) }, class: 'inline-block text-slate-300 hover:text-slate-400 hover:no-underline text-lg' do %>
                   <i class="ti ti-close"></i>
                 <% end %>
               <% end %>

--- a/bullet_train-integrations-stripe/app/views/account/integrations/stripe_installations/_list.html.erb
+++ b/bullet_train-integrations-stripe/app/views/account/integrations/stripe_installations/_list.html.erb
@@ -19,7 +19,7 @@
             </div>
             <div class="flex-0 min-w-0 space-x-2 text-lg">
               <% if can? :destroy, stripe_installation %>
-                <%= link_to [:account, stripe_installation, return_to: request.path], method: :delete, data: { turbo_confirm: t('.buttons.confirmations.destroy_from_user', team_name: stripe_installation.team.label_string) }, class: 'inline-block text-slate-300 hover:text-slate-400 hover:no-underline' do %>
+                <%= button_to [:account, stripe_installation, return_to: request.path], method: :delete, data: { turbo_confirm: t('.buttons.confirmations.destroy_from_user', team_name: stripe_installation.team.label_string) }, class: 'inline-block text-slate-300 hover:text-slate-400 hover:no-underline' do %>
                   <i class="ti ti-close"></i>
                 <% end %>
               <% end %>

--- a/bullet_train-integrations-stripe/app/views/account/integrations/stripe_installations/_list.html.erb
+++ b/bullet_train-integrations-stripe/app/views/account/integrations/stripe_installations/_list.html.erb
@@ -19,7 +19,7 @@
             </div>
             <div class="flex-0 min-w-0 space-x-2 text-lg">
               <% if can? :destroy, stripe_installation %>
-                <%= link_to [:account, stripe_installation, return_to: request.path], method: :delete, data: { confirm: t('.buttons.confirmations.destroy_from_user', team_name: stripe_installation.team.label_string) }, class: 'inline-block text-slate-300 hover:text-slate-400 hover:no-underline' do %>
+                <%= link_to [:account, stripe_installation, return_to: request.path], method: :delete, data: { turbo_confirm: t('.buttons.confirmations.destroy_from_user', team_name: stripe_installation.team.label_string) }, class: 'inline-block text-slate-300 hover:text-slate-400 hover:no-underline' do %>
                   <i class="ti ti-close"></i>
                 <% end %>
               <% end %>

--- a/bullet_train-integrations-stripe/app/views/account/integrations/stripe_installations/show.html.erb
+++ b/bullet_train-integrations-stripe/app/views/account/integrations/stripe_installations/show.html.erb
@@ -17,7 +17,7 @@
 
       <% box.actions do %>
         <%= link_to t('.buttons.edit'), [:edit, :account, @stripe_installation], class: first_button_primary if can? :edit, @stripe_installation %>
-        <%= button_to t('.buttons.destroy'), [:account, @stripe_installation], method: :delete, class: first_button_primary, data: { confirm: t('.buttons.confirmations.destroy', model_locales(@stripe_installation)) } if can? :destroy, @stripe_installation %>
+        <%= button_to t('.buttons.destroy'), [:account, @stripe_installation], method: :delete, class: first_button_primary, data: { turbo_confirm: t('.buttons.confirmations.destroy', model_locales(@stripe_installation)) } if can? :destroy, @stripe_installation %>
         <%= link_to t('global.buttons.back'), [:account, @team, :integrations_stripe_installations], class: first_button_primary %>
       <% end %>
     <% end %>

--- a/bullet_train-integrations-stripe/app/views/account/oauth/stripe_accounts/_index.html.erb
+++ b/bullet_train-integrations-stripe/app/views/account/oauth/stripe_accounts/_index.html.erb
@@ -21,7 +21,7 @@
             </div>
             <div class="flex-0 min-w-0 space-x-2 text-lg">
               <% if can? :destroy, stripe_account %>
-                <%= link_to [:account, stripe_account], method: :delete, data: { confirm: t('.buttons.confirmations.destroy', model_locales(stripe_account)) }, class: 'inline-block text-slate-300 hover:text-slate-400 hover:no-underline' do %>
+                <%= link_to [:account, stripe_account], method: :delete, data: { turbo_confirm: t('.buttons.confirmations.destroy', model_locales(stripe_account)) }, class: 'inline-block text-slate-300 hover:text-slate-400 hover:no-underline' do %>
                   <i class="ti ti-close"></i>
                 <% end %>
               <% end %>

--- a/bullet_train-integrations-stripe/app/views/account/oauth/stripe_accounts/_index.html.erb
+++ b/bullet_train-integrations-stripe/app/views/account/oauth/stripe_accounts/_index.html.erb
@@ -21,7 +21,7 @@
             </div>
             <div class="flex-0 min-w-0 space-x-2 text-lg">
               <% if can? :destroy, stripe_account %>
-                <%= link_to [:account, stripe_account], method: :delete, data: { turbo_confirm: t('.buttons.confirmations.destroy', model_locales(stripe_account)) }, class: 'inline-block text-slate-300 hover:text-slate-400 hover:no-underline' do %>
+                <%= button_to [:account, stripe_account], method: :delete, data: { turbo_confirm: t('.buttons.confirmations.destroy', model_locales(stripe_account)) }, class: 'inline-block text-slate-300 hover:text-slate-400 hover:no-underline' do %>
                   <i class="ti ti-close"></i>
                 <% end %>
               <% end %>

--- a/bullet_train-integrations-stripe/app/views/account/oauth/stripe_accounts/show.html.erb
+++ b/bullet_train-integrations-stripe/app/views/account/oauth/stripe_accounts/show.html.erb
@@ -5,7 +5,7 @@
       <% box.t :description, title: '.header' %>
       <% box.actions do %>
         <%= link_to t('.buttons.edit'), [:edit, :account, @stripe_account], class: first_button_primary if can? :edit, @stripe_account %>
-        <%= button_to t('.buttons.destroy'), [:account, @stripe_account], method: :delete, class: first_button_primary, data: { confirm: t('.buttons.confirmations.destroy', model_locales(@stripe_account)) } if can? :destroy, @stripe_account %>
+        <%= button_to t('.buttons.destroy'), [:account, @stripe_account], method: :delete, class: first_button_primary, data: { turbo_confirm: t('.buttons.confirmations.destroy', model_locales(@stripe_account)) } if can? :destroy, @stripe_account %>
         <%= link_to t('global.buttons.back'), [:account, @user, :oauth_stripe_accounts], class: first_button_primary %>
       <% end %>
     <% end %>

--- a/bullet_train-outgoing_webhooks/app/views/account/webhooks/outgoing/deliveries/_index.html.erb
+++ b/bullet_train-outgoing_webhooks/app/views/account/webhooks/outgoing/deliveries/_index.html.erb
@@ -43,7 +43,7 @@
                       <%= link_to t('.buttons.shorthand.edit'), [:edit, :account, delivery], class: 'button-secondary button-smaller' %>
                     <% end %>
                     <% if can? :destroy, delivery %>
-                      <%= button_to t('.buttons.shorthand.destroy'), [:account, delivery], method: :delete, data: { confirm: t('.buttons.confirmations.destroy', model_locales(delivery)) }, class: 'button-secondary button-smaller' %>
+                      <%= button_to t('.buttons.shorthand.destroy'), [:account, delivery], method: :delete, data: { turbo_confirm: t('.buttons.confirmations.destroy', model_locales(delivery)) }, class: 'button-secondary button-smaller' %>
                     <% end %>
                   <% end %>
                 </td>

--- a/bullet_train-outgoing_webhooks/app/views/account/webhooks/outgoing/deliveries/show.html.erb
+++ b/bullet_train-outgoing_webhooks/app/views/account/webhooks/outgoing/deliveries/show.html.erb
@@ -26,7 +26,7 @@
 
       <% box.actions do %>
         <%= link_to t('.buttons.edit'), [:edit, :account, @delivery], class: first_button_primary if can? :edit, @delivery %>
-        <%= button_to t('.buttons.destroy'), [:account, @delivery], method: :delete, class: first_button_primary, data: { confirm: t('.buttons.confirmations.destroy', model_locales(@delivery)) } if can? :destroy, @delivery %>
+        <%= button_to t('.buttons.destroy'), [:account, @delivery], method: :delete, class: first_button_primary, data: { turbo_confirm: t('.buttons.confirmations.destroy', model_locales(@delivery)) } if can? :destroy, @delivery %>
         <%= link_to t('global.buttons.back'), [:account, @endpoint, :deliveries], class: first_button_primary %>
       <% end %>
     <% end %>

--- a/bullet_train-outgoing_webhooks/app/views/account/webhooks/outgoing/delivery_attempts/_index.html.erb
+++ b/bullet_train-outgoing_webhooks/app/views/account/webhooks/outgoing/delivery_attempts/_index.html.erb
@@ -39,7 +39,7 @@
                       <%= link_to t('.buttons.shorthand.edit'), [:edit, :account, delivery_attempt], class: 'button-secondary button-smaller' %>
                     <% end %>
                     <% if can? :destroy, delivery_attempt %>
-                      <%= button_to t('.buttons.shorthand.destroy'), [:account, delivery_attempt], method: :delete, data: { confirm: t('.buttons.confirmations.destroy', model_locales(delivery_attempt)) }, class: 'button-secondary button-smaller' %>
+                      <%= button_to t('.buttons.shorthand.destroy'), [:account, delivery_attempt], method: :delete, data: { turbo_confirm: t('.buttons.confirmations.destroy', model_locales(delivery_attempt)) }, class: 'button-secondary button-smaller' %>
                     <% end %>
                   <% end %>
                 </td>

--- a/bullet_train-outgoing_webhooks/app/views/account/webhooks/outgoing/delivery_attempts/show.html.erb
+++ b/bullet_train-outgoing_webhooks/app/views/account/webhooks/outgoing/delivery_attempts/show.html.erb
@@ -22,7 +22,7 @@
 
       <% box.actions do %>
         <%= link_to t('.buttons.edit'), [:edit, :account, @delivery_attempt], class: first_button_primary if can? :edit, @delivery_attempt %>
-        <%= button_to t('.buttons.destroy'), [:account, @delivery_attempt], method: :delete, class: first_button_primary, data: { confirm: t('.buttons.confirmations.destroy', model_locales(@delivery_attempt)) } if can? :destroy, @delivery_attempt %>
+        <%= button_to t('.buttons.destroy'), [:account, @delivery_attempt], method: :delete, class: first_button_primary, data: { turbo_confirm: t('.buttons.confirmations.destroy', model_locales(@delivery_attempt)) } if can? :destroy, @delivery_attempt %>
         <%= link_to t('global.buttons.back'), [:account, @delivery, :delivery_attempts], class: first_button_primary %>
       <% end %>
     <% end %>

--- a/bullet_train-outgoing_webhooks/app/views/account/webhooks/outgoing/endpoints/_index.html.erb
+++ b/bullet_train-outgoing_webhooks/app/views/account/webhooks/outgoing/endpoints/_index.html.erb
@@ -32,7 +32,7 @@
                       <%= link_to t('.buttons.shorthand.edit'), [:edit, :account, endpoint], class: 'button-secondary button-smaller' %>
                     <% end %>
                     <% if can? :destroy, endpoint %>
-                      <%= button_to t('.buttons.shorthand.destroy'), [:account, endpoint], method: :delete, data: { confirm: t('.buttons.confirmations.destroy', model_locales(endpoint)) }, class: 'button-secondary button-smaller' %>
+                      <%= button_to t('.buttons.shorthand.destroy'), [:account, endpoint], method: :delete, data: { turbo_confirm: t('.buttons.confirmations.destroy', model_locales(endpoint)) }, class: 'button-secondary button-smaller' %>
                     <% end %>
                   <% end %>
                 </td>

--- a/bullet_train-outgoing_webhooks/app/views/account/webhooks/outgoing/endpoints/show.html.erb
+++ b/bullet_train-outgoing_webhooks/app/views/account/webhooks/outgoing/endpoints/show.html.erb
@@ -34,7 +34,7 @@
 
       <% box.actions do %>
         <%= link_to t('.buttons.edit'), [:edit, :account, @endpoint], class: first_button_primary if can? :edit, @endpoint %>
-        <%= button_to t('.buttons.destroy'), [:account, @endpoint], method: :delete, class: first_button_primary, data: { confirm: t('.buttons.confirmations.destroy', model_locales(@endpoint)) } if can? :destroy, @endpoint %>
+        <%= button_to t('.buttons.destroy'), [:account, @endpoint], method: :delete, class: first_button_primary, data: { turbo_confirm: t('.buttons.confirmations.destroy', model_locales(@endpoint)) } if can? :destroy, @endpoint %>
         <%= link_to t('global.buttons.back'), [:account, @parent, :webhooks_outgoing_endpoints], class: first_button_primary %>
       <% end %>
     <% end %>

--- a/bullet_train-super_scaffolding/app/views/account/scaffolding/absolutely_abstract/creative_concepts/_creative_concept.html.erb
+++ b/bullet_train-super_scaffolding/app/views/account/scaffolding/absolutely_abstract/creative_concepts/_creative_concept.html.erb
@@ -11,7 +11,7 @@
       <% unless hide_actions %>
         <%# We write the full path here since this partial is called from different scopes. %>
         <%= link_to t('account.scaffolding.absolutely_abstract.creative_concepts.buttons.shorthand.edit'), [:edit, :account, creative_concept], class: 'button-secondary button-smaller' if can? :edit, creative_concept %>
-        <%= button_to t('account.scaffolding.absolutely_abstract.creative_concepts.buttons.shorthand.destroy'), [:account, creative_concept], method: :delete, data: { confirm: t('account.scaffolding.absolutely_abstract.creative_concepts.buttons.confirmations.destroy', model_locales(creative_concept)) }, class: 'button-secondary button-smaller' if can? :destroy, creative_concept %>
+        <%= button_to t('account.scaffolding.absolutely_abstract.creative_concepts.buttons.shorthand.destroy'), [:account, creative_concept], method: :delete, data: { turbo_confirm: t('account.scaffolding.absolutely_abstract.creative_concepts.buttons.confirmations.destroy', model_locales(creative_concept)) }, class: 'button-secondary button-smaller' if can? :destroy, creative_concept %>
       <% end %>
     </td>
   </tr>

--- a/bullet_train-super_scaffolding/app/views/account/scaffolding/absolutely_abstract/creative_concepts/show.html.erb
+++ b/bullet_train-super_scaffolding/app/views/account/scaffolding/absolutely_abstract/creative_concepts/show.html.erb
@@ -14,7 +14,7 @@
 
         <% box.actions do %>
           <%= link_to t('.buttons.edit'), [:edit, :account, @creative_concept], class: first_button_primary if can? :edit, @creative_concept %>
-          <%= button_to t('.buttons.destroy'), [:account, @creative_concept], method: :delete, class: first_button_primary, data: { confirm: t('.buttons.confirmations.destroy', model_locales(@creative_concept)) } if can? :destroy, @creative_concept %>
+          <%= button_to t('.buttons.destroy'), [:account, @creative_concept], method: :delete, class: first_button_primary, data: { turbo_confirm: t('.buttons.confirmations.destroy', model_locales(@creative_concept)) } if can? :destroy, @creative_concept %>
           <%= link_to t('global.buttons.back'), [:account, @team, :scaffolding_absolutely_abstract_creative_concepts], class: first_button_primary %>
         <% end %>
       <% end %>

--- a/bullet_train-super_scaffolding/app/views/account/scaffolding/completely_concrete/tangible_things/_tangible_thing.html.erb
+++ b/bullet_train-super_scaffolding/app/views/account/scaffolding/completely_concrete/tangible_things/_tangible_thing.html.erb
@@ -21,7 +21,7 @@
           <%= link_to t('.buttons.shorthand.edit'), [:edit, :account, tangible_thing], class: 'button-secondary button-smaller' %>
         <% end %>
         <% if can? :destroy, tangible_thing %>
-          <%= button_to t('.buttons.shorthand.destroy'), [:account, tangible_thing], method: :delete, data: { confirm: t('.buttons.confirmations.destroy', model_locales(tangible_thing)) }, class: 'button-secondary button-smaller' %>
+          <%= button_to t('.buttons.shorthand.destroy'), [:account, tangible_thing], method: :delete, data: { turbo_confirm: t('.buttons.confirmations.destroy', model_locales(tangible_thing)) }, class: 'button-secondary button-smaller' %>
         <% end %>
         <%# 🚅 super scaffolding will insert new action model buttons above this line. %>
       <% end %>

--- a/bullet_train-super_scaffolding/app/views/account/scaffolding/completely_concrete/tangible_things/show.html.erb
+++ b/bullet_train-super_scaffolding/app/views/account/scaffolding/completely_concrete/tangible_things/show.html.erb
@@ -39,7 +39,7 @@
         <% box.actions do %>
           <%= link_to t('.buttons.edit'), [:edit, :account, @tangible_thing], class: first_button_primary if can? :edit, @tangible_thing %>
           <%# 🚅 super scaffolding will insert new action model buttons above this line. %>
-          <%= button_to t('.buttons.destroy'), [:account, @tangible_thing], method: :delete, class: first_button_primary, data: { confirm: t('.buttons.confirmations.destroy', model_locales(@tangible_thing)) } if can? :destroy, @tangible_thing %>
+          <%= button_to t('.buttons.destroy'), [:account, @tangible_thing], method: :delete, class: first_button_primary, data: { turbo_confirm: t('.buttons.confirmations.destroy', model_locales(@tangible_thing)) } if can? :destroy, @tangible_thing %>
           <%= link_to t('global.buttons.back'), [:account, @absolutely_abstract_creative_concept, :completely_concrete_tangible_things], class: first_button_primary %>
         <% end %>
 

--- a/bullet_train-themes-light/app/views/themes/light/actions/_action.html.erb
+++ b/bullet_train-themes-light/app/views/themes/light/actions/_action.html.erb
@@ -26,7 +26,7 @@
             <%= link_to t("#{action.class.name.pluralize.underscore}.buttons.shorthand.edit"), build_action_model_path(action, type: :edit), class: 'button-secondary button-smaller' %>
           <% end %>
           <% if can? :destroy, action %>
-            <%= button_to t("#{action.class.name.pluralize.underscore}.buttons.shorthand.destroy"), build_action_model_path(action), method: :delete, data: { confirm: t("#{action.class.name.pluralize.underscore}.buttons.confirmations.destroy", model_locales(action)) }, class: 'button-secondary button-smaller' %>
+            <%= button_to t("#{action.class.name.pluralize.underscore}.buttons.shorthand.destroy"), build_action_model_path(action), method: :delete, data: { turbo_confirm: t("#{action.class.name.pluralize.underscore}.buttons.confirmations.destroy", model_locales(action)) }, class: 'button-secondary button-smaller' %>
           <% end %>
         </div>
       </div>

--- a/bullet_train/app/views/account/invitations/show.html.erb
+++ b/bullet_train/app/views/account/invitations/show.html.erb
@@ -13,17 +13,17 @@
 
         <div class="space-y-3 pb-1">
           <p><%= raw t('.accept_the_invitation', user_email: current_user.email) %></p>
-          <%= link_to t('.buttons.join_team'), accept_account_invitation_path(@invitation.uuid), method: :post, class: 'button full' %>
+          <%= button_to t('.buttons.join_team'), accept_account_invitation_path(@invitation.uuid), method: :post, class: 'button full' %>
         </div>
 
         <%= render 'account/shared/decision_line' %>
 
         <div class="space-y-3">
           <p><%= t('.sign_out') %></p>
-          <%= link_to t('.buttons.logout'), main_app.destroy_user_session_path, method: 'delete', class: 'button-alternative full' %>
+          <%= button_to t('.buttons.logout'), main_app.destroy_user_session_path, method: :delete, class: 'button-alternative full' %>
         </div>
       <% else %>
-        <%= link_to t('.buttons.join_team'), accept_account_invitation_path(@invitation.uuid), method: :post, class: 'button full' %>
+        <%= button_to t('.buttons.join_team'), accept_account_invitation_path(@invitation.uuid), method: :post, class: 'button full' %>
       <% end %>
     </div>
   <% end %>

--- a/bullet_train/app/views/account/memberships/_tombstones.html.erb
+++ b/bullet_train/app/views/account/memberships/_tombstones.html.erb
@@ -47,7 +47,7 @@
                 <% end %>
               </td>
               <td class="text-right">
-                <%= link_to t('.buttons.reinvite'), [:reinvite, :account, membership], class: 'button-secondary button-smaller', method: :post, data: {turbo_confirm: t('.buttons.confirmations.reinvite', membership_name: membership.name)} if can? :edit, membership %>
+                <%= button_to t('.buttons.reinvite'), [:reinvite, :account, membership], class: 'button-secondary button-smaller', method: :post, data: {turbo_confirm: t('.buttons.confirmations.reinvite', membership_name: membership.name)} if can? :edit, membership %>
                 <%= link_to t('.buttons.show'), [:account, membership], class: 'button-secondary button-smaller' %>
               </td>
             </tr>

--- a/bullet_train/app/views/account/memberships/_tombstones.html.erb
+++ b/bullet_train/app/views/account/memberships/_tombstones.html.erb
@@ -47,7 +47,7 @@
                 <% end %>
               </td>
               <td class="text-right">
-                <%= link_to t('.buttons.reinvite'), [:reinvite, :account, membership], class: 'button-secondary button-smaller', method: :post, data: {confirm: t('.buttons.confirmations.reinvite', membership_name: membership.name)} if can? :edit, membership %>
+                <%= link_to t('.buttons.reinvite'), [:reinvite, :account, membership], class: 'button-secondary button-smaller', method: :post, data: {turbo_confirm: t('.buttons.confirmations.reinvite', membership_name: membership.name)} if can? :edit, membership %>
                 <%= link_to t('.buttons.show'), [:account, membership], class: 'button-secondary button-smaller' %>
               </td>
             </tr>

--- a/bullet_train/app/views/account/memberships/edit.html.erb
+++ b/bullet_train/app/views/account/memberships/edit.html.erb
@@ -9,7 +9,7 @@
     <% if can? :destroy, @membership %>
       <%= render 'account/shared/box', divider: true do |box| %>
         <% box.t title: '.remove_header', description: '.remove_description' %>
-        <% box.body.button_to t('.buttons.destroy'), [:account, @membership], method: :delete, data: { confirm: t('.buttons.confirmations.destroy') }, class: 'button' %>
+        <% box.body.button_to t('.buttons.destroy'), [:account, @membership], method: :delete, data: { turbo_confirm: t('.buttons.confirmations.destroy') }, class: 'button' %>
       <% end %>
     <% end %>
   <% end %>

--- a/bullet_train/app/views/account/memberships/show.html.erb
+++ b/bullet_train/app/views/account/memberships/show.html.erb
@@ -34,16 +34,16 @@
 
       <% box.actions do %>
         <% if @membership.tombstone? %>
-          <%= link_to t('.buttons.reinvite'), [:reinvite, :account, @membership], class: first_button_primary, method: :post, data: {turbo_confirm: t('.buttons.confirmations.reinvite', membership_name: @membership.name)} if can? :edit, @membership %>
+          <%= button_to t('.buttons.reinvite'), [:reinvite, :account, @membership], class: first_button_primary, method: :post, data: {turbo_confirm: t('.buttons.confirmations.reinvite', membership_name: @membership.name)} if can? :edit, @membership %>
         <% end %>
 
         <%= link_to t('.buttons.edit'), [:edit, :account, @membership], class: first_button_primary if can? :edit, @membership %>
 
         <% unless @membership.tombstone? %>
           <% if @membership.admin? %>
-            <%= link_to t('.buttons.demote'), [:demote, :account, @membership], method: :post, data: { turbo_confirm: t('global.confirm_message') }, class: first_button_primary if can? :demote, @membership %>
+            <%= button_to t('.buttons.demote'), [:demote, :account, @membership], method: :post, data: { turbo_confirm: t('global.confirm_message') }, class: first_button_primary if can? :demote, @membership %>
           <% else %>
-            <%= link_to t('.buttons.promote'), [:promote, :account, @membership], method: :post, data: { turbo_confirm: t('global.confirm_message') }, class: first_button_primary if can? :promote, @membership %>
+            <%= button_to t('.buttons.promote'), [:promote, :account, @membership], method: :post, data: { turbo_confirm: t('global.confirm_message') }, class: first_button_primary if can? :promote, @membership %>
           <% end %>
           <% if (can? :destroy, @membership) && (!@membership.platform_agent) %>
             <%= button_to t(".buttons.#{membership_destroy_locale_key(@membership)}"), [:account, @membership], method: :delete, data: { turbo_confirm: t(".buttons.confirmations.#{membership_destroy_locale_key(@membership)}", model_locales(@membership)) }, class: first_button_primary %>

--- a/bullet_train/app/views/account/memberships/show.html.erb
+++ b/bullet_train/app/views/account/memberships/show.html.erb
@@ -34,19 +34,19 @@
 
       <% box.actions do %>
         <% if @membership.tombstone? %>
-          <%= link_to t('.buttons.reinvite'), [:reinvite, :account, @membership], class: first_button_primary, method: :post, data: {confirm: t('.buttons.confirmations.reinvite', membership_name: @membership.name)} if can? :edit, @membership %>
+          <%= link_to t('.buttons.reinvite'), [:reinvite, :account, @membership], class: first_button_primary, method: :post, data: {turbo_confirm: t('.buttons.confirmations.reinvite', membership_name: @membership.name)} if can? :edit, @membership %>
         <% end %>
 
         <%= link_to t('.buttons.edit'), [:edit, :account, @membership], class: first_button_primary if can? :edit, @membership %>
 
         <% unless @membership.tombstone? %>
           <% if @membership.admin? %>
-            <%= link_to t('.buttons.demote'), [:demote, :account, @membership], method: :post, data: { confirm: t('global.confirm_message') }, class: first_button_primary if can? :demote, @membership %>
+            <%= link_to t('.buttons.demote'), [:demote, :account, @membership], method: :post, data: { turbo_confirm: t('global.confirm_message') }, class: first_button_primary if can? :demote, @membership %>
           <% else %>
-            <%= link_to t('.buttons.promote'), [:promote, :account, @membership], method: :post, data: { confirm: t('global.confirm_message') }, class: first_button_primary if can? :promote, @membership %>
+            <%= link_to t('.buttons.promote'), [:promote, :account, @membership], method: :post, data: { turbo_confirm: t('global.confirm_message') }, class: first_button_primary if can? :promote, @membership %>
           <% end %>
           <% if (can? :destroy, @membership) && (!@membership.platform_agent) %>
-            <%= button_to t(".buttons.#{membership_destroy_locale_key(@membership)}"), [:account, @membership], method: :delete, data: { confirm: t(".buttons.confirmations.#{membership_destroy_locale_key(@membership)}", model_locales(@membership)) }, class: first_button_primary %>
+            <%= button_to t(".buttons.#{membership_destroy_locale_key(@membership)}"), [:account, @membership], method: :delete, data: { turbo_confirm: t(".buttons.confirmations.#{membership_destroy_locale_key(@membership)}", model_locales(@membership)) }, class: first_button_primary %>
           <% end %>
         <% end %>
 

--- a/bullet_train/app/views/account/onboarding/invitation_lists/new.html.erb
+++ b/bullet_train/app/views/account/onboarding/invitation_lists/new.html.erb
@@ -22,7 +22,7 @@
           <% if other_teams.any? %>
             <%= link_to t('global.buttons.back'), main_app.account_teams_path, class: first_button_primary %>
           <% else %>
-            <%= link_to t('menus.main.labels.logout'), main_app.destroy_user_session_path(@user, onboard_logout: true), class: first_button_primary, method: 'delete' %>
+            <%= button_to t('menus.main.labels.logout'), main_app.destroy_user_session_path(@user, onboard_logout: true), class: first_button_primary, method: :delete %>
           <% end %>
         </div>
       <% end %>

--- a/bullet_train/app/views/account/onboarding/user_details/edit.html.erb
+++ b/bullet_train/app/views/account/onboarding/user_details/edit.html.erb
@@ -39,7 +39,7 @@
           <% if other_teams.any? %>
             <%= link_to t('global.buttons.back'), main_app.account_teams_path, class: first_button_primary %>
           <% else %>
-            <%= link_to t('menus.main.labels.logout'), main_app.destroy_user_session_path(@user, onboard_logout: true), class: first_button_primary, method: 'delete' %>
+            <%= button_to t('menus.main.labels.logout'), main_app.destroy_user_session_path(@user, onboard_logout: true), class: first_button_primary, method: :delete %>
           <% end %>
         </div>
       <% end %>

--- a/bullet_train/app/views/account/onboarding/user_email/edit.html.erb
+++ b/bullet_train/app/views/account/onboarding/user_email/edit.html.erb
@@ -24,7 +24,7 @@
           <% if current_user.teams.any? %>
             <%= link_to t('global.buttons.back'), main_app.account_teams_path, class: first_button_primary %>
           <% else %>
-            <%= link_to t('menus.main.labels.logout'), main_app.destroy_user_session_path, class: first_button_primary, method: 'delete' %>
+            <%= button_to t('menus.main.labels.logout'), main_app.destroy_user_session_path, class: first_button_primary, method: :delete %>
           <% end %>
         </div>
       <% end %>

--- a/bullet_train/app/views/account/teams/_form.html.erb
+++ b/bullet_train/app/views/account/teams/_form.html.erb
@@ -18,7 +18,7 @@
   <div class="buttons">
     <%= form.submit (form.object.persisted? ? t('.buttons.update') : t('.buttons.create')), class: "button" %>
     <% if controller.action_name == "edit" %>
-      <%= link_to t('account.teams.buttons.destroy'), [:account, team], method: :delete, data: { turbo_confirm: t('account.teams.buttons.confirmations.destroy') } %>
+      <%= button_to t('account.teams.buttons.destroy'), [:account, team], method: :delete, data: { turbo_confirm: t('account.teams.buttons.confirmations.destroy') } %>
     <% end %>
     <%= link_to t('global.buttons.cancel'), form.object.persisted? ? [:account, team] : [:account, :teams], class: "button-secondary" %>
   </div>

--- a/bullet_train/app/views/account/teams/_form.html.erb
+++ b/bullet_train/app/views/account/teams/_form.html.erb
@@ -18,7 +18,7 @@
   <div class="buttons">
     <%= form.submit (form.object.persisted? ? t('.buttons.update') : t('.buttons.create')), class: "button" %>
     <% if controller.action_name == "edit" %>
-      <%= link_to t('account.teams.buttons.destroy'), [:account, team], method: :delete, data: { confirm: t('account.teams.buttons.confirmations.destroy') } %>
+      <%= link_to t('account.teams.buttons.destroy'), [:account, team], method: :delete, data: { turbo_confirm: t('account.teams.buttons.confirmations.destroy') } %>
     <% end %>
     <%= link_to t('global.buttons.cancel'), form.object.persisted? ? [:account, team] : [:account, :teams], class: "button-secondary" %>
   </div>

--- a/bullet_train/app/views/account/teams/new.html.erb
+++ b/bullet_train/app/views/account/teams/new.html.erb
@@ -33,7 +33,7 @@ end
           <p><%= t('.log_out') %></p>
         </div>
 
-        <%= link_to t('menus.main.labels.logout'), main_app.destroy_user_session_path, class: 'button-alternative full', method: 'delete' %></p>
+        <%= button_to t('menus.main.labels.logout'), main_app.destroy_user_session_path, class: 'button-alternative full', method: :delete %></p>
 
         <%= render 'account/shared/decision_line' %>
 
@@ -70,7 +70,7 @@ end
             <% if current_user.teams.any? %>
               <%= link_to t('global.buttons.back'), main_app.account_teams_path, class: first_button_primary %>
             <% else %>
-              <%= link_to t('menus.main.labels.logout'), main_app.destroy_user_session_path, class: first_button_primary, method: 'delete' %>
+              <%= button_to t('menus.main.labels.logout'), main_app.destroy_user_session_path, class: first_button_primary, method: :delete %>
             <% end %>
           </div>
         <% end %>

--- a/bullet_train/app/views/devise/registrations/_two_factor.html.erb
+++ b/bullet_train/app/views/devise/registrations/_two_factor.html.erb
@@ -52,9 +52,9 @@
       <% end %>
 
       <% if current_user.otp_required_for_login? %>
-        <%= link_to t('users.edit.two_factor.buttons.disable'), account_two_factor_path, method: :delete, remote: true, class: "button" %>
+        <%= button_to t('users.edit.two_factor.buttons.disable'), account_two_factor_path, method: :delete, remote: true, class: "button" %>
       <% else %>
-        <%= link_to t('users.edit.two_factor.buttons.enable'), account_two_factor_path, method: :post, remote: true, class: "button" %>
+        <%= button_to t('users.edit.two_factor.buttons.enable'), account_two_factor_path, method: :post, remote: true, class: "button" %>
       <% end %>
     </div>
   <% end %>

--- a/bullet_train/app/views/devise/registrations/edit.html.erb
+++ b/bullet_train/app/views/devise/registrations/edit.html.erb
@@ -38,6 +38,6 @@
 
 <h3><%= t('devise.headers.cancel_account') %></h3>
 
-<p>Unhappy? <%= button_to t('devise.buttons.cancel_account'), registration_path(resource_name), data: { confirm: t('global.confirm_message') }, method: :delete %></p>
+<p>Unhappy? <%= button_to t('devise.buttons.cancel_account'), registration_path(resource_name), data: { turbo_confirm: t('global.confirm_message') }, method: :delete %></p>
 
 <%= link_to t('global.buttons.back'), :back %>


### PR DESCRIPTION
rails 7 without `rails-ujs` is supposed to use `turbo_confirm` instead of `confirm`

confirmation dialog does not show up unless we make it `turbo_confirm`

<img width="1460" alt="Screenshot 2025-03-21 at 21 02 21" src="https://github.com/user-attachments/assets/4be2d14a-f0f0-40ef-9ffe-de2c609a087a" />
