### PR TITLE
Allow gifs to animate when embedded in ActionText

### DIFF
--- a/bullet_train/app/views/active_storage/blobs/_blob.html.erb
+++ b/bullet_train/app/views/active_storage/blobs/_blob.html.erb
@@ -1,6 +1,15 @@
 <figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
   <% if blob.representable? %>
-    <%= image_tag blob.representation(loader: { n: -1 }, resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
+    <%
+      # loader_options are passed through to lib-vips: https://www.libvips.org/API/current/ctor.Image.gifload.html
+      # By default the loader uses page = 1, and n = 1 to pick just the first "page" (aka frame) of a GIF.
+      # We pass -1 for n to indicate that it should pull all the frames and give us a scaled verison of the whole GIF.
+      loader_options = {}
+      if blob.filename.extension.casecmp("gif")
+        loader_options[:n] = -1
+      end
+    %>
+    <%= image_tag blob.representation(loader: loader_options, resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
   <% end %>
 
   <figcaption class="attachment__caption">


### PR DESCRIPTION
By default the `vips` library will read only the first frame of a `.gif` when creating a "representation" of it. Passing `-1` to `loader -> n` tells it to read all of the frames.

https://www.libvips.org/API/current/ctor.Image.gifload.html

This allows us to show the whole gif animation, but to also scale it down if needed.

Fixes: https://github.com/bullet-train-co/bullet_train/issues/2303

Note: This is a stacked PR that points into the branch for https://github.com/bullet-train-co/bullet_train-core/pull/1272. We should merge them in series (starting with #1272) and then release them at the same time.