### PR TITLE
making previews for attachments in action text

### DIFF
--- a/bullet_train-themes/app/views/themes/base/attributes/_html.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_html.html.erb
@@ -5,10 +5,9 @@
 <% if object.public_send(attribute).present? %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
     <% if object.send(attribute).is_a?(ActionText::RichText) %>
-      <%= html_sanitize(object.public_send(attribute).body.to_s).html_safe %>
-    <% else %>
-      <% # `.to_s` is for action text. %>
-      <%= html_sanitize(object.public_send(attribute).to_s).html_safe %>
+      <%= tag.div(class: "trix-content") do %>
+        <%= object.public_send(attribute) %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/bullet_train-themes/app/views/themes/base/attributes/_image.html.erb
+++ b/bullet_train-themes/app/views/themes/base/attributes/_image.html.erb
@@ -1,13 +1,8 @@
 <% object ||= current_attributes_object %>
-<% strategy ||= current_attributes_strategy || :none %>
-<% url ||= nil %>
+<% attribute ||= :image %>
 <% options ||= {} %>
-<% options[:height] ||= 200 %>
 
-<% if cloudinary_enabled? %>
-  <%= cloudinary_image_tag object.public_send(attribute), options %>
-<% else %>
-  <% if object.public_send(attribute).attached? %>
-    <%= image_tag photo_url_for_active_storage_attachment(object.public_send(attribute), options) %>
-  <% end %>
+<% attachment = object.public_send(attribute) %>
+<% if attachment && attachment.attached? %>
+  <%= render 'active_storage/blobs/blob', blob: attachment, options: options %>
 <% end %>


### PR DESCRIPTION
In [this PR](https://github.com/bullet-train-co/bullet_train/pull/2269), I made it so that attachments in action text render previews for images, videos, GIFs, PDFs, and files that can't be rendered like ZIP files. This time I replaced all the hardcoded style attributes in _blob with Tailwind CSS, and I'm making two PRs, this one and [this one](https://github.com/bullet-train-co/bullet_train/pull/2293). @jagthedrummer what do you think?