### PR TITLE
Better error display for email address on new Invitations

### DIFF
--- a/bullet_train/app/models/concerns/invitations/base.rb
+++ b/bullet_train/app/models/concerns/invitations/base.rb
@@ -48,7 +48,7 @@ module Invitations::Base
   end
 
   def hoist_membership_email_error
-    # This is special handling for the email field because we have a uniquness validation in the
+    # This is special handling for the email field because we have a uniqueness validation in the
     # `Membership` model for the `user_email` field. Since we copy the value from `invitation.email`
     # into `invitation.membership.user_email` the error isn't passed through to the form in the normal way.
     errors[:"membership.user_email"]&.each do |error|


### PR DESCRIPTION
Fixes: https://github.com/bullet-train-co/bullet_train-core/issues/1267

<img width="1157" height="318" alt="CleanShot 2025-11-11 at 13 28 24" src="https://github.com/user-attachments/assets/ac90bf16-dc1b-4427-bd57-d395d5d14fe2" />
