### PR TITLE
Bump rdoc

### DIFF
--- a/bullet_train-api/Gemfile.lock
+++ b/bullet_train-api/Gemfile.lock
@@ -206,6 +206,7 @@ GEM
     doorkeeper (5.8.1)
       railties (>= 5)
     drb (2.2.1)
+    erb (5.0.2)
     erubi (1.13.1)
     factory_bot (6.5.1)
       activesupport (>= 6.1.0)
@@ -351,7 +352,8 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
-    rdoc (6.13.1)
+    rdoc (6.14.2)
+      erb
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
     reline (0.6.0)

--- a/bullet_train-fields/Gemfile.lock
+++ b/bullet_train-fields/Gemfile.lock
@@ -209,6 +209,7 @@ GEM
     doorkeeper (5.8.1)
       railties (>= 5)
     drb (2.2.1)
+    erb (5.0.2)
     erubi (1.13.1)
     factory_bot (6.5.1)
       activesupport (>= 6.1.0)
@@ -363,7 +364,8 @@ GEM
     rake-compiler-dock (1.9.1)
     rb_sys (0.9.111)
       rake-compiler-dock (= 1.9.1)
-    rdoc (6.13.1)
+    rdoc (6.14.2)
+      erb
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
     reline (0.6.0)

--- a/bullet_train-has_uuid/Gemfile.lock
+++ b/bullet_train-has_uuid/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
     date (3.4.1)
     docile (1.4.1)
     drb (2.2.1)
+    erb (5.0.2)
     erubi (1.13.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -175,7 +176,8 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.2.1)
-    rdoc (6.13.1)
+    rdoc (6.14.2)
+      erb
       psych (>= 4.0.0)
     reline (0.6.0)
       io-console (~> 0.5)

--- a/bullet_train-incoming_webhooks/Gemfile.lock
+++ b/bullet_train-incoming_webhooks/Gemfile.lock
@@ -214,6 +214,7 @@ GEM
     doorkeeper (5.8.1)
       railties (>= 5)
     drb (2.2.1)
+    erb (5.0.2)
     erubi (1.13.1)
     factory_bot (6.5.1)
       activesupport (>= 6.1.0)
@@ -356,7 +357,8 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.2.1)
-    rdoc (6.13.1)
+    rdoc (6.14.2)
+      erb
       psych (>= 4.0.0)
     reline (0.6.0)
       io-console (~> 0.5)

--- a/bullet_train-integrations-stripe/Gemfile.lock
+++ b/bullet_train-integrations-stripe/Gemfile.lock
@@ -224,6 +224,7 @@ GEM
     doorkeeper (5.8.1)
       railties (>= 5)
     drb (2.2.1)
+    erb (5.0.2)
     erubi (1.13.1)
     factory_bot (6.5.1)
       activesupport (>= 6.1.0)
@@ -382,7 +383,8 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.2.1)
-    rdoc (6.13.1)
+    rdoc (6.14.2)
+      erb
       psych (>= 4.0.0)
     reline (0.6.0)
       io-console (~> 0.5)

--- a/bullet_train-integrations/Gemfile.lock
+++ b/bullet_train-integrations/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
     date (3.4.1)
     docile (1.4.1)
     drb (2.2.1)
+    erb (5.0.2)
     erubi (1.13.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -175,7 +176,8 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.2.1)
-    rdoc (6.13.1)
+    rdoc (6.14.2)
+      erb
       psych (>= 4.0.0)
     reline (0.6.0)
       io-console (~> 0.5)

--- a/bullet_train-obfuscates_id/Gemfile.lock
+++ b/bullet_train-obfuscates_id/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
     date (3.4.1)
     docile (1.4.1)
     drb (2.2.1)
+    erb (5.0.2)
     erubi (1.13.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -177,7 +178,8 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.2.1)
-    rdoc (6.13.1)
+    rdoc (6.14.2)
+      erb
       psych (>= 4.0.0)
     reline (0.6.0)
       io-console (~> 0.5)

--- a/bullet_train-outgoing_webhooks/Gemfile.lock
+++ b/bullet_train-outgoing_webhooks/Gemfile.lock
@@ -218,6 +218,7 @@ GEM
     doorkeeper (5.8.1)
       railties (>= 5)
     drb (2.2.1)
+    erb (5.0.2)
     erubi (1.13.1)
     factory_bot (6.5.1)
       activesupport (>= 6.1.0)
@@ -366,7 +367,8 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
-    rdoc (6.13.1)
+    rdoc (6.14.2)
+      erb
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
     reline (0.6.0)

--- a/bullet_train-roles/Gemfile.lock
+++ b/bullet_train-roles/Gemfile.lock
@@ -96,6 +96,7 @@ GEM
     date (3.4.1)
     docile (1.4.1)
     drb (2.2.1)
