### PR TITLE
Set a poster for the video player

### DIFF
--- a/bullet_train-fields/app/helpers/fields/html_editor_helper.rb
+++ b/bullet_train-fields/app/helpers/fields/html_editor_helper.rb
@@ -7,7 +7,7 @@ module Fields::HtmlEditorHelper
     string = string.gsub("bullettrain://", TEMPORARY_REPLACEMENT)
     string = sanitize(string,
       tags: %w[div br strong em b i del a h1 blockquote pre ul ol li action-text-attachment figure figcaption img video source],
-      attributes: %w[href sgid content-type url filename filesize width height presentation src class controls preload type])
+      attributes: %w[href sgid content-type url filename filesize width height presentation src class controls preload type poster type])
     # given the limited scope of what we're doing here, this string replace should work.
     # it should also use a lot less memory than nokogiri.
     string = string.gsub(/<a href="#{TEMPORARY_REPLACEMENT}(.*?)\/.*?">(.*?)<\/a>/o, "<span class=\"tribute-reference tribute-\\1-reference\">\\2</span>").html_safe

--- a/bullet_train/app/views/active_storage/blobs/_blob.html.erb
+++ b/bullet_train/app/views/active_storage/blobs/_blob.html.erb
@@ -1,13 +1,10 @@
 <figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
   <% if blob.video? %>
-    <video controls width="<%= local_assigns[:in_gallery] ? 800 : 1024 %>" preload="metadata" class="max-w-full h-auto rounded-md">
+    <video controls width="<%= local_assigns[:in_gallery] ? 800 : 1024 %>" preload="metadata" class="max-w-full h-auto rounded-md"
+      poster="<%= url_for(blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ])) %>"
+    >
       <source src="<%= rails_blob_url(blob) %>" type="<%= blob.content_type %>">
     </video>
-    <%
-      # This next thing kind of sucks, but seems necessary. If we don't force an image representation to be created after a record
-      # is saved then when you edit the record we show a broken image link instead of a good one in the editor.
-    %>
-    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]), class: 'hidden' %>
   <% elsif blob.representable? %>
     <%
       # loader_options are passed through to lib-vips: https://www.libvips.org/API/current/ctor.Image.gifload.html

--- a/bullet_train/config/initializers/action_text_sanitzer.rb
+++ b/bullet_train/config/initializers/action_text_sanitzer.rb
@@ -6,7 +6,7 @@
 # https://github.com/rails/rails/issues/54478
 Rails.application.config.after_initialize do
   default_allowed_attributes = Rails::HTML5::Sanitizer.safe_list_sanitizer.allowed_attributes + ActionText::Attachment::ATTRIBUTES.to_set
-  custom_allowed_attributes = Set.new(%w[controls])
+  custom_allowed_attributes = Set.new(%w[controls poster type])
   ActionText::ContentHelper.allowed_attributes = (default_allowed_attributes + custom_allowed_attributes).freeze
 
   default_allowed_tags = Rails::HTML5::Sanitizer.safe_list_sanitizer.allowed_tags + Set.new([ActionText::Attachment.tag_name, "figure", "figcaption"])


### PR DESCRIPTION
This makes the player a little friendlier to users, and has the benefit of causing Rails to generate an image representation without us needing to include a hidden image on the page.