### PR TITLE
Remove `pagy_cursor`

### DIFF
--- a/bullet_train-api/Gemfile.lock
+++ b/bullet_train-api/Gemfile.lock
@@ -87,7 +87,6 @@ PATH
       factory_bot
       jbuilder-schema (~> 2.6.6)
       pagy (~> 8)
-      pagy_cursor
       rails (>= 6.0.0)
 
 GEM
@@ -294,9 +293,6 @@ GEM
     orm_adapter (0.5.0)
     ostruct (0.6.1)
     pagy (8.6.3)
-    pagy_cursor (0.8.0)
-      activerecord (>= 5)
-      pagy (>= 6, < 9)
     parallel (1.26.3)
     parser (3.3.7.4)
       ast (~> 2.4.1)

--- a/bullet_train-api/app/controllers/concerns/api/controllers/base.rb
+++ b/bullet_train-api/app/controllers/concerns/api/controllers/base.rb
@@ -42,7 +42,7 @@ module Api::Controllers::Base
     end
 
     def last_id_in_collection
-      @last_id_in_collection ||= collection&.any? ? collection.last&.id : nil
+      @last_id_in_collection ||= collection&.last&.id
     end
 
     rescue_from CanCan::AccessDenied, ActiveRecord::RecordNotFound do |exception|

--- a/bullet_train-api/app/controllers/concerns/api/controllers/base.rb
+++ b/bullet_train-api/app/controllers/concerns/api/controllers/base.rb
@@ -110,12 +110,12 @@ module Api::Controllers::Base
   end
 
   def apply_pagination
-    _collection = collection.order(id: :asc)
+    pagination_collection = collection.order(id: :asc)
     if params[:after]
-      _collection = _collection.where("id > ?", params[:after])
+      pagination_collection = pagination_collection.where("id > ?", params[:after])
     end
-    @pagy, _collection = pagy(_collection)
-    self.collection = _collection
+    @pagy, pagination_collection = pagy(pagination_collection)
+    self.collection = pagination_collection
   end
 
   def set_default_response_format

--- a/bullet_train-api/app/controllers/concerns/api/controllers/base.rb
+++ b/bullet_train-api/app/controllers/concerns/api/controllers/base.rb
@@ -43,9 +43,10 @@ module Api::Controllers::Base
 
     def collection_has_more?
       collection = instance_variable_get(collection_variable)
-      return false unless collection.any?
-      last_id = collection.last.id
-      remaining_collection = @unpaginated_collection.order(id: :asc).where("id > ?", last_id)
+      return false unless collection&.any?
+      last_id = collection.last&.id
+      return false unless last_id
+      remaining_collection = collection.limit(nil).order(id: :asc).where("id > ?", last_id)
       remaining_collection.any?
     end
 
@@ -106,7 +107,6 @@ module Api::Controllers::Base
 
   def apply_pagination
     collection = instance_variable_get(collection_variable).order(id: :asc)
-    @unpaginated_collection = collection
     if params[:after]
       collection = collection.where("id > ?", params[:after])
     end

--- a/bullet_train-api/app/controllers/concerns/api/controllers/base.rb
+++ b/bullet_train-api/app/controllers/concerns/api/controllers/base.rb
@@ -104,13 +104,12 @@ module Api::Controllers::Base
   end
 
   def apply_pagination
-    collection = instance_variable_get collection_variable
+    collection = instance_variable_get(collection_variable).order(id: :asc)
     @unpaginated_collection = collection
-    collection = collection.order(id: :asc)
     if params[:after]
       collection = collection.where("id > ?", params[:after])
     end
-    @pagy, collection = pagy collection
+    @pagy, collection = pagy(collection)
     instance_variable_set collection_variable, collection
   end
 

--- a/bullet_train-api/app/controllers/concerns/api/controllers/base.rb
+++ b/bullet_train-api/app/controllers/concerns/api/controllers/base.rb
@@ -104,13 +104,18 @@ module Api::Controllers::Base
     @collection ||= instance_variable_get(collection_variable)
   end
 
+  def collection=(new_collection)
+    @collection = new_collection
+    instance_variable_set collection_variable, new_collection
+  end
+
   def apply_pagination
-    collection = instance_variable_get(collection_variable).order(id: :asc)
+    _collection = collection.order(id: :asc)
     if params[:after]
-      collection = collection.where("id > ?", params[:after])
+      _collection = _collection.where("id > ?", params[:after])
     end
-    @pagy, collection = pagy(collection)
-    instance_variable_set collection_variable, collection
+    @pagy, _collection = pagy(_collection)
+    self.collection = _collection
   end
 
   def set_default_response_format

