### PR TITLE
extract sortable-* styles out of sortable_controller.js

### DIFF
--- a/bullet_train-sortable/app/javascript/controllers/sortable_controller.js
+++ b/bullet_train-sortable/app/javascript/controllers/sortable_controller.js
@@ -52,9 +52,9 @@ class SortableTable{
   // These are defaults so that we don't have to require people to update their templates.
   // If the template does contain values for any of these the template values will be used instead.
   static defaultClasses = {
-    "activeDropzoneClasses": "border-dashed bg-gray-50 border-slate-400",
-    "activeItemClasses": "shadow bg-white *:bg-white opacity-100 *:opacity-100",
-    "dropTargetClasses": "shadow-inner shadow-gray-500 hover:shadow-inner bg-gray-100 *:opacity-0 *:bg-gray-100"
+    "activeDropzoneClasses": "sortable-active-dropzone",
+    "activeItemClasses": "sortable-active-item",
+    "dropTargetClasses": "sortable-drop-target"
   };
 
   constructor(tbodyElement, saveSortOrder, handleTargets, styles, customEventPrefix){

--- a/bullet_train-themes-light/app/assets/stylesheets/light/tailwind/components.css
+++ b/bullet_train-themes-light/app/assets/stylesheets/light/tailwind/components.css
@@ -195,4 +195,16 @@
   details > summary.list-none::marker {
     display: none;
   }
+
+  .sortable-active-dropzone {
+    @apply border-dashed bg-gray-50 border-slate-400;
+  }
+
+  .sortable-active-item {
+    @apply shadow bg-white *:bg-white opacity-100 *:opacity-100;
+  }
+
+  .sortable-drop-target {
+    @apply shadow-inner shadow-gray-500 hover:shadow-inner bg-gray-100 *:opacity-0 *:bg-gray-100;
+  }
 }


### PR DESCRIPTION
Extracting the styles into `.sortable-*` classes seems to fix it for Safari, or maybe it never really worked in other browsers?

![CleanShot 2025-10-13 at 19 53 14](https://github.com/user-attachments/assets/3f418313-80f8-4071-b2a3-eda5beb0eeb4)
