### PR TITLE
OpenApi: Add support to disable required params

### DIFF
--- a/bullet_train-api/app/helpers/api/open_api_helper.rb
+++ b/bullet_train-api/app/helpers/api/open_api_helper.rb
@@ -249,6 +249,9 @@ module Api
           if details["required"]
             original["required"] << property
             details.delete("required")
+          elsif details["required"] == false
+            original["required"].delete(property)
+            details.delete("required")
           end
           original["properties"][property] = details
           if details["example"]

--- a/bullet_train-api/app/helpers/api/open_api_helper.rb
+++ b/bullet_train-api/app/helpers/api/open_api_helper.rb
@@ -248,11 +248,12 @@ module Api
         custom["add"].each do |property, details|
           if details["required"]
             original["required"] << property
-            details.delete("required")
-          elsif details["required"] == false
+          else
             original["required"].delete(property)
-            details.delete("required")
           end
+          # Always delete required because this attribute should only go
+          # into the required array according to OpenAPI 3.1.
+          details.delete("required")
           original["properties"][property] = details
           if details["example"]
             original["example"][property] = details["example"]


### PR DESCRIPTION
✅ The changes are tested in a real project with docs generation.

This PR allows you to disable a required field for OpenApi generation.
It was previously impossible to do this when a field has a presence validation.

It can be very useful for update params, where you can skip some parameters in the payload if you don't want to update them.

For example:

```
automatic_components_for Workspace, parameters: {update: {add: {subdomain: {required: false}}}
```

will return:
```
WorkspaceParametersUpdate:
      type: object
      title: Workspaces
      description: Workspaces
      required:
      - name
      properties:
        name:
          type: string
          description: Workspace name
        subdomain:
          type: string
          description: Subdomain
```

Since it's post-processing, this will work even if the field has presence validation.

P.S. I tried to add a test for this because it doesn't seem to be set up for the `api` gem and it throws 
`Minitest::UnexpectedError:         ActiveRecord::StatementInvalid: Could not find table 'teams'`, so I gave up.