--- a/bullet_train-api/app/controllers/concerns/api/controllers/base.rb
+++ b/bullet_train-api/app/controllers/concerns/api/controllers/base.rb
@@ -43,6 +43,7 @@ module Api::Controllers::Base
 
     def collection_has_more?
       collection = instance_variable_get(collection_variable)
+      return false unless collection.any?
       last_id = collection.last.id
       remaining_collection = @unpaginated_collection.order(id: :asc).where("id > ?", last_id)
       remaining_collection.any?

--- a/bullet_train-api/bullet_train-api.gemspec
+++ b/bullet_train-api/bullet_train-api.gemspec
@@ -39,7 +39,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails", ">= 6.0.0"
   spec.add_dependency "pagy", "~> 8"
-  spec.add_dependency "pagy_cursor"
   spec.add_dependency "doorkeeper"
   spec.add_dependency "jbuilder-schema", "~> 2.6.6"
   spec.add_dependency "factory_bot"

--- a/bullet_train-api/lib/bullet_train/api.rb
+++ b/bullet_train-api/lib/bullet_train/api.rb
@@ -7,7 +7,6 @@ require "bullet_train/platform/connection_workflow"
 
 # require "wine_bouncer"
 require "pagy"
-require "pagy_cursor"
 require "doorkeeper"
 require "scaffolding"
 require "scaffolding/block_manipulator"

--- a/bullet_train-fields/Gemfile.lock
+++ b/bullet_train-fields/Gemfile.lock
@@ -8,7 +8,6 @@ PATH
       factory_bot
       jbuilder-schema (~> 2.6.6)
       pagy (~> 8)
-      pagy_cursor
       rails (>= 6.0.0)
 
 PATH
@@ -303,9 +302,6 @@ GEM
     orm_adapter (0.5.0)
     ostruct (0.6.1)
     pagy (8.6.3)
-    pagy_cursor (0.8.0)
-      activerecord (>= 5)
-      pagy (>= 6, < 9)
     parallel (1.26.3)
     parser (3.3.7.4)
       ast (~> 2.4.1)

--- a/bullet_train-incoming_webhooks/Gemfile.lock
+++ b/bullet_train-incoming_webhooks/Gemfile.lock
@@ -8,7 +8,6 @@ PATH
       factory_bot
       jbuilder-schema (~> 2.6.6)
       pagy (~> 8)
-      pagy_cursor
       rails (>= 6.0.0)
 
 PATH
@@ -303,9 +302,6 @@ GEM
     orm_adapter (0.5.0)
     ostruct (0.6.1)
     pagy (8.6.3)
-    pagy_cursor (0.8.0)
-      activerecord (>= 5)
-      pagy (>= 6, < 9)
     pg (1.5.9)
     phonelib (0.10.6)
     possessive (1.0.1)

--- a/bullet_train-integrations-stripe/Gemfile.lock
+++ b/bullet_train-integrations-stripe/Gemfile.lock
@@ -8,7 +8,6 @@ PATH
       factory_bot
       jbuilder-schema (~> 2.6.6)
       pagy (~> 8)
-      pagy_cursor
       rails (>= 6.0.0)
 
 PATH
@@ -330,9 +329,6 @@ GEM
     orm_adapter (0.5.0)
     ostruct (0.6.1)
     pagy (8.6.3)
-    pagy_cursor (0.8.0)
-      activerecord (>= 5)
-      pagy (>= 6, < 9)
     phonelib (0.10.6)
     possessive (1.0.1)
     pp (0.6.2)

--- a/bullet_train-outgoing_webhooks/Gemfile.lock
+++ b/bullet_train-outgoing_webhooks/Gemfile.lock
@@ -8,7 +8,6 @@ PATH
       factory_bot
       jbuilder-schema (~> 2.6.6)
       pagy (~> 8)
-      pagy_cursor
       rails (>= 6.0.0)
 
 PATH
@@ -301,9 +300,6 @@ GEM
     orm_adapter (0.5.0)
     ostruct (0.6.1)
     pagy (8.6.3)
-    pagy_cursor (0.8.0)
-      activerecord (>= 5)
-      pagy (>= 6, < 9)
     parallel (1.26.3)
     parser (3.3.7.4)
       ast (~> 2.4.1)

--- a/bullet_train-sortable/Gemfile.lock
+++ b/bullet_train-sortable/Gemfile.lock
@@ -8,7 +8,6 @@ PATH
       factory_bot
       jbuilder-schema (~> 2.6.6)
       pagy (~> 8)
