### PR TITLE
Add support for Pagy 9

### DIFF
--- a/bullet_train-api/Gemfile.lock
+++ b/bullet_train-api/Gemfile.lock
@@ -86,7 +86,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (~> 8)
+      pagy (>= 8.0)
       pagy_cursor
       rails (>= 6.0.0)
 

--- a/bullet_train-api/Gemfile.lock
+++ b/bullet_train-api/Gemfile.lock
@@ -86,7 +86,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (>= 8.0)
+      pagy (>= 8.0, < 10)
       pagy_cursor
       rails (>= 6.0.0)
 

--- a/bullet_train-api/bullet_train-api.gemspec
+++ b/bullet_train-api/bullet_train-api.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bullet_train"
 
   spec.add_dependency "rails", ">= 6.0.0"
-  spec.add_dependency "pagy", "~> 8"
+  spec.add_dependency "pagy", ">= 8.0"
   spec.add_dependency "pagy_cursor"
   spec.add_dependency "doorkeeper"
   spec.add_dependency "jbuilder-schema", "~> 2.6.6"

--- a/bullet_train-api/bullet_train-api.gemspec
+++ b/bullet_train-api/bullet_train-api.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bullet_train"
 
   spec.add_dependency "rails", ">= 6.0.0"
-  spec.add_dependency "pagy", ">= 8.0"
+  spec.add_dependency "pagy", ">= 8.0", "< 10"
   spec.add_dependency "pagy_cursor"
   spec.add_dependency "doorkeeper"
   spec.add_dependency "jbuilder-schema", "~> 2.6.6"

--- a/bullet_train-fields/Gemfile.lock
+++ b/bullet_train-fields/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (>= 8.0)
+      pagy (>= 8.0, < 10)
       pagy_cursor
       rails (>= 6.0.0)
 

--- a/bullet_train-fields/Gemfile.lock
+++ b/bullet_train-fields/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (~> 8)
+      pagy (>= 8.0)
       pagy_cursor
       rails (>= 6.0.0)
 

--- a/bullet_train-incoming_webhooks/Gemfile.lock
+++ b/bullet_train-incoming_webhooks/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (>= 8.0)
+      pagy (>= 8.0, < 10)
       pagy_cursor
       rails (>= 6.0.0)
 

--- a/bullet_train-incoming_webhooks/Gemfile.lock
+++ b/bullet_train-incoming_webhooks/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (~> 8)
+      pagy (>= 8.0)
       pagy_cursor
       rails (>= 6.0.0)
 

--- a/bullet_train-integrations-stripe/Gemfile.lock
+++ b/bullet_train-integrations-stripe/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (>= 8.0)
+      pagy (>= 8.0, < 10)
       pagy_cursor
       rails (>= 6.0.0)
 

--- a/bullet_train-integrations-stripe/Gemfile.lock
+++ b/bullet_train-integrations-stripe/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (~> 8)
+      pagy (>= 8.0)
       pagy_cursor
       rails (>= 6.0.0)
 

--- a/bullet_train-outgoing_webhooks/Gemfile.lock
+++ b/bullet_train-outgoing_webhooks/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (>= 8.0)
+      pagy (>= 8.0, < 10)
       pagy_cursor
       rails (>= 6.0.0)
 

--- a/bullet_train-outgoing_webhooks/Gemfile.lock
+++ b/bullet_train-outgoing_webhooks/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (~> 8)
+      pagy (>= 8.0)
       pagy_cursor
       rails (>= 6.0.0)
 

--- a/bullet_train-sortable/Gemfile.lock
+++ b/bullet_train-sortable/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (>= 8.0)
+      pagy (>= 8.0, < 10)
       pagy_cursor
       rails (>= 6.0.0)
 

--- a/bullet_train-sortable/Gemfile.lock
+++ b/bullet_train-sortable/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (~> 8)
+      pagy (>= 8.0)
       pagy_cursor
       rails (>= 6.0.0)
 

--- a/bullet_train-super_scaffolding/Gemfile.lock
+++ b/bullet_train-super_scaffolding/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (>= 8.0)
+      pagy (>= 8.0, < 10)
       pagy_cursor
       rails (>= 6.0.0)
 

--- a/bullet_train-super_scaffolding/Gemfile.lock
+++ b/bullet_train-super_scaffolding/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (~> 8)
+      pagy (>= 8.0)
       pagy_cursor
       rails (>= 6.0.0)
 

--- a/bullet_train-themes-light/Gemfile.lock
+++ b/bullet_train-themes-light/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (>= 8.0)
+      pagy (>= 8.0, < 10)
       pagy_cursor
       rails (>= 6.0.0)
 

--- a/bullet_train-themes-light/Gemfile.lock
+++ b/bullet_train-themes-light/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (~> 8)
+      pagy (>= 8.0)
       pagy_cursor
       rails (>= 6.0.0)
 

--- a/bullet_train-themes-tailwind_css/Gemfile.lock
+++ b/bullet_train-themes-tailwind_css/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (>= 8.0)
+      pagy (>= 8.0, < 10)
       pagy_cursor
       rails (>= 6.0.0)
 

--- a/bullet_train-themes-tailwind_css/Gemfile.lock
+++ b/bullet_train-themes-tailwind_css/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (~> 8)
+      pagy (>= 8.0)
       pagy_cursor
       rails (>= 6.0.0)
 

--- a/bullet_train-themes/Gemfile.lock
+++ b/bullet_train-themes/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (>= 8.0)
+      pagy (>= 8.0, < 10)
       pagy_cursor
       rails (>= 6.0.0)
 

--- a/bullet_train-themes/Gemfile.lock
+++ b/bullet_train-themes/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (~> 8)
+      pagy (>= 8.0)
       pagy_cursor
       rails (>= 6.0.0)
 

--- a/bullet_train/Gemfile.lock
+++ b/bullet_train/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (>= 8.0)
+      pagy (>= 8.0, < 10)
       pagy_cursor
       rails (>= 6.0.0)
 

--- a/bullet_train/Gemfile.lock
+++ b/bullet_train/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       doorkeeper
       factory_bot
       jbuilder-schema (~> 2.6.6)
-      pagy (~> 8)
+      pagy (>= 8.0)
       pagy_cursor
       rails (>= 6.0.0)
 


### PR DESCRIPTION
Since Pagy 9 is already stable, it would be great to be able to use it in the projects.

The current bullet-train code works fine with version 9 and does not require any changes.

The only problem (not related to bullet-train) is that the `pagy_cursor` gem currently has no official support for Pagy 9.x, but this can be solved by using an unofficial fork, for example [this](https://github.com/clickfunnels2/pagy-cursor).

This means we can't just bump the pagy gem to `pagy (~> 9)`, but this PR **allows** you to use the 9.x version if you really want to.

--- 
Related issues: [BT issue](https://github.com/bullet-train-co/bullet_train-core/issues/1083), [pagy-cursor issue](https://github.com/Uysim/pagy-cursor/issues/68)