### PR TITLE
Enable GHA to be an OIDC "trusted publisher" for npmjs.com

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,6 +4,11 @@ on:
   workflow_call:
   workflow_dispatch:
 
+# This allows the workflow to generate OIDC "trusted publisher" tokens for npmjs.com
+# https://docs.npmjs.com/trusted-publishers
+permissions:
+  id-token: write
+
 jobs:
   push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://docs.npmjs.com/trusted-publishers