### PR TITLE
Add docs for overriding BT Stimulus controllers

### DIFF
--- a/bullet_train/docs/javascript.md
+++ b/bullet_train/docs/javascript.md
@@ -16,7 +16,7 @@ And then update that controller to first `import` the BT controller that you wan
 and then `export` a class that `extends` the controller that you just imported.
 
 For example, this will make it so that the BT Super Select controller will log a line to the console
-every time that `connect` is calle:
+every time that `connect` is called:
 
 ```javascript
 import { SuperSelectController } from '@bullet-train/fields'


### PR DESCRIPTION
We enabled easy overriding of the BT Stimulus controllers in: https://github.com/bullet-train-co/bullet_train/pull/2006

This adds documentation to the [JavaScript docs page](https://bullettrain.co/docs/javascript) letting people know that they can do this.

Fixes: https://github.com/bullet-train-co/bullet_train-core/issues/1077