### PR TITLE
Update all gems to rack 3.2.3

### DIFF
--- a/bullet_train-api/Gemfile.lock
+++ b/bullet_train-api/Gemfile.lock
@@ -309,7 +309,7 @@ GEM
       stringio
     pwned (2.4.1)
     racc (1.8.1)
-    rack (3.1.16)
+    rack (3.2.3)
     rack-protection (4.1.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)

--- a/bullet_train-fields/Gemfile.lock
+++ b/bullet_train-fields/Gemfile.lock
@@ -318,7 +318,7 @@ GEM
       stringio
     pwned (2.4.1)
     racc (1.8.1)
-    rack (3.1.16)
+    rack (3.2.3)
     rack-protection (4.1.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)

--- a/bullet_train-has_uuid/Gemfile.lock
+++ b/bullet_train-has_uuid/Gemfile.lock
@@ -138,7 +138,7 @@ GEM
       date
       stringio
     racc (1.8.1)
-    rack (3.1.16)
+    rack (3.2.3)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)

--- a/bullet_train-incoming_webhooks/Gemfile.lock
+++ b/bullet_train-incoming_webhooks/Gemfile.lock
@@ -315,7 +315,7 @@ GEM
       stringio
     pwned (2.4.1)
     racc (1.8.1)
-    rack (3.1.16)
+    rack (3.2.3)
     rack-protection (4.1.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)

--- a/bullet_train-integrations-stripe/Gemfile.lock
+++ b/bullet_train-integrations-stripe/Gemfile.lock
@@ -341,7 +341,7 @@ GEM
       stringio
     pwned (2.4.1)
     racc (1.8.1)
-    rack (3.1.16)
+    rack (3.2.3)
     rack-protection (4.1.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)

--- a/bullet_train-integrations/Gemfile.lock
+++ b/bullet_train-integrations/Gemfile.lock
@@ -138,7 +138,7 @@ GEM
       date
       stringio
     racc (1.8.1)
-    rack (3.1.16)
+    rack (3.2.3)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)

--- a/bullet_train-obfuscates_id/Gemfile.lock
+++ b/bullet_train-obfuscates_id/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
       date
       stringio
     racc (1.8.1)
-    rack (3.1.16)
+    rack (3.2.3)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)

--- a/bullet_train-outgoing_webhooks/Gemfile.lock
+++ b/bullet_train-outgoing_webhooks/Gemfile.lock
@@ -324,7 +324,7 @@ GEM
     public_suffix (6.0.1)
     pwned (2.4.1)
     racc (1.8.1)
-    rack (3.1.16)
+    rack (3.2.3)
     rack-protection (4.1.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)

--- a/bullet_train-roles/Gemfile.lock
+++ b/bullet_train-roles/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
       date
       stringio
     racc (1.8.1)
-    rack (3.1.16)
+    rack (3.2.3)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)

--- a/bullet_train-scope_validator/Gemfile.lock
+++ b/bullet_train-scope_validator/Gemfile.lock
@@ -147,7 +147,7 @@ GEM
       date
       stringio
     racc (1.8.1)
-    rack (3.1.16)
+    rack (3.2.3)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)

--- a/bullet_train-sortable/Gemfile.lock
+++ b/bullet_train-sortable/Gemfile.lock
@@ -315,7 +315,7 @@ GEM
       stringio
     pwned (2.4.1)
     racc (1.8.1)
-    rack (3.1.16)
+    rack (3.2.3)
     rack-protection (4.1.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)

--- a/bullet_train-super_load_and_authorize_resource/Gemfile.lock
+++ b/bullet_train-super_load_and_authorize_resource/Gemfile.lock
@@ -145,7 +145,7 @@ GEM
       date
       stringio
     racc (1.8.1)
-    rack (3.1.16)
+    rack (3.2.3)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)

--- a/bullet_train-super_scaffolding/Gemfile.lock
+++ b/bullet_train-super_scaffolding/Gemfile.lock
@@ -309,7 +309,7 @@ GEM
       stringio
     pwned (2.4.1)
     racc (1.8.1)
-    rack (3.1.16)
+    rack (3.2.3)
     rack-protection (4.1.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)

--- a/bullet_train-themes-light/Gemfile.lock
+++ b/bullet_train-themes-light/Gemfile.lock
@@ -324,7 +324,7 @@ GEM
       stringio
     pwned (2.4.1)
     racc (1.8.1)
-    rack (3.1.16)
+    rack (3.2.3)
     rack-protection (4.1.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)

--- a/bullet_train-themes-tailwind_css/Gemfile.lock
+++ b/bullet_train-themes-tailwind_css/Gemfile.lock
@@ -316,7 +316,7 @@ GEM
       stringio
     pwned (2.4.1)
     racc (1.8.1)
-    rack (3.1.16)
+    rack (3.2.3)
     rack-protection (4.1.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)

--- a/bullet_train-themes/Gemfile.lock
+++ b/bullet_train-themes/Gemfile.lock
@@ -312,7 +312,7 @@ GEM
       stringio
     pwned (2.4.1)
     racc (1.8.1)
-    rack (3.1.16)
+    rack (3.2.3)
     rack-protection (4.1.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)

--- a/bullet_train/Gemfile.lock
+++ b/bullet_train/Gemfile.lock
@@ -341,7 +341,7 @@ GEM
       stringio
     pwned (2.4.1)
     racc (1.8.1)
-    rack (3.1.16)
+    rack (3.2.3)
     rack-protection (4.1.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)


### PR DESCRIPTION
This just affects local development and CI. It doesn't flow down to starter repo apps.

```
./bin/each-gem run-command "bundle update rack --conservative"
```