### PR TITLE
Add turbo_stream support to delegate_json_to_api

### DIFF
--- a/bullet_train/app/controllers/concerns/controllers/base.rb
+++ b/bullet_train/app/controllers/concerns/controllers/base.rb
@@ -136,6 +136,7 @@ module Controllers::Base
   def delegate_json_to_api(&block)
     respond_to do |format|
       format.html(&block)
+      format.turbo_stream(&block)
       format.json { render "#{params[:controller].gsub(/^account\//, "api/#{BulletTrain::Api.current_version}/")}/#{params[:action]}" }
     end
   end


### PR DESCRIPTION
scenario: for infinite scroll pagination with hotwire, I want to respond to index with format.turbo_stream.

I have to manually override `def delegate_json_to_api` to add format.turbo_stream` for it to work, otherwise I get this error:

<img width="1002" height="283" alt="Screenshot 2025-10-02 at 01 10 11" src="https://github.com/user-attachments/assets/b24cb674-c921-4792-80bb-39024ef4b04c" />
