### PR TITLE
Replace `@extend` rules with `@apply`

### DIFF
--- a/bullet_train-themes-light/app/assets/stylesheets/light/fields/super_select.css
+++ b/bullet_train-themes-light/app/assets/stylesheets/light/fields/super_select.css
@@ -65,7 +65,7 @@
     @apply rounded-md shadow-sm pt-0 focus:ring-primary-500 !important;
 
     &.focus-visible {
-      @extend .select2-border;
+      @apply select2-border !important;
     }
 
     &:focus {
@@ -89,7 +89,7 @@
 
   .select2-container--open, .select2-container--focus {
     .select2-selection--single, .select2-selection--multiple {
-      @extend .select2-border;
+      @apply select2-border !important;
     }
   }
 

--- a/bullet_train-themes-light/app/assets/stylesheets/light/tailwind/components.css
+++ b/bullet_train-themes-light/app/assets/stylesheets/light/tailwind/components.css
@@ -50,7 +50,7 @@
   }
 
   .button-color {
-    @extend .button;
+    @apply button;
     @apply rounded-full;
   }
 
@@ -59,7 +59,7 @@
       display: none;
       &:checked {
         & + button {
-          @extend .button;
+          @apply button;
         }
       }
     }


### PR DESCRIPTION
This will make it possible to remove the `postcss-extend-rule` package from the starter repo.

Joint PR: https://github.com/bullet-train-co/bullet_train/pull/2291