### PR TITLE
fix: `to_param` for non-persisted records

### DIFF
--- a/bullet_train-obfuscates_id/app/models/concerns/obfuscates_id.rb
+++ b/bullet_train-obfuscates_id/app/models/concerns/obfuscates_id.rb
@@ -15,7 +15,6 @@ module ObfuscatesId
 
     def encode_id(id)
       return if id.nil?
-      
       hashids.encode(id)
     end
 

--- a/bullet_train-obfuscates_id/app/models/concerns/obfuscates_id.rb
+++ b/bullet_train-obfuscates_id/app/models/concerns/obfuscates_id.rb
@@ -14,6 +14,8 @@ module ObfuscatesId
     end
 
     def encode_id(id)
+      return if id.nil?
+      
       hashids.encode(id)
     end
 

--- a/bullet_train-obfuscates_id/test/models/obfuscates_id_concern_test.rb
+++ b/bullet_train-obfuscates_id/test/models/obfuscates_id_concern_test.rb
@@ -18,6 +18,15 @@ class FakeModel
   end
 end
 
+# This model simulates a Model.new instance that is not persisted yet.
+class FakeModelWithNilId
+  include ObfuscatesId
+
+  def id
+    nil
+  end
+end
+
 class BulletTrain::ObfuscatesIdConcernTest < ActiveSupport::TestCase
   test "FakeModel has an id" do
     fake_model = FakeModel.new
@@ -32,5 +41,9 @@ class BulletTrain::ObfuscatesIdConcernTest < ActiveSupport::TestCase
   test "FakeModel can accurately decode an id" do
     fake_model = FakeModel.new
     assert_equal fake_model.id, FakeModel.decode_id(fake_model.expected_obfuscated_id)
+  end
+
+  test "FakeModelWithNilId returns nil when id is nil" do
+    assert_nil FakeModelWithNilId.new.to_param
   end
 end


### PR DESCRIPTION
This PR fixes a bug where calling `to_param` would raise `can't convert nil into Integer` for non-persisted records.