### PR TITLE
Add additional checks and warnings to `openai_enabled?`

### DIFF
--- a/bullet_train/lib/bullet_train.rb
+++ b/bullet_train/lib/bullet_train.rb
@@ -180,7 +180,15 @@ def silence_logs?
 end
 
 def openai_enabled?
-  ENV["OPENAI_ACCESS_TOKEN"].present?
+  if ENV["OPENAI_ACCESS_TOKEN"].present? && !defined?(OpenAI)
+    Rails.logger.warn "OpenAI access token is set, but the OpenAI gem is not loaded. Please add the 'ruby-openai' gem to your Gemfile to enable OpenAI features."
+  end
+
+  if !ENV["OPENAI_ACCESS_TOKEN"].present? && defined?(OpenAI)
+    Rails.logger.warn "OpenAI access token is not set, but the OpenAI gem is loaded. Please set the OPENAI_ACCESS_TOKEN environment variable to enable OpenAI features."
+  end
+
+  ENV["OPENAI_ACCESS_TOKEN"].present? && defined?(OpenAI)
 end
 
 def openai_organization_exists?


### PR DESCRIPTION
Issue: https://github.com/bullet-train-co/bullet_train-core/issues/1191

If the api token environment variable is set but the gem is not loaded (or vice versa) we log an error and return false.