### PR TITLE
Webhook signature verification mechanism

### DIFF
--- a/bullet_train-outgoing_webhooks/Gemfile
+++ b/bullet_train-outgoing_webhooks/Gemfile
@@ -22,7 +22,5 @@ gem "bullet_train-themes", path: "../bullet_train-themes"
 
 group :test do
   gem "minitest-reporters"
+  gem "webmock"
 end
-
-# Start debugger with binding.b [https://github.com/ruby/debug]
-# gem "debug", ">= 1.0.0"

--- a/bullet_train-outgoing_webhooks/Gemfile.lock
+++ b/bullet_train-outgoing_webhooks/Gemfile.lock
@@ -173,6 +173,8 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     ansi (1.5.0)
     ast (2.4.3)
     base64 (0.2.0)
@@ -199,6 +201,9 @@ GEM
     commonmarker (2.2.0-x86_64-linux)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
+    crack (1.0.0)
+      bigdecimal
+      rexml
     crass (1.0.6)
     date (3.4.1)
     devise (4.9.4)
@@ -232,6 +237,7 @@ GEM
       thor (>= 0.14.0, < 2)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashdiff (1.2.0)
     hashie (5.0.0)
     http_accept_language (2.1.1)
     i18n (1.14.7)
@@ -372,6 +378,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rexml (3.4.1)
     rubocop (1.73.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -434,6 +441,10 @@ GEM
     useragent (0.16.11)
     warden (1.2.9)
       rack (>= 2.0.9)
+    webmock (3.25.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.7)
       base64
       websocket-extensions (>= 0.1.0)
@@ -464,6 +475,7 @@ DEPENDENCIES
   sprockets-rails
   sqlite3
   standard
+  webmock
 
 BUNDLED WITH
    2.6.2

--- a/bullet_train-outgoing_webhooks/app/controllers/account/webhooks/outgoing/endpoints_controller.rb
+++ b/bullet_train-outgoing_webhooks/app/controllers/account/webhooks/outgoing/endpoints_controller.rb
@@ -60,6 +60,19 @@ class Account::Webhooks::Outgoing::EndpointsController < Account::ApplicationCon
     end
   end
 
+  # POST /account/webhooks/outgoing/endpoints/:id/rotate_secret
+  def rotate_secret
+    @endpoint ||= Webhooks::Outgoing::Endpoint.accessible_by(current_ability).find(params[:id])
+
+    respond_to do |format|
+      if @endpoint.rotate_webhook_secret!
+        format.html { redirect_to [:account, @endpoint], notice: I18n.t("webhooks/outgoing/endpoints.notifications.secret_rotated") }
+      else
+        format.html { render :show, status: :unprocessable_entity }
+      end
+    end
+  end
+
   private
 
   # Never trust parameters from the scary internet, only allow the white list through.

--- a/bullet_train-outgoing_webhooks/app/controllers/concerns/api/v1/webhooks/outgoing/endpoints/controller_base.rb
+++ b/bullet_train-outgoing_webhooks/app/controllers/concerns/api/v1/webhooks/outgoing/endpoints/controller_base.rb
@@ -43,6 +43,9 @@ module Api::V1::Webhooks::Outgoing::Endpoints::ControllerBase
   # POST /api/v1/teams/:team_id/webhooks/outgoing/endpoints
   def create
     if @endpoint.save
+      # Set instance variable to indicate this is a newly created endpoint.
+      # This will be used in the Jbuilder template to determine whether to include the webhook_secret.
+      @newly_created_endpoint = true
       render :show, status: :created, location: [:api, :v1, @endpoint]
     else
       render json: @endpoint.errors, status: :unprocessable_entity

--- a/bullet_train-outgoing_webhooks/app/models/concerns/webhooks/outgoing/delivery_attempt_support.rb
+++ b/bullet_train-outgoing_webhooks/app/models/concerns/webhooks/outgoing/delivery_attempt_support.rb
@@ -59,10 +59,22 @@ module Webhooks::Outgoing::DeliveryAttemptSupport
         http.verify_mode = BulletTrain::OutgoingWebhooks.http_verify_mode
       end
     end
+
     request = Net::HTTP::Post.new(uri.request_uri)
     request.add_field("Host", uri.host)
     request.add_field("Content-Type", "application/json")
-    request.body = delivery.event.payload.to_json
+
+    # Generate and add signature headers
+    payload = delivery.event.payload
+    signature_data = BulletTrain::OutgoingWebhooks::SignatureVerification
+      .generate_signature(payload, delivery.endpoint.webhook_secret)
+
+    webhook_headers_namespace = Rails.configuration.outgoing_webhooks[:webhook_headers_namespace]
+    request.add_field("#{webhook_headers_namespace}-Signature", signature_data[:signature])
+    request.add_field("#{webhook_headers_namespace}-Timestamp", signature_data[:timestamp])
+    request.add_field("#{webhook_headers_namespace}-Id", delivery.event.uuid)
+
+    request.body = payload.to_json
 
     begin
       response = http.request(request)

--- a/bullet_train-outgoing_webhooks/app/models/concerns/webhooks/outgoing/endpoint_support.rb
+++ b/bullet_train-outgoing_webhooks/app/models/concerns/webhooks/outgoing/endpoint_support.rb
@@ -14,8 +14,10 @@ module Webhooks::Outgoing::EndpointSupport
     validates :name, presence: true
 
     before_validation { url&.strip! }
+    before_validation :generate_webhook_secret, on: :create
 
     validates :url, presence: true, allowed_uri: BulletTrain::OutgoingWebhooks.advanced_hostname_security
+    validates :webhook_secret, presence: true
 
     after_initialize do
       self.event_type_ids ||= []
@@ -39,5 +41,13 @@ module Webhooks::Outgoing::EndpointSupport
 
   def touch_parent
     send(BulletTrain::OutgoingWebhooks.parent_association).touch
+  end
+
+  def generate_webhook_secret
+    self.webhook_secret ||= SecureRandom.hex(32)
+  end
+
+  def rotate_webhook_secret!
+    update(webhook_secret: SecureRandom.hex(32))
   end
 end

--- a/bullet_train-outgoing_webhooks/app/views/account/webhooks/outgoing/endpoints/_form.html.erb
+++ b/bullet_train-outgoing_webhooks/app/views/account/webhooks/outgoing/endpoints/_form.html.erb
@@ -11,8 +11,16 @@
       choices: @endpoint.valid_event_types.map { |event_type| [event_type.label_string, event_type.id] } %>
     <%= render 'shared/fields/super_select', method: :scaffolding_absolutely_abstract_creative_concept_id,
       choices: [['None', '']] + @endpoint.creative_concepts.map { |event_type| [event_type.name, event_type.id] }, other_options: {search: true} %>
+
+    <% if endpoint.persisted? %>
+    <br>
+    <%= t('.fields.webhook_secret.label') %>
+    <br>
+      <%= "#{endpoint.webhook_secret[0..5]}#{t('.fields.webhook_secret.truncation_with_instructions')}" %>
+    <% end %>
     <%# 🚅 super scaffolding will insert new fields above this line. %>
   <% end %>
+
 
   <div class="buttons">
     <%= form.submit (form.object.persisted? ? t('.buttons.update') : t('.buttons.create')), class: "button" %>
@@ -23,4 +31,13 @@
     <% end %>
   </div>
 
+<% end %>
+
+<% if endpoint.persisted? %>
+  <%=
+    button_to t('.buttons.rotate_secret'),
+      rotate_secret_account_webhooks_outgoing_endpoint_path(endpoint),
+      method: :post, class: "button-secondary",
+      data: { confirm: t('.buttons.confirmations.rotate_secret', model_locales(@endpoint)) }
+  %>
 <% end %>

--- a/bullet_train-outgoing_webhooks/app/views/account/webhooks/outgoing/endpoints/_index.html.erb
+++ b/bullet_train-outgoing_webhooks/app/views/account/webhooks/outgoing/endpoints/_index.html.erb
@@ -15,6 +15,7 @@
           <tr>
             <th><%= t('.fields.name.heading') %></th>
             <th><%= t('.fields.url.heading') %></th>
+            <th><%= t('.fields.webhook_secret.heading') %></th>
             <%# 🚅 super scaffolding will insert new field headers above this line. %>
             <th class="text-right"></th>
           </tr>
@@ -25,6 +26,7 @@
               <tr data-id="<%= endpoint.id %>">
                 <td><%= render 'shared/attributes/text', attribute: :name, url: [:account, endpoint] %></td>
                 <td><%= render 'shared/attributes/code', attribute: :url %></td>
+                <td><%= render 'shared/attributes/code', attribute: :webhook_secret, secret: true %></td>
                 <%# 🚅 super scaffolding will insert new fields above this line. %>
                 <td class="buttons">
                   <% unless hide_actions %>

--- a/bullet_train-outgoing_webhooks/app/views/account/webhooks/outgoing/endpoints/show.html.erb
+++ b/bullet_train-outgoing_webhooks/app/views/account/webhooks/outgoing/endpoints/show.html.erb
@@ -28,6 +28,7 @@
           <% end %>
 
           <%= render 'shared/attributes/belongs_to', attribute: :scaffolding_absolutely_abstract_creative_concept %>
+          <%= render 'shared/attributes/code', attribute: :webhook_secret, secret: true %>
           <%# 🚅 super scaffolding will insert new fields above this line. %>
         <% end %>
       <% end %>
@@ -36,6 +37,14 @@
         <%= link_to t('.buttons.edit'), [:edit, :account, @endpoint], class: first_button_primary if can? :edit, @endpoint %>
         <%= button_to t('.buttons.destroy'), [:account, @endpoint], method: :delete, class: first_button_primary, data: { turbo_confirm: t('.buttons.confirmations.destroy', model_locales(@endpoint)) } if can? :destroy, @endpoint %>
         <%= link_to t('global.buttons.back'), [:account, @parent, :webhooks_outgoing_endpoints], class: first_button_primary %>
+        <% if can? :edit, @endpoint %>
+          <%=
+            button_to t('.buttons.rotate_secret'),
+              rotate_secret_account_webhooks_outgoing_endpoint_path(@endpoint),
+              method: :post, class: first_button_primary,
+              data: { turbo_confirm: t('.buttons.confirmations.rotate_secret', model_locales(@endpoint)) }
+          %>
+        <% end %>
       <% end %>
     <% end %>
 

--- a/bullet_train-outgoing_webhooks/app/views/api/v1/webhooks/outgoing/endpoints/_endpoint.json.jbuilder
+++ b/bullet_train-outgoing_webhooks/app/views/api/v1/webhooks/outgoing/endpoints/_endpoint.json.jbuilder
@@ -7,3 +7,8 @@ json.extract! endpoint,
   # 🚅 super scaffolding will insert new fields above this line.
   :created_at,
   :updated_at
+
+# Avoid spilling secrets via the API. We still need to show it once on create so
+# endpoints created programmaticly via the API can save it and use it to verify
+# the signature.
+json.webhook_secret endpoint.webhook_secret if defined?(@newly_created_endpoint) && @newly_created_endpoint

--- a/bullet_train-outgoing_webhooks/config/locales/en/webhooks/outgoing/endpoints.en.yml
+++ b/bullet_train-outgoing_webhooks/config/locales/en/webhooks/outgoing/endpoints.en.yml
@@ -12,12 +12,15 @@ en:
       edit: Edit Settings
       update: Update Endpoint
       destroy: Remove Endpoint
+      rotate_secret: Rotate Secret
       shorthand:
         edit: Settings
         destroy: Delete
       confirmations:
-        # TODO customize for your use-case.
         destroy: Are you sure you want to remove %{endpoint_name}? This will also remove it's associated data. This can't be undone.
+        rotate_secret: >
+          Are you sure you want to rotate the secret of the endpoint %{endpoint_name}?
+          Your webhook event verification system will need to start handling the new secret.
     fields: &fields
       id:
         _: &id Endpoint ID
@@ -74,6 +77,15 @@ en:
 
       scaffolding_absolutely_abstract_creative_concept: *scaffolding_absolutely_abstract_creative_concept
 
+      webhook_secret:
+        _: &webhook_secret Webhook Secret
+        label: *webhook_secret
+        heading: *webhook_secret
+        api_description: |
+          Each webhook endpoint has a rollable secret. If you create your endpoints programmatically
+          via the API, the secret is only shown after creating the endpoint. If you missed to store
+          it, you will need to look it up on the app's UI endpoint show or index pages.
+        truncation_with_instructions: ... (use button below to rotate)
       # 🚅 super scaffolding will insert new fields above this line.
       created_at:
         _: &created_at Added
@@ -130,6 +142,7 @@ en:
       created: Endpoint was successfully created.
       updated: Endpoint was successfully updated.
       destroyed: Endpoint was successfully destroyed.
+      secret_rotated: Endpoint's webhook secret successfully rotated.
   account:
     webhooks:
       outgoing:
@@ -142,6 +155,7 @@ en:
         api_version: *api_version
         event_type_ids: *event_type_ids
         scaffolding_absolutely_abstract_creative_concept_id: *scaffolding_absolutely_abstract_creative_concept_id
+        webhook_secret: *webhook_secret
         # 🚅 super scaffolding will insert new activerecord attributes above this line.
         created_at: *created_at
         updated_at: *updated_at

--- a/bullet_train-outgoing_webhooks/config/routes.rb
+++ b/bullet_train-outgoing_webhooks/config/routes.rb
@@ -10,6 +10,10 @@ Rails.application.routes.draw do
               resources :deliveries, only: %i[index show] do
                 resources :delivery_attempts, only: %i[index show]
               end
+
+              member do
+                post :rotate_secret
+              end
             end
           end
         end

--- a/bullet_train-outgoing_webhooks/lib/bullet_train/outgoing_webhooks.rb
+++ b/bullet_train-outgoing_webhooks/lib/bullet_train/outgoing_webhooks.rb
@@ -1,5 +1,6 @@
 require "bullet_train/outgoing_webhooks/version"
 require "bullet_train/outgoing_webhooks/engine"
+require "bullet_train/outgoing_webhooks/signature_verification"
 
 module BulletTrain
   module OutgoingWebhooks

--- a/bullet_train-outgoing_webhooks/lib/bullet_train/outgoing_webhooks/engine.rb
+++ b/bullet_train-outgoing_webhooks/lib/bullet_train/outgoing_webhooks/engine.rb
@@ -22,7 +22,9 @@ module BulletTrain
           allowed_schemes: %w[http https],
           custom_block_callback: nil,
           custom_allow_callback: nil,
-          audit_callback: ->(obj, uri) { Rails.logger.error("BlockedURI obj=#{obj.persisted? ? obj.to_global_id : "New #{obj.class}"} uri=#{uri}") }
+          audit_callback: ->(obj, uri) { Rails.logger.error("BlockedURI obj=#{obj.persisted? ? obj.to_global_id : "New #{obj.class}"} uri=#{uri}") },
+          webhook_headers_namespace: "X-Bullet-Train-Webhook",
+          event_verification_tolerance_seconds: 600 # 5-10 minutes is industry-default.
         }
       end
     end

--- a/bullet_train-outgoing_webhooks/lib/bullet_train/outgoing_webhooks/signature_verification.rb
+++ b/bullet_train-outgoing_webhooks/lib/bullet_train/outgoing_webhooks/signature_verification.rb
@@ -1,0 +1,68 @@
+module BulletTrain
+  module OutgoingWebhooks
+    # Provides methods for webhook signatures. This module also serves as an
+    # example that can be used by receiving applications to verify webhook
+    # authenticity.
+    module SignatureVerification
+      # Verifies the authenticity of a webhook request.
+      #
+      # @param payload [String] The raw request body as a string.
+      # @param timestamp [String] The timestamp from the Timestamp request header.
+      # @param signature [String] The signature from the Signature request header.
+      # @param secret [String] The webhook secret attached to the endpoint the event comes from.
+      # @return [Boolean] True if the signature is valid, false otherwise.
+      def self.verify_signature(payload, signature, timestamp, secret)
+        return false if payload.blank? || signature.blank? || timestamp.blank? || secret.blank?
+
+        tolerance = Rails.configuration.outgoing_webhooks[:event_verification_tolerance_seconds]
+        # Check if the timestamp is too old
+        timestamp_int = timestamp.to_i
+        now = Time.now.to_i
+
+        if (now - timestamp_int).abs > tolerance
+          return false # Webhook is too old or timestamp is from the future
+        end
+
+        # Compute the expected signature
+        signature_payload = "#{timestamp}.#{payload}"
+        expected_signature = OpenSSL::HMAC.hexdigest("SHA256", secret, signature_payload)
+
+        # Compare signatures using constant-time comparison to prevent timing attacks
+        ActiveSupport::SecurityUtils.secure_compare(expected_signature, signature)
+      end
+
+      # A Rails controller helper example to verify webhook requests.
+      #
+      # @param request [ActionDispatch::Request] The Rails request object.
+      # @param secret [String] The webhook secret shared with the sender.
+      # @return [Boolean] True if the signature is valid, false otherwise.
+      def self.verify_request(request, secret)
+        return false if request.blank? || secret.blank?
+
+        webhook_headers_namespace = Rails.configuration.outgoing_webhooks[:webhook_headers_namespace]
+        signature = request.headers["#{webhook_headers_namespace}-Signature"]
+        timestamp = request.headers["#{webhook_headers_namespace}-Timestamp"]
+        payload = request.raw_post
+
+        return false if signature.blank? || timestamp.blank?
+
+        verify_signature(payload, signature, timestamp, secret)
+      end
+
+      # Algorithm to generate the signature.
+      #
+      # @payload [Hash] The payload to be encoded into a signature.
+      # @secret [String] The secret stored on each webhook endpoint.
+      def self.generate_signature(payload, secret)
+        timestamp = Time.now.to_i.to_s
+        signature_payload = "#{timestamp}.#{payload.to_json}"
+        signature = OpenSSL::HMAC.hexdigest("SHA256", secret, signature_payload)
+
+        {
+          signature: signature,
+          timestamp: timestamp
+        }
+      end
+    end
+  end
+end

--- a/bullet_train-outgoing_webhooks/test/dummy/db/migrate/20250527133852_add_webhook_secret_to_webhooks_outgoing_endpoints.rb
+++ b/bullet_train-outgoing_webhooks/test/dummy/db/migrate/20250527133852_add_webhook_secret_to_webhooks_outgoing_endpoints.rb
@@ -1,0 +1,5 @@
+class AddWebhookSecretToWebhooksOutgoingEndpoints < ActiveRecord::Migration[8.0]
+  def change
+    add_column :webhooks_outgoing_endpoints, :webhook_secret, :string, null: false
+  end
+end

--- a/bullet_train-outgoing_webhooks/test/dummy/db/schema.rb
+++ b/bullet_train-outgoing_webhooks/test/dummy/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_31_003438) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_27_133852) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension "pg_catalog.plpgsql"
 
   create_table "bullet_train_webhooks", force: :cascade do |t|
     t.jsonb "data"
@@ -92,6 +92,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_31_003438) do
     t.jsonb "event_type_ids", default: []
     t.bigint "scaffolding_absolutely_abstract_creative_concept_id"
     t.integer "api_version", null: false
+    t.string "webhook_secret", null: false
     t.index ["scaffolding_absolutely_abstract_creative_concept_id"], name: "index_endpoints_on_abstract_creative_concept_id"
     t.index ["team_id"], name: "index_webhooks_outgoing_endpoints_on_team_id"
   end

--- a/bullet_train-outgoing_webhooks/test/lib/bullet_train/outgoing_webhooks/signature_verification_test.rb
+++ b/bullet_train-outgoing_webhooks/test/lib/bullet_train/outgoing_webhooks/signature_verification_test.rb
@@ -37,7 +37,7 @@ class BulletTrain::OutgoingWebhooks::SignatureVerificationTest < ActiveSupport::
   end
 
   test "#verify_signature returns false for invalid signatures" do
-    invalid_signature = "invalid" + @valid_signature[7..-1]
+    invalid_signature = "invalid" + @valid_signature[7..]
 
     result = BulletTrain::OutgoingWebhooks::SignatureVerification.verify_signature(
       @payload,

--- a/bullet_train-outgoing_webhooks/test/lib/bullet_train/outgoing_webhooks/signature_verification_test.rb
+++ b/bullet_train-outgoing_webhooks/test/lib/bullet_train/outgoing_webhooks/signature_verification_test.rb
@@ -1,0 +1,154 @@
+require "test_helper"
+
+class BulletTrain::OutgoingWebhooks::SignatureVerificationTest < ActiveSupport::TestCase
+  setup do
+    @secret = "test-webhook-secret"
+    payload_hash = {"test" => "data"}
+    @payload = payload_hash.to_json
+
+    signature_data = BulletTrain::OutgoingWebhooks::SignatureVerification.generate_signature(
+      payload_hash,
+      @secret
+    )
+    @valid_signature = signature_data[:signature]
+    @timestamp = signature_data[:timestamp]
+  end
+
+  test "#verify_signature returns true for valid signatures" do
+    result = BulletTrain::OutgoingWebhooks::SignatureVerification.verify_signature(
+      @payload,
+      @valid_signature,
+      @timestamp,
+      @secret
+    )
+
+    assert result, "Should return true for valid signature"
+  end
+
+  test "#verify_signature returns false for wrong webhook secret" do
+    result = BulletTrain::OutgoingWebhooks::SignatureVerification.verify_signature(
+      @payload,
+      @valid_signature,
+      @timestamp,
+      "making-this-up"
+    )
+
+    assert_not result, "Should return false for wrong webhook secret"
+  end
+
+  test "#verify_signature returns false for invalid signatures" do
+    invalid_signature = "invalid" + @valid_signature[7..-1]
+
+    result = BulletTrain::OutgoingWebhooks::SignatureVerification.verify_signature(
+      @payload,
+      invalid_signature,
+      @timestamp,
+      @secret
+    )
+
+    assert_not result, "Should return false for invalid signature"
+  end
+
+  test "#verify_signature returns false for empty string signatures" do
+    invalid_signature = ""
+
+    result = BulletTrain::OutgoingWebhooks::SignatureVerification.verify_signature(
+      @payload,
+      invalid_signature,
+      @timestamp,
+      @secret
+    )
+
+    assert_not result, "Should return false for empty string signature"
+  end
+
+  test "#verify_signature returns false for nil signatures" do
+    invalid_signature = nil
+
+    result = BulletTrain::OutgoingWebhooks::SignatureVerification.verify_signature(
+      @payload,
+      invalid_signature,
+      @timestamp,
+      @secret
+    )
+
+    assert_not result, "Should return false for nil signature"
+  end
+
+  test "#verify_signature returns false for expired timestamps" do
+    tolerance_seconds = Rails.configuration.outgoing_webhooks[:event_verification_tolerance_seconds]
+    result = BulletTrain::OutgoingWebhooks::SignatureVerification.verify_signature(
+      @payload,
+      @valid_signature,
+      (tolerance_seconds + 5.seconds).from_now.to_i,
+      @secret
+    )
+    assert_not result, "Should return false for expired timestamps"
+  end
+
+  test "#verify_signature returns false for future timestamps" do
+    tolerance_seconds = Rails.configuration.outgoing_webhooks[:event_verification_tolerance_seconds]
+    result = BulletTrain::OutgoingWebhooks::SignatureVerification.verify_signature(
+      @payload,
+      @valid_signature,
+      (tolerance_seconds + 5.seconds).ago.to_i,
+      @secret
+    )
+    assert_not result, "Should return false for future timestamps"
+  end
+
+  test "#verify_request verifies a request's signature" do
+    mock_request = Struct.new(:headers, :raw_post).new(
+      {
+        "X-Bullet-Train-Webhook-Signature" => @valid_signature,
+        "X-Bullet-Train-Webhook-Timestamp" => @timestamp
+      },
+      @payload
+    )
+
+    result = BulletTrain::OutgoingWebhooks::SignatureVerification.verify_request(
+      mock_request,
+      @secret
+    )
+
+    assert result, "Should verify valid request"
+  end
+
+  test "verify_request returns false with missing headers" do
+    mock_request = Struct.new(:headers, :raw_post).new(
+      {
+        # Missing required headers
+      },
+      @payload
+    )
+
+    result = BulletTrain::OutgoingWebhooks::SignatureVerification.verify_request(
+      mock_request,
+      @secret
+    )
+
+    assert_not result, "Should fail with missing headers"
+  end
+
+  test "#generate_signature generates a valid signature that can be verified" do
+    payload_hash = {"test" => "data2"}
+
+    signature_data = BulletTrain::OutgoingWebhooks::SignatureVerification.generate_signature(
+      payload_hash,
+      @secret
+    )
+
+    assert signature_data[:signature].present?, "Should generate a signature"
+    assert signature_data[:timestamp].present?, "Should generate a timestamp"
+
+    # Verify the generated signature works
+    result = BulletTrain::OutgoingWebhooks::SignatureVerification.verify_signature(
+      payload_hash.to_json,
+      signature_data[:signature],
+      signature_data[:timestamp],
+      @secret
+    )
+
+    assert result, "Generated signature should be verifiable"
+  end
+end

--- a/bullet_train-outgoing_webhooks/test/models/webhooks/outgoing/delivery_attempt_test.rb
+++ b/bullet_train-outgoing_webhooks/test/models/webhooks/outgoing/delivery_attempt_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+
+class Webhooks::Outgoing::DeliveryAttemptTest < ActiveSupport::TestCase
+  setup do
+    @team = Team.create!(name: "test-team")
+    @endpoint = Webhooks::Outgoing::Endpoint.create!(
+      url: "https://example.com/webhook",
+      name: "test",
+      team: @team
+    )
+
+    @event = Webhooks::Outgoing::Event.create!(
+      team: @team,
+      subject: @team,
+      uuid: SecureRandom.uuid,
+      payload: {"test" => "data"},
+      event_type_id: "team.created",
+      data: {"good" => "data"},
+      api_version: 1
+    )
+
+    @delivery = Webhooks::Outgoing::Delivery.create!(
+      endpoint: @endpoint,
+      event: @event,
+      endpoint_url: "https://example.com/webhook"
+    )
+
+    @attempt = @delivery.delivery_attempts.new
+
+    stub_request(:any, "https://example.com/webhook")
+      .to_return(status: 200, body: "Success", headers: {})
+  end
+
+  test "#attempt creates a request with valid x-webhook-headers and payload" do
+    @attempt.attempt
+
+    assert_requested :post, "https://example.com/webhook", {
+      headers: {
+        "X-Bullet-Train-Webhook-Timestamp" => /.+/,
+        "X-Bullet-Train-Webhook-Signature" => /.+/,
+        "X-Bullet-Train-Webhook-Id" => @event.uuid,
+        "Content-Type" => "application/json"
+      },
+      body: {
+        "event_id" => @event.uuid,
+        "event_type" => "team.created",
+        "subject_id" => @team.id,
+        "subject_type" => "Team",
+        "data" => {
+          "good" => "data"
+        }
+      }
+    }
+  end
+end

--- a/bullet_train-outgoing_webhooks/test/models/webhooks/outgoing/endpoint_test.rb
+++ b/bullet_train-outgoing_webhooks/test/models/webhooks/outgoing/endpoint_test.rb
@@ -1,51 +1,51 @@
 require "test_helper"
 
 class Webhooks::Outgoing::EndpointTest < ActiveSupport::TestCase
-  include ActiveJob::TestHelper
-
   setup do
     @team = Team.create!(name: "test-team")
-    @endpoint = Webhooks::Outgoing::Endpoint.create!(url: "https://example.com/webhook", name: "test", team: @team)
   end
 
-  test "#create should accept valid event_types" do
-    @endpoint = Webhooks::Outgoing::Endpoint.create!(
-      url: "https://example.com/webhook",
-      name: "test",
-      team: @team,
-      event_type_ids: [Webhooks::Outgoing::EventType.all.first.id]
-    )
-    assert @endpoint.persisted?
-  end
-
-  test "#create should accept non-existent event_types" do
-    @endpoint = Webhooks::Outgoing::Endpoint.create!(
-      url: "https://example.com/webhook",
-      name: "test",
-      team: @team,
-      event_type_ids: ["fake-thing.create"]
-    )
-    assert @endpoint.persisted?
-  end
-
-  test "#event_types should return existent EventTypes" do
+  test "#event_types accepts and returns existent EventTypes" do
     valid_event_type = Webhooks::Outgoing::EventType.all.first
-    @endpoint = Webhooks::Outgoing::Endpoint.create!(
+    endpoint = Webhooks::Outgoing::Endpoint.create!(
       url: "https://example.com/webhook",
       name: "test",
       team: @team,
       event_type_ids: [valid_event_type.id]
     )
-    assert_equal [valid_event_type.id], @endpoint.event_types.map(&:id)
+    assert endpoint.persisted?
+    assert_equal [valid_event_type.id], endpoint.event_types.map(&:id)
   end
 
-  test "#event_types should not raise an error for non-existent event_type_ids" do
-    @endpoint = Webhooks::Outgoing::Endpoint.create!(
+  test "#create ignores non-existent event_types" do
+    endpoint = Webhooks::Outgoing::Endpoint.create!(
       url: "https://example.com/webhook",
       name: "test",
       team: @team,
       event_type_ids: ["fake-thing.create"]
     )
-    assert_equal [], @endpoint.event_types
+    assert endpoint.persisted?
+    assert_equal [], endpoint.event_types
+  end
+
+  test "#create generates webhook_secret" do
+    endpoint = Webhooks::Outgoing::Endpoint.create!(
+      url: "https://example.com/webhook",
+      name: "test-auto-secret",
+      team: @team
+    )
+
+    assert_not_nil endpoint.webhook_secret
+    assert_equal 64, endpoint.webhook_secret.length
+  end
+
+  test "#rotate_webhook_secret! changes the webhook secret" do
+    endpoint = Webhooks::Outgoing::Endpoint.create!(url: "https://example.com/webhook", name: "test", team: @team)
+
+    old_secret = endpoint.webhook_secret
+    endpoint.rotate_webhook_secret!
+
+    assert_not_equal old_secret, endpoint.webhook_secret
+    assert_equal 64, endpoint.webhook_secret.length
   end
 end

--- a/bullet_train-outgoing_webhooks/test/test_helper.rb
+++ b/bullet_train-outgoing_webhooks/test/test_helper.rb
@@ -10,6 +10,7 @@ require "rails/test_help"
 
 require "setup/active_record"
 require "setup/endpoints"
+require "webmock/minitest"
 
 # Load fixtures from the engine
 if ActiveSupport::TestCase.respond_to?(:fixture_path=)
@@ -19,4 +20,7 @@ if ActiveSupport::TestCase.respond_to?(:fixture_path=)
   ActiveSupport::TestCase.fixtures :all
 end
 
-require_relative "../../test_support/minitest_reporters"
+# Enable running tests inside RubyMine IDE.
+unless ENV["RM_INFO"]
+  require_relative "../../test_support/minitest_reporters"
+end


### PR DESCRIPTION
Adding the ability to verify webhook event payloads using a new `Webhooks::Outgoing::Endpoint#webhook_secret` column.

The meat of the verification logic is inside `signature_verification.rb`. There we have a method to generate the signature and also methods to verify it. The latter aren't used anywhere in the starter template or core, but are useful as examples for how to verify the signature and for tests. If we all agree on the approach, we can have extra documentation for this in the docs.

