### PR TITLE
Replace deprecated divide-opacity with tailwind color opacity modifiers

### DIFF
--- a/bullet_train-themes-light/app/assets/stylesheets/light/tailwind/components.css
+++ b/bullet_train-themes-light/app/assets/stylesheets/light/tailwind/components.css
@@ -115,7 +115,7 @@
   }
 
   .table {
-    @apply w-full divide-y divide-slate-900 dark:divide-slate-700 divide-opacity-5 text-left;
+    @apply w-full divide-y divide-slate-900/5 dark:divide-slate-700/5 text-left;
 
 
     th {
@@ -132,8 +132,8 @@
     }
 
     tbody {
-      @apply divide-y divide-slate-900 divide-opacity-5;
-      @apply dark:divide-slate-700;
+      @apply divide-y divide-slate-900/5;
+      @apply dark:divide-slate-700/5;
     }
 
     td {

--- a/bullet_train-themes-light/app/views/themes/light/actions/_list.html.erb
+++ b/bullet_train-themes-light/app/views/themes/light/actions/_list.html.erb
@@ -1,3 +1,3 @@
-<div class="divide-y divide-slate-900 divide-opacity-5 border-t dark:border-slate-500">
+<div class="divide-y divide-slate-900/5 border-t dark:border-slate-500/5">
   <%= partial.content.presence || partial.yield %>
 </div>


### PR DESCRIPTION
`divide-opacity` has been deprecated.

This issue replaces `divide-opacity-5` with appropriate `divide-slate-900/5`, etc.

Plus, this fixes another bug. When overriding `slate` with a custom set of colors (I know, it's backwards, but it's a workaround I've used for theming), then the `divide-opacity-5` doesn't get picked up consistently and the table dividers looks full opacity. It's how I noticed the issue.

As a workaround, if anyone has this issue, add this in `application.css`:

```css
@layer components {
  .table {
    @apply divide-slate-900/5 dark:divide-slate-700/5;

    tbody {
      @apply divide-slate-900/5 dark:divide-slate-700/5;
    }
  }
}
```