### PR TITLE
light theme: on initialize, warn if darkMode set in tailwind.config.js

### DIFF
--- a/bullet_train-themes-light/lib/bullet_train/themes/light/engine.rb
+++ b/bullet_train-themes-light/lib/bullet_train/themes/light/engine.rb
@@ -15,55 +15,55 @@ module BulletTrain
 
           Rails.application.config.after_initialize do
             tailwind_config_path = Rails.root.join("tailwind.config.js")
-            
+
             if tailwind_config_path.exist?
               config_content = tailwind_config_path.read
-              
+
               # Check for darkMode configuration with 'class' or 'selector'
               if config_content.match?(/darkMode\s*[=:]\s*['"](?:class|selector)['"]/) ||
-                 config_content.match?(/themeConfig\.darkMode\s*=\s*['"](?:class|selector)['"]/)
-                
+                  config_content.match?(/themeConfig\.darkMode\s*=\s*['"](?:class|selector)['"]/)
+
                 Rails.logger.warn <<~WARNING
  
-                   ------------------------------------------------------------
-                   
-                   ⚠️  DEPRECATION WARNING: Dark mode configuration in tailwind.config.js
-                   
-                   Your tailwind.config.js file contains a darkMode setting using 'class' or 'selector'.
-                   This is now the default setting for Bullet Train, allowing users to choose their preference in Account Details.
-                   
-                   If you want to force light mode for all users, use the force_color_scheme_to option in config/initializers/theme.rb:
-                   
-                     BulletTrain::Themes::Light.force_color_scheme_to = :light  # or :dark
-                   
-                   You can then remove the darkMode configuration from tailwind.config.js.
+                  ------------------------------------------------------------
+                  
+                  ⚠️  DEPRECATION WARNING: Dark mode configuration in tailwind.config.js
+                  
+                  Your tailwind.config.js file contains a darkMode setting using 'class' or 'selector'.
+                  This is now the default setting for Bullet Train, allowing users to choose their preference in Account Details.
+                  
+                  If you want to force light mode for all users, use the force_color_scheme_to option in config/initializers/theme.rb:
+                  
+                    BulletTrain::Themes::Light.force_color_scheme_to = :light  # or :dark
+                  
+                  You can then remove the darkMode configuration from tailwind.config.js.
  
-                   ------------------------------------------------------------
-                   
+                  ------------------------------------------------------------
+                  
                 WARNING
               # Check for darkMode configuration with 'media'
               elsif config_content.match?(/darkMode\s*[=:]\s*['"]media['"]/) ||
-                    config_content.match?(/themeConfig\.darkMode\s*=\s*['"]media['"]/)
-                
+                  config_content.match?(/themeConfig\.darkMode\s*=\s*['"]media['"]/)
+
                 Rails.logger.warn <<~WARNING
  
-                   ------------------------------------------------------------
-                   
-                   ℹ️  NOTICE: Dark mode configuration in tailwind.config.js
-                   
-                   Your tailwind.config.js file contains a darkMode setting using 'media'.
-                   This setting is safe to remove, as Bullet Train now handles color scheme preferences automatically.
-                   
-                   Users can choose their preferred color scheme in Account Details, which respects their system preference by default.
-                   
-                   If you want to force a specific color scheme for all users, use the force_color_scheme_to option in config/initializers/theme.rb:
-                   
-                     BulletTrain::Themes::Light.force_color_scheme_to = :light  # or :dark
-                   
-                   You can safely remove the darkMode configuration from tailwind.config.js.
+                  ------------------------------------------------------------
+                  
+                  ℹ️  NOTICE: Dark mode configuration in tailwind.config.js
+                  
+                  Your tailwind.config.js file contains a darkMode setting using 'media'.
+                  This setting is safe to remove, as Bullet Train now handles color scheme preferences automatically.
+                  
+                  Users can choose their preferred color scheme in Account Details, which respects their system preference by default.
+                  
+                  If you want to force a specific color scheme for all users, use the force_color_scheme_to option in config/initializers/theme.rb:
+                  
+                    BulletTrain::Themes::Light.force_color_scheme_to = :light  # or :dark
+                  
+                  You can safely remove the darkMode configuration from tailwind.config.js.
  
-                   ------------------------------------------------------------
-                   
+                  ------------------------------------------------------------
+                  
                 WARNING
               end
             end


### PR DESCRIPTION
If a user has added a `darkMode` setting in their local `tailwind.config.js`, it probably means they wanted to show the `light` mode to all their users.

```js
themeConfig.darkMode = 'selector' // or the deprecated 'class'
```

Or maybe they once did, and then backtracked, and set the value to `media` back again.

```js
themeConfig.darkMode = 'media'
```

In either case, applying the update to the `light` theme gem will for them produce a surprise. In the first case the dark mode will show to some users who are running dark mode in their system preferences, and in the second, some styles will appear off (for components like the super_select, date fields, and trix editor), as we no longer use the `@media` rule for selecting dark mode.

This PR solves this issue by warning devs and encouraging them to remove their custom darkMode setting entirely, and introducing the new `force_color_scheme_to` setting.

<img width="2008" height="580" alt="CleanShot 2025-10-15 at 10 01 01@2x" src="https://github.com/user-attachments/assets/2f4444ac-bf84-4fd5-befd-77ba4735a929" />
