### PR TITLE
Add a test for `obfuscates_id`

### DIFF
--- a/bullet_train-obfuscates_id/test/models/obfuscates_id_concern_test.rb
+++ b/bullet_train-obfuscates_id/test/models/obfuscates_id_concern_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+# These are basic defensive tests that will let us know if we accidentally change
+# the obfuscation method, which would break any links that people have in the wild.
+# If you encounter a failure in these tests you probably DO NOT want to change the
+# test to fix it. You most likely want to undo whatever change that cause them to
+# start failing. Yes, we are basically testing the implementation here, because it's
+# important that we maintain the same implementation over time.
+class FakeModel
+  include ObfuscatesId
+
+  def id
+    42
+  end
+
+  def expected_obfuscated_id
+    "WjmmMj"
+  end
+end
+
+class BulletTrain::ObfuscatesIdConcernTest < ActiveSupport::TestCase
+  test "FakeModel has an id" do
+    fake_model = FakeModel.new
+    assert_equal 42, fake_model.id
+  end
+
+  test "FakeModel has a stable obfuscated_id" do
+    fake_model = FakeModel.new
+    assert_equal fake_model.expected_obfuscated_id, fake_model.obfuscated_id
+  end
+
+  test "FakeModel can accurately decode an id" do
+    fake_model = FakeModel.new
+    assert_equal fake_model.id, FakeModel.decode_id(fake_model.expected_obfuscated_id)
+  end
+end


### PR DESCRIPTION
This is a basic stability test that will prevent us from accidentally changing the obfuscation/decoding method.

Fixes https://github.com/bullet-train-co/bullet_train-core/issues/1084