### PR TITLE
Multiple locales: fix broken button_field_options

### DIFF
--- a/bullet_train/app/views/account/users/_form.html.erb
+++ b/bullet_train/app/views/account/users/_form.html.erb
@@ -27,7 +27,7 @@
 
       <% if multiple_locales? %>
         <div class="sm:col-span-2">
-          <%= render 'shared/fields/buttons', method: :locale, options: {"": t("locale.default")}.merge(t("locale.locales")) %>
+          <%= render 'shared/fields/buttons', method: :locale, button_field_options: {"": t("locale.default")}.merge(t("locale.locales")) %>
         </div>
       <% end %>
 


### PR DESCRIPTION
When adding a second locale and navigating to user settings (user/edit), an error is shown.

The call to the button field uses the deprecated `options` key, and it should be replaced with `button_field_options`