### PR TITLE
Setup and add tests for automatic_components_for helper

### DIFF
--- a/bullet_train-api/Gemfile
+++ b/bullet_train-api/Gemfile
@@ -22,4 +22,5 @@ gem "bullet_train-themes", path: "../bullet_train-themes"
 
 group :test do
   gem "minitest-reporters"
+  gem "factory_bot"
 end

--- a/bullet_train-api/Gemfile.lock
+++ b/bullet_train-api/Gemfile.lock
@@ -425,6 +425,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES
@@ -437,6 +438,7 @@ DEPENDENCIES
   bullet_train-super_load_and_authorize_resource!
   bullet_train-super_scaffolding!
   bullet_train-themes!
+  factory_bot
   minitest-reporters
   simplecov
   sprockets-rails

--- a/bullet_train-api/app/helpers/api/open_api_helper.rb
+++ b/bullet_train-api/app/helpers/api/open_api_helper.rb
@@ -50,8 +50,10 @@ module Api
     def automatic_components_for(model, **options)
       locals = options.delete(:locals) || {}
 
-      path = "app/views/api/#{@version}"
-      paths = [path, "app/views"] + gem_paths.product(%W[/#{path} /app/views]).map(&:join)
+      view_path = "app/views"
+      api_path = "#{view_path}/api/#{@version || "v1"}"
+      paths = [Rails.root.join(api_path).to_s, Rails.root.join(view_path).to_s]
+      paths += gem_paths.product(%W[/#{api_path} /#{view_path}]).map(&:join)
 
       # Transform values the same way we do for Jbuilder templates
       Jbuilder::Schema::Template.prepend ValuesTransformer

--- a/bullet_train-api/app/helpers/api/open_api_helper.rb
+++ b/bullet_train-api/app/helpers/api/open_api_helper.rb
@@ -249,6 +249,9 @@ module Api
           if details["required"]
             original["required"] << property
             details.delete("required")
+          elsif details["required"] == false
+            original["required"].delete(property)
+            details.delete("required")
           end
           original["properties"][property] = details
           if details["example"]

--- a/bullet_train-api/app/helpers/api/open_api_helper.rb
+++ b/bullet_train-api/app/helpers/api/open_api_helper.rb
@@ -248,11 +248,12 @@ module Api
         custom["add"].each do |property, details|
           if details["required"]
             original["required"] << property
-            details.delete("required")
-          elsif details["required"] == false
+          else
             original["required"].delete(property)
-            details.delete("required")
           end
+          # Always delete required because this attribute should only go
+          # into the required array according to OpenAPI 3.1.
+          details.delete("required")
           original["properties"][property] = details
           if details["example"]
             original["example"][property] = details["example"]

--- a/bullet_train-api/test/dummy/app/views/api/v1/teams/_team.json.jbuilder
+++ b/bullet_train-api/test/dummy/app/views/api/v1/teams/_team.json.jbuilder
@@ -1,0 +1,8 @@
+json.extract! team,
+  :id,
+  :name,
+  :slug,
+  :time_zone,
+  # 🚅 super scaffolding will insert new fields above this line.
+  :created_at,
+  :updated_at

--- a/bullet_train-api/test/dummy/config/locales/teams.en.yml
+++ b/bullet_train-api/test/dummy/config/locales/teams.en.yml
@@ -1,0 +1,23 @@
+en:
+  teams:
+    label: Teams
+    fields:
+      id:
+        label: Team ID
+        api_description: Team ID description
+      name:
+        label: Business name
+      slug:
+        label: Slug
+        api_description: URL param to point to a team
+      time_zone:
+        label: "Primary time zone"
+        api_description: |
+          The human-readable time zone set manually by a user or dynamically by the app.
+          Read more about time zones and how to map them back to the TZ standard in [our Time Zones guide.](https://google.com/).
+      created_at:
+        label: Created
+        api_description: Created description
+      updated_at:
+        label: Updated
+        api_description: Updated description

--- a/bullet_train-api/test/dummy/db/schema.rb
+++ b/bullet_train-api/test/dummy/db/schema.rb
@@ -1,0 +1,35 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 2022_12_31_003438) do
+  # These are extensions that must be enabled in order to support this database
+
+  create_table "teams", force: :cascade do |t|
+    t.string "name"
+    t.string "slug"
+    t.string "time_zone"
+    t.boolean "being_destroyed"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "email"
+    t.string "first_name"
+    t.string "last_name"
+    t.integer "current_team_id"
+    t.string "time_zone"
+    t.string "encrypted_password"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+end

--- a/bullet_train-api/test/factories/teams.rb
+++ b/bullet_train-api/test/factories/teams.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :team, class: Team do
+    name { "Test Team" }
+    slug { "test_team" }
+    time_zone { "Pacific Time (US & Canada)" }
+  end
+
+  factory :team_example, class: Team do
+    id { 42000 }
+    name { "Example Team" }
+    slug { "example_team" }
+    time_zone { "Pacific Time (US & Canada)" }
+    created_at { 1.month.ago }
+    updated_at { 1.month.ago }
+  end
+end

--- a/bullet_train-api/test/helpers/open_api_helper_test.rb
+++ b/bullet_train-api/test/helpers/open_api_helper_test.rb
@@ -1,0 +1,157 @@
+require "test_helper"
+
+class Api::OpenApiHelperTest < ActiveSupport::TestCase
+  class TestClass
+    include Api::OpenApiHelper
+
+    def initialize
+      @version = "v1"
+    end
+  end
+
+  # TeamAttributes:
+  #   type: object
+  #   title: Teams
+  #   description: Teams
+  #   required:
+  #   - id
+  #   - name
+  #   properties:
+  #     id:
+  #       type: integer
+  #       description: Team ID description
+  #     name:
+  #       type: string
+  #       description: Team Name
+  #     slug:
+  #       type:
+  #       - string
+  #       - 'null'
+  #       description: URL param to point to a team
+  #     time_zone:
+  #       type:
+  #       - string
+  #       - 'null'
+  #       description: |
+  #         The human-readable time zone set manually by a user or dynamically by the app.
+  #         Read more about time zones and how to map them back to the TZ standard in [our Time Zones guide.](https://google.com/).
+  #     created_at:
+  #       type:
+  #       - string
+  #       - 'null'
+  #       format: date-time
+  #       description: Created description
+  #     updated_at:
+  #       type:
+  #       - string
+  #       - 'null'
+  #       format: date-time
+  #       description: Updated description
+  #   example:
+  #     id: 42000
+  #     name: Example Team
+  #     slug: example_team
+  #     time_zone: Pacific Time (US & Canada)
+  #     created_at: '2025-02-28T16:13:08.000Z'
+  #     updated_at: '2025-02-28T16:13:08.000Z'
+  # TeamParametersUpdate:
+  #   type: object
+  #   title: Teams
+  #   description: Teams
+  #   required:
+  #   - name
+  #   properties:
+  #     name:
+  #       type: string
+  #       description: Team Name
+  #     time_zone:
+  #       type:
+  #       - string
+  #       - 'null'
+  #       description: |
+  #         The human-readable time zone set manually by a user or dynamically by the app.
+  #         Read more about time zones and how to map them back to the TZ standard in [our Time Zones guide.](https://google.com/).
+  #   example:
+  #     team:
+  #       name: Example Team
+  #       time_zone: Pacific Time (US & Canada)
+  def assert_full_result(result, team_example)
+    assert result.key?("TeamAttributes")
+    assert result.key?("TeamParametersUpdate")
+
+    attributes = result["TeamAttributes"]
+    assert_equal "object", attributes["type"]
+    assert_equal "Teams", attributes["title"]
+    assert_equal "Teams", attributes["description"]
+    assert_equal ["id", "name"], attributes["required"]
+    assert attributes.key?("properties")
+
+    properties = attributes["properties"]
+    assert_equal "integer", properties["id"]["type"]
+    assert_equal "Team ID description", properties["id"]["description"]
+
+    assert_equal "string", properties["name"]["type"]
+    assert_equal "Team Name", properties["name"]["description"]
+
+    assert_equal ["string", "null"], properties["slug"]["type"]
+    assert_equal "URL param to point to a team", properties["slug"]["description"]
+
+    assert_equal ["string", "null"], properties["time_zone"]["type"]
+    time_zone_description = "The human-readable time zone set manually by a user or dynamically by the app.\nRead more about time zones and how to map them back to the TZ standard in [our Time Zones guide.](https://google.com/).\n"
+    assert_equal time_zone_description, properties["time_zone"]["description"]
+
+    assert_equal ["string", "null"], properties["created_at"]["type"]
+    assert_equal "date-time", properties["created_at"]["format"]
+    assert_equal "Created description", properties["created_at"]["description"]
+
+    assert_equal ["string", "null"], properties["updated_at"]["type"]
+    assert_equal "date-time", properties["updated_at"]["format"]
+    assert_equal "Updated description", properties["updated_at"]["description"]
+
+    example = attributes["example"]
+    assert_equal team_example.id, example["id"]
+    assert_equal team_example.name, example["name"]
+    assert_equal team_example.slug, example["slug"]
+    assert_equal team_example.time_zone, example["time_zone"]
+    assert_equal team_example.created_at.iso8601(3), example["created_at"]
+    assert_equal team_example.updated_at.iso8601(3), example["updated_at"]
+
+    parameters = result["TeamParametersUpdate"]
+    assert_equal "object", parameters["type"]
+    assert_equal "Teams", parameters["title"]
+    assert_equal "Teams", parameters["description"]
+    assert_equal ["name"], parameters["required"]
+
+    properties = parameters["properties"]
+    assert_equal "string", properties["name"]["type"]
+    assert_equal "Team Name", properties["name"]["description"]
+
+    assert_equal ["string", "null"], properties["time_zone"]["type"]
+    assert_equal time_zone_description, properties["time_zone"]["description"]
+
+    example = parameters["example"]["team"]
+    assert_equal team_example.name, example["name"]
+    assert_equal team_example.time_zone, example["time_zone"]
+  end
+
+  test "#automatic_components_for" do
+    freeze_time do # to match examples created_at and updated_at values
+      result_yaml = TestClass.new.automatic_components_for Team
+      result = YAML.safe_load("    #{result_yaml}") # Indent the first YAML string for proper formatting
+      assert_full_result result, create(:team_example)
+    end
+  end
+
+  test "#automatic_components_for can make a parameter as not required" do
+    result_yaml = TestClass.new.automatic_components_for Team, parameters: {add: {name: {required: false}}}
+    result = YAML.safe_load("    #{result_yaml}") # Indent the first YAML string for proper formatting
+
+    params = result["TeamParametersUpdate"]
+    assert params
+    assert_equal [], params["required"] # initially name was required
+
+    properties = params["properties"]
+    assert properties.key?("name")
+    assert_not properties["name"].key?("required") # required field was deleted
+  end
+end

--- a/bullet_train-api/test/helpers/open_api_helper_test.rb
+++ b/bullet_train-api/test/helpers/open_api_helper_test.rb
@@ -9,6 +9,13 @@ class Api::OpenApiHelperTest < ActiveSupport::TestCase
     end
   end
 
+  # TODO: In the future, we can solve this more elegantly than providing
+  # a comment here and doing individual asserts. For example, by having a
+  # team_attributes.yml fixture and then doing one assert_equal against a
+  # string or a `expected_hash.to_yml`.
+  #
+  # An example of the resulting OpenAPI schema:
+  #
   # TeamAttributes:
   #   type: object
   #   title: Teams

--- a/bullet_train-api/test/test_helper.rb
+++ b/bullet_train-api/test/test_helper.rb
@@ -17,3 +17,12 @@ if ActiveSupport::TestCase.respond_to?(:fixture_path=)
 end
 
 require_relative "../../test_support/minitest_reporters"
+
+include FactoryBot::Syntax::Methods
+FactoryBot.find_definitions
+
+# Copied from ClickFunnels
+Jbuilder::Schema.configure do |config|
+  config.title_name = ["api_title", "title"]
+  config.description_name = ["api_description", "heading"]
+end

--- a/bullet_train-api/test/test_helper.rb
+++ b/bullet_train-api/test/test_helper.rb
@@ -18,7 +18,7 @@ end
 
 require_relative "../../test_support/minitest_reporters"
 
-include FactoryBot::Syntax::Methods
+ActiveSupport::TestCase.include FactoryBot::Syntax::Methods
 FactoryBot.find_definitions
 
 # Copied from ClickFunnels


### PR DESCRIPTION
Continue of https://github.com/bullet-train-co/bullet_train-core/pull/1080 with test setup for `api` gem and added tests for `automatic_components_for` helper

I decided to put it in a separate PR in case we have any issues/comments with the test setup or anything else not related to the fix itself.
This way we can merge the fix (https://github.com/bullet-train-co/bullet_train-core/pull/1080) first and tests (this PR) separately.
Or we can just merge this PR only.

✅ Initial fix included

---

PR Description from #1080 (which is included in this PR):

✅ The changes are tested in a real project with docs generation.

This PR allows you to disable a required field for OpenApi generation.
It was previously impossible to do this when a field has a presence validation.

It can be very useful for update params, where you can skip some parameters in the payload if you don't want to update them.

For example:

```
automatic_components_for Workspace, parameters: {update: {add: {subdomain: {required: false}}}
```

will return:
```
WorkspaceParametersUpdate:
      type: object
      title: Workspaces
      description: Workspaces
      required:
      - name
      properties:
        name:
          type: string
          description: Workspace name
        subdomain:
          type: string
          description: Subdomain
```

Since it's post-processing, this will work even if the field has presence validation.

P.S. I tried to add a test for this because it doesn't seem to be set up for the `api` gem and it throws 
`Minitest::UnexpectedError:         ActiveRecord::StatementInvalid: Could not find table 'teams'`, so I gave up.
