### PR TITLE
Allow language to be set for code_editor fields during super scaffolding

### DIFF
--- a/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
+++ b/bullet_train-super_scaffolding/lib/scaffolding/transformer.rb
@@ -799,6 +799,10 @@ class Scaffolding::Transformer
           field_attributes[:color_picker_field_options] = "t('#{child.pluralize.underscore}.fields.#{attribute.name}.options')"
         end
 
+        if attribute.type == "code_editor" && attribute.options[:language]
+          field_attributes[:language] = "\"#{attribute.options[:language]}\""
+        end
+
         field_content = "<%= render 'shared/fields/#{attribute.type}'#{", " if field_attributes.any?}#{field_attributes.map { |key, value| "#{key}: #{value}" }.join(", ")} %>"
 
         # TODO Add more of these from other packages?

--- a/bullet_train/docs/field-partials.md
+++ b/bullet_train/docs/field-partials.md
@@ -181,11 +181,25 @@ rails generate model Project team:references multiple_buttons:jsonb
 ## Formating `date` and `date_and_time`
 After Super Scaffolding a `date` or `date_and_time` field, you can pass a format for the object like so:
 
-```
+```erb
 <%= render 'shared/attributes/date', attribute: date_object, format: :short %>
 ```
 
 Please refer to the [Ruby on Rails documentation](https://guides.rubyonrails.org/i18n.html#adding-date-time-formats) for more information.
+
+## Setting a `language` for `code_editor` fields
+
+When rendering the `code_editor` attribute you can pass in a language to affect syntax highlighting and what not.
+
+```erb
+<%= render 'shared/fields/code_editor', method: :source, language: "ruby" %>
+```
+
+During Super Scaffolding you can pass in the language when declaring the attribute and it will be added to your form:
+
+````
+rails generate super_scaffold:field Project source:code_editor{language=ruby}
+````
 
 ## Dynamic Forms and Dependent Fields
 


### PR DESCRIPTION
This allows you to do something like this:

```
rails generate super_scaffold:field Project source:code_editor{language=ruby}
```

Which will then generate a line like this in your form:

```erb
<%= render 'shared/fields/code_editor', method: :source, language: "ruby" %>
```

Fixes https://github.com/bullet-train-co/bullet_train-core/issues/1121