-      pagy_cursor
       rails (>= 6.0.0)
 
 PATH
@@ -300,9 +299,6 @@ GEM
     orm_adapter (0.5.0)
     ostruct (0.6.1)
     pagy (8.6.3)
-    pagy_cursor (0.8.0)
-      activerecord (>= 5)
-      pagy (>= 6, < 9)
     parallel (1.26.3)
     parser (3.3.7.4)
       ast (~> 2.4.1)

--- a/bullet_train-super_scaffolding/Gemfile.lock
+++ b/bullet_train-super_scaffolding/Gemfile.lock
@@ -8,7 +8,6 @@ PATH
       factory_bot
       jbuilder-schema (~> 2.6.6)
       pagy (~> 8)
-      pagy_cursor
       rails (>= 6.0.0)
 
 PATH
@@ -294,9 +293,6 @@ GEM
     orm_adapter (0.5.0)
     ostruct (0.6.1)
     pagy (8.6.3)
-    pagy_cursor (0.8.0)
-      activerecord (>= 5)
-      pagy (>= 6, < 9)
     parallel (1.26.3)
     parser (3.3.7.4)
       ast (~> 2.4.1)

--- a/bullet_train-themes-light/Gemfile.lock
+++ b/bullet_train-themes-light/Gemfile.lock
@@ -8,7 +8,6 @@ PATH
       factory_bot
       jbuilder-schema (~> 2.6.6)
       pagy (~> 8)
-      pagy_cursor
       rails (>= 6.0.0)
 
 PATH
@@ -309,9 +308,6 @@ GEM
     orm_adapter (0.5.0)
     ostruct (0.6.1)
     pagy (8.6.3)
-    pagy_cursor (0.8.0)
-      activerecord (>= 5)
-      pagy (>= 6, < 9)
     parallel (1.26.3)
     parser (3.3.7.4)
       ast (~> 2.4.1)

--- a/bullet_train-themes-tailwind_css/Gemfile.lock
+++ b/bullet_train-themes-tailwind_css/Gemfile.lock
@@ -8,7 +8,6 @@ PATH
       factory_bot
       jbuilder-schema (~> 2.6.6)
       pagy (~> 8)
-      pagy_cursor
       rails (>= 6.0.0)
 
 PATH
@@ -301,9 +300,6 @@ GEM
     orm_adapter (0.5.0)
     ostruct (0.6.1)
     pagy (8.6.3)
-    pagy_cursor (0.8.0)
-      activerecord (>= 5)
-      pagy (>= 6, < 9)
     parallel (1.26.3)
     parser (3.3.7.4)
       ast (~> 2.4.1)

--- a/bullet_train-themes/Gemfile.lock
+++ b/bullet_train-themes/Gemfile.lock
@@ -8,7 +8,6 @@ PATH
       factory_bot
       jbuilder-schema (~> 2.6.6)
       pagy (~> 8)
-      pagy_cursor
       rails (>= 6.0.0)
 
 PATH
@@ -297,9 +296,6 @@ GEM
     orm_adapter (0.5.0)
     ostruct (0.6.1)
     pagy (8.6.3)
-    pagy_cursor (0.8.0)
-      activerecord (>= 5)
-      pagy (>= 6, < 9)
     parallel (1.26.3)
     parser (3.3.7.4)
       ast (~> 2.4.1)

--- a/bullet_train/Gemfile.lock
+++ b/bullet_train/Gemfile.lock
@@ -8,7 +8,6 @@ PATH
       factory_bot
       jbuilder-schema (~> 2.6.6)
       pagy (~> 8)
-      pagy_cursor
       rails (>= 6.0.0)
 
 PATH
@@ -319,9 +318,6 @@ GEM
     orm_adapter (0.5.0)
     ostruct (0.6.1)
     pagy (8.6.3)
-    pagy_cursor (0.8.0)
-      activerecord (>= 5)
-      pagy (>= 6, < 9)
     parallel (1.26.3)
     parser (3.3.7.4)
       ast (~> 2.4.1)


### PR DESCRIPTION
This is the simplest thing I could get to work for removing `pagy_cursor`. Luckily we seem to only use it for one feature, which is an `after` filter. That filter only seems to be used by API clients, and is not used via the UI (we use the standard `page` for `pagy` there). I don't personally use the API in BT for anything, so I'm not sure if there are subtleties in there that I'm missing.

I previously added a test for pagination here: https://github.com/bullet-train-co/bullet_train-core/pull/1131/files