### PR TITLE
Move ActionText and ActiveStorage partials to `core`

### DIFF
--- a/bullet_train/app/views/active_storage/blobs/_blob.html.erb
+++ b/bullet_train/app/views/active_storage/blobs/_blob.html.erb
@@ -1,0 +1,14 @@
+<figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
+  <% if blob.representable? %>
+    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
+  <% end %>
+
+  <figcaption class="attachment__caption">
+    <% if caption = blob.try(:caption) %>
+      <%= caption %>
+    <% else %>
+      <span class="attachment__name"><%= blob.filename %></span>
+      <span class="attachment__size"><%= number_to_human_size blob.byte_size %></span>
+    <% end %>
+  </figcaption>
+</figure>

--- a/bullet_train/app/views/layouts/action_text/contents/_content.html.erb
+++ b/bullet_train/app/views/layouts/action_text/contents/_content.html.erb
@@ -1,0 +1,3 @@
+<div class="trix-content">
+  <%= yield -%>
+</div>


### PR DESCRIPTION
We had some ActionText and ActiveStorage configs/artifacts in the starter repo and some in `core`. To standardize we're moving a couple of partials out of the starter repo and into `core`.

Joint PR: https://github.com/bullet-train-co/bullet_train/pull/2306