### PR TITLE
Allow custom label string method for has_many attribute

### DIFF
--- a/bullet_train-themes/app/views/themes/base/attributes/_has_many.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_has_many.html.erb
@@ -3,12 +3,12 @@
 <% link_source ||= nil %>
 <% disable_links ||= false %>
 <% link_options ||= {} %>
-<% label_string_method ||= nil %>
+<% label_string_method ||= :label_string %>
 
 <% if object.public_send(attribute).any? %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy do %>
     <%= object.public_send(attribute).map do |child_object| %>
-      <% label_string = label_string_method ? child_object.public_send(label_string_method) : child_object.label_string %>
+      <% label_string = child_object.public_send(label_string_method) %>
 
       <% capture do %>
         <% if disable_links %>


### PR DESCRIPTION
In one of the project I am working on, we have a instance where has_many attribute label should show different title/label depending on the parent model.

Example:

- We have InvoicePayment model that tracks how much amount has been paid for each invoice, invoice can have multiple payments.
- In Invoice index page, it should show "$290.00 - 2025-06-12" under Payment column
- In Payment index page, it should show "Test Client - 2025-06-12 - $290.00" under Invoice column

Both of these columns link to InvoicePayment model but with just one label_string allowed we can't accommodate these two different labels.

Hence the new change aims to allow custom label string method which can be created in the related model and we will call them using public_send.