### PR TITLE
Prevent table contents from being hidden

### DIFF
--- a/bullet_train-themes-light/app/views/themes/light/_box.html.erb
+++ b/bullet_train-themes-light/app/views/themes/light/_box.html.erb
@@ -26,7 +26,7 @@
 
   <div class="space-y-4">
     <% if partial.table? %>
-      <div class="box-table <%= divider ? 'mt-4' : '-mt-1' %> pb-0.5">
+      <div class="box-table <%= divider ? 'mt-4' : '-mt-1' %> pb-0.5 overflow-y-auto">
         <%= partial.table %>
       </div>
     <% end %>


### PR DESCRIPTION
In the cases where the table is wider than the screen this will allow side-to-side scrolling to be able to get to all the content.

Fixes https://github.com/bullet-train-co/bullet_train-core/issues/1183

<img width="445" height="407" alt="CleanShot 2025-10-29 at 12 27 47" src="https://github.com/user-attachments/assets/021284d1-3c9f-4fca-90c5-fb4cdc5606a2" />
