### PR TITLE
Use `Gem::Specification` instead of relying on shelling out to `bundle show`

### DIFF
--- a/bullet_train-api/app/helpers/api/open_api_helper.rb
+++ b/bullet_train-api/app/helpers/api/open_api_helper.rb
@@ -20,7 +20,7 @@ module Api
     end
 
     def gem_paths
-      @gem_paths ||= `bundle show --paths`.lines.map { |gem_path| gem_path.chomp }
+      @gem_paths ||= Bundler.load.specs.map(&:gem_dir)
     end
 
     def automatic_paths_for(model, parent, except: [])

--- a/bullet_train-themes-light/lib/tasks/application.rb
+++ b/bullet_train-themes-light/lib/tasks/application.rb
@@ -4,7 +4,7 @@ module BulletTrain
   module Themes
     module Application
       def self.eject_theme_main_css(theme_name)
-        theme_base_path = `bundle show --paths bullet_train-themes-#{theme_name}`.chomp
+        theme_base_path = Gem::Specification.find_by_name("bullet_train-themes-#{theme_name}").gem_dir
 
         puts "Ejecting app/assets/stylesheets/#{theme_name}.tailwind.css."
         Rails.root.join("app/assets/stylesheets").mkpath
@@ -16,7 +16,7 @@ module BulletTrain
         constantized_theme = theme_parts.join
         humanized_theme = theme_parts.join(" ")
 
-        theme_base_path = `bundle show --paths bullet_train-themes-#{theme_name}`.chomp
+        theme_base_path = Gem::Specification.find_by_name("bullet_train-themes-#{theme_name}").gem_dir
         puts "Ejecting from #{humanized_theme} theme in `#{theme_base_path}`."
 
         puts "Ejecting Tailwind configuration into `./tailwind.#{ejected_theme_name}.config.js`."
@@ -46,7 +46,7 @@ module BulletTrain
           "bullet_train-themes-tailwind_css" => "tailwind_css",
           "bullet_train-themes-light" => "light"
         }.each do |gem, theme_name|
-          gem_path = `bundle show --paths #{gem}`.chomp
+          gem_path = Gem::Specification.find_by_name(gem).gem_dir
           showcase_partials = Dir.glob("#{gem_path}/app/views/showcase/**/*.html.erb")
 
           `find #{gem_path}/app/views/themes`.lines.map(&:chomp).each do |file_or_directory|
@@ -239,9 +239,9 @@ module BulletTrain
       end
 
       def self.clean_theme(theme_name, args)
-        light_base_path = `bundle show --paths bullet_train-themes-light`.chomp
-        tailwind_base_path = `bundle show --paths bullet_train-themes-tailwind_css`.chomp
-        theme_base_path = `bundle show --paths bullet_train-themes`.chomp
+        light_base_path = Gem::Specification.find_by_name("bullet_train-themes-light").gem_dir
+        tailwind_base_path = Gem::Specification.find_by_name("bullet_train-themes-tailwind_css").gem_dir
+        theme_base_path = Gem::Specification.find_by_name("bullet_train-themes").gem_dir
 
         directory_content = `find . | grep 'app/.*#{args[:theme]}'`.lines.map(&:chomp)
         directory_content = directory_content.reject { |content| content.match?("app/assets/builds/") }

--- a/bullet_train-themes/lib/tasks/bullet_train/themes_tasks.rake
+++ b/bullet_train-themes/lib/tasks/bullet_train/themes_tasks.rake
@@ -18,7 +18,7 @@ namespace :bt do
     `touch tmp/gems/.keep`
 
     BulletTrain.linked_gems.each do |linked_gem|
-      target = `bundle show #{linked_gem}`.chomp
+      target = Gem::Specification.find_by_name(linked_gem).gem_dir
       if target.present?
         puts "Linking '#{linked_gem}' to '#{target}'."
         `ln -s #{target} tmp/gems/#{linked_gem}`

--- a/bullet_train/app/controllers/concerns/documentation_support.rb
+++ b/bullet_train/app/controllers/concerns/documentation_support.rb
@@ -1,14 +1,10 @@
 module DocumentationSupport
   extend ActiveSupport::Concern
 
-  BULLET_TRAIN_BASE_PATH = `bundle show bullet_train`.chomp
+  BULLET_TRAIN_BASE_PATH = Gem::Specification.find_by_name("bullet_train").gem_dir
 
   def docs
     target = params[:page].presence || "index"
-
-    # TODO For some reason this didn't work on Heroku.
-    # all_paths = ([Rails.root.to_s] + `bundle show --paths`.lines.map(&:chomp))
-    # @path = all_paths.map { |path| path + "/docs/#{target}.md" }.detect { |path| File.exist?(path) }
 
     @path = "#{BULLET_TRAIN_BASE_PATH}/docs/#{target}.md"
 

