### PR TITLE
Remove most of the placeholder docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,3 +3,11 @@ name: "🚢 ~ Docker"
 
 on:
   workflow_dispatch:
+
+jobs:
+  placeholder-job:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4


### PR DESCRIPTION
This workflow was added so that it can be run from a branch. (It's impossible to run any workflow until the file is present in `main` because you have no way to get to it.)

I originally added it with some placeholder content, but that makes it harder to see what's happening in the branch/PR where I'm getting things dialed in. I'm removing most of the workflow so that it's easier to see everything at once in the PR.