+    erb (5.0.2)
     erubi (1.13.1)
     factory_bot (6.5.1)
       activesupport (>= 6.1.0)
@@ -196,7 +197,8 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
-    rdoc (6.13.1)
+    rdoc (6.14.2)
+      erb
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
     reline (0.6.0)

--- a/bullet_train-scope_validator/Gemfile.lock
+++ b/bullet_train-scope_validator/Gemfile.lock
@@ -186,7 +186,7 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
-    rdoc (6.14.0)
+    rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
     regexp_parser (2.10.0)

--- a/bullet_train-sortable/Gemfile.lock
+++ b/bullet_train-sortable/Gemfile.lock
@@ -212,6 +212,7 @@ GEM
     doorkeeper (5.8.1)
       railties (>= 5)
     drb (2.2.1)
+    erb (5.0.2)
     erubi (1.13.1)
     factory_bot (6.5.1)
       activesupport (>= 6.1.0)
@@ -357,7 +358,8 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
-    rdoc (6.13.1)
+    rdoc (6.14.2)
+      erb
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
     reline (0.6.0)

--- a/bullet_train-super_load_and_authorize_resource/Gemfile.lock
+++ b/bullet_train-super_load_and_authorize_resource/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
     date (3.4.1)
     docile (1.4.1)
     drb (2.2.1)
+    erb (5.0.2)
     erubi (1.13.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -182,7 +183,8 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.2.1)
-    rdoc (6.13.1)
+    rdoc (6.14.2)
+      erb
       psych (>= 4.0.0)
     reline (0.6.0)
       io-console (~> 0.5)

--- a/bullet_train-super_scaffolding/Gemfile.lock
+++ b/bullet_train-super_scaffolding/Gemfile.lock
@@ -206,6 +206,7 @@ GEM
     doorkeeper (5.8.1)
       railties (>= 5)
     drb (2.2.1)
+    erb (5.0.2)
     erubi (1.13.1)
     factory_bot (6.5.1)
       activesupport (>= 6.1.0)
@@ -351,7 +352,8 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
-    rdoc (6.13.1)
+    rdoc (6.14.2)
+      erb
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
     reline (0.6.0)

--- a/bullet_train-themes-light/Gemfile.lock
+++ b/bullet_train-themes-light/Gemfile.lock
@@ -221,6 +221,7 @@ GEM
     doorkeeper (5.8.1)
       railties (>= 5)
     drb (2.2.1)
+    erb (5.0.2)
     erubi (1.13.1)
     factory_bot (6.5.1)
       activesupport (>= 6.1.0)
@@ -366,7 +367,8 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
-    rdoc (6.13.1)
+    rdoc (6.14.2)
+      erb
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
     reline (0.6.0)

--- a/bullet_train-themes-tailwind_css/Gemfile.lock
+++ b/bullet_train-themes-tailwind_css/Gemfile.lock
@@ -213,6 +213,7 @@ GEM
     doorkeeper (5.8.1)
       railties (>= 5)
     drb (2.2.1)
+    erb (5.0.2)
     erubi (1.13.1)
     factory_bot (6.5.1)
       activesupport (>= 6.1.0)
@@ -358,7 +359,8 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
-    rdoc (6.13.1)
+    rdoc (6.14.2)
+      erb
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
     reline (0.6.0)

--- a/bullet_train-themes/Gemfile.lock
+++ b/bullet_train-themes/Gemfile.lock
@@ -207,6 +207,7 @@ GEM
     doorkeeper (5.8.1)
       railties (>= 5)
     drb (2.2.1)
+    erb (5.0.2)
     erubi (1.13.1)
     factory_bot (6.5.1)
       activesupport (>= 6.1.0)
@@ -357,7 +358,8 @@ GEM
     rake-compiler-dock (1.9.1)
     rb_sys (0.9.111)
       rake-compiler-dock (= 1.9.1)
-    rdoc (6.13.1)
+    rdoc (6.14.2)
+      erb
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
     reline (0.6.0)

--- a/bullet_train/Gemfile.lock
+++ b/bullet_train/Gemfile.lock
@@ -227,6 +227,7 @@ GEM
     doorkeeper (5.8.1)
       railties (>= 5)
     drb (2.2.1)
+    erb (5.0.2)
     erubi (1.13.1)
     factory_bot (6.5.1)
       activesupport (>= 6.1.0)
@@ -386,7 +387,8 @@ GEM
     rake-compiler-dock (1.9.1)
     rb_sys (0.9.111)
       rake-compiler-dock (= 1.9.1)
-    rdoc (6.13.1)
+    rdoc (6.14.2)
+      erb
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
     reline (0.6.0)


### PR DESCRIPTION
This only affects CI for `core`.

```
./bin/each-gem run-command "bundle update rdoc --conservative"
```