--- a/bullet_train/lib/bullet_train/resolver.rb
+++ b/bullet_train/lib/bullet_train/resolver.rb
@@ -65,7 +65,7 @@ module BulletTrain
 
               # Look for showcase preview.
               file_name = source_file[:absolute_path].split("/").last
-              showcase_partials = Dir.glob(`bundle show bullet_train-themes-light`.chomp + "/app/views/showcase/**/*.html.erb")
+              showcase_partials = Dir.glob(Gem::Specification.find_by_name("bullet_train-themes-light").gem_dir + "/app/views/showcase/**/*.html.erb")
               showcase_preview = showcase_partials.find { |partial| partial.split("/").last == file_name }
               if showcase_preview
                 puts "Ejecting showcase preview for #{source_file[:relative_path]}"
@@ -191,11 +191,11 @@ module BulletTrain
           # If it's a full path, we need to make sure we're getting it from the right package.
           _, partial_view_package, partial_path_without_package = @needle.partition(/(bullet_train-core\/)?bullet_train[a-z|\-._0-9]*/)
 
-          # Pop off `bullet_train-core` and the gem's version so we can call `bundle show` correctly.
+          # Pop off `bullet_train-core` and the gem's version so we can call `Gem::Specification.find_by_name` correctly.
           partial_view_package.gsub!("bullet_train-core/", "")
           partial_view_package.gsub!(/[-|.0-9]*$/, "") if partial_view_package.match?(/[-|.0-9]*$/)
 
-          local_package_path = `bundle show #{partial_view_package}`.chomp
+          local_package_path = Gem::Specification.find_by_name(partial_view_package).gem_dir
           return local_package_path + partial_path_without_package
         else
           puts "You passed the absolute path for a partial literal, but we couldn't find the package name in the string:".red
@@ -223,7 +223,7 @@ module BulletTrain
         # If the developer enters a partial that is in bullet_train-base like devise/shared/oauth or devise/shared/links,
         # it will return a string starting with app/ so we simply point them to the file in this repository.
         if annotated_path.match?(/^<!-- BEGIN app/) && !ejected_theme?
-          gem_path = `bundle show bullet_train`.chomp
+          gem_path = Gem::Specification.find_by_name("bullet_train").gem_dir
           "#{gem_path}/#{$1}"
         else
           $1
@@ -283,7 +283,7 @@ module BulletTrain
         absolute_file_path
       else
         # Search for the file in its respective gem. Fall back to the `light` theme if no gem is available.
-        gem_path = [`bundle show bullet_train-themes-#{current_theme}`, `bundle show bullet_train-themes-light`].map(&:chomp).find(&:present?)
+        gem_path = [Gem::Specification.find_by_name("bullet_train-themes-#{current_theme}").gem_dir, Gem::Specification.find_by_name("bullet_train-themes-light").gem_dir].map(&:chomp).find(&:present?)
         return nil unless gem_path
 
         # At this point we can be more generic since we're inside the gem.

--- a/bullet_train/lib/tasks/bullet_train_tasks.rake
+++ b/bullet_train/lib/tasks/bullet_train_tasks.rake
@@ -55,7 +55,7 @@ namespace :bullet_train do
       gem_names = I18n.t("framework_packages").map { |key, value| key.to_s }
       gem_names.each do |gem|
         puts "Searching for locales in #{gem}...".blue
-        gem_path = `bundle show #{gem}`.chomp
+        gem_path = Gem::Specification.find_by_name(gem).gem_dir
         gem_with_version = gem_path.split("/").last
         locales = Dir.glob("#{gem_path}/**/config/locales/**/*.yml").reject { |path| path.match?("dummy") }
         next if locales.empty?

--- a/bullet_train/test/lib/tasks/bullet_train_tasks_test.rb
+++ b/bullet_train/test/lib/tasks/bullet_train_tasks_test.rb
@@ -6,7 +6,7 @@ module BulletTrain::Tasks; end
 
 class BulletTrain::Tasks::ResolveTaskTest < ActiveSupport::TestCase
   setup do
-    light_theme_gem = `bundle show bullet_train-themes-light`.chomp
+    light_theme_gem = Gem::Specification.find_by_name("bullet_train-themes-light").gem_dir
     light_box_path = "#{light_theme_gem}/app/views/themes/light/workflow/_box.html.erb"
     @annotated_path = "<!-- BEGIN #{light_box_path} -->"
   end


### PR DESCRIPTION
Apparently some systems/configurations can end up in a state where doing something like `bundle show bullet_train-themes-light` will result in bundler showing the location of the gem twice, which then messes up code that expects the output to be a single line.

So instead we'll use `Gem::Specification` direclty to find the info we need.