### PR TITLE
Monkeypatch Rails to work around a PDF preview bug

### DIFF
--- a/bullet_train/config/initializers/actiontext_override.rb
+++ b/bullet_train/config/initializers/actiontext_override.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# We're using this monkey patch: https://github.com/rails/rails/pull/39113#issuecomment-1729082686
+# To work around this long-standing bug: https://github.com/rails/rails/issues/38027
+# If PR #39113 is ever merged and released in Rails we can ditch this entire file.
+
+require "active_support/core_ext/object/try"
+module ActionText
+  module Attachments
+    module TrixConversion
+      def to_trix_attachment(content = trix_attachment_content)
+        attributes = full_attributes.dup
+        attributes["content"] = content if content
+        attributes["url"] = trix_attachable_url if previewable_attachable? && previewable?
+        TrixAttachment.from_attributes(attributes)
+      end
+
+      def trix_attachable_url
+        Rails.application.routes.url_helpers.rails_blob_url(preview_image.blob, only_path: true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We're using this monkey patch: https://github.com/rails/rails/pull/39113#issuecomment-1729082686
To work around this long-standing bug: https://github.com/rails/rails/issues/38027

If rails/rails PR #39113 is ever merged and released we can ditch this new initializer.

Fixes: https://github.com/bullet-train-co/bullet_train/issues/2307

Note this is a stacked PR and points into the branch for https://github.com/bullet-train-co/bullet_train-core/pull/1273. We should merge #1273 before this one and then release them at the same time.