### PR TITLE
i18n: add es, fr, zh-CN, zh-TW locales for teams, devise, memberships, onboarding

### DIFF
--- a/bullet_train/config/locales/es/devise.es.yml
+++ b/bullet_train/config/locales/es/devise.es.yml
@@ -1,0 +1,136 @@
+---
+es:
+  devise:
+    titles:
+      reset_password: Restablecer tu contraseña
+      sign_in: Iniciar sesión
+    headers:
+      resend_confirm: Reenviar instrucciones de confirmación
+      change_password: Cambiar tu contraseña
+      reset_password: Restablecer contraseña
+      edit_registration: Editar %{resource_name}
+      cancel_account: Cancelar mi cuenta
+      create_account: Crear tu cuenta
+      sign_in: Iniciar sesión
+      resend_unlock: Reenviar instrucciones de desbloqueo
+    labels:
+      wait_confirm: 'Actualmente esperando confirmación para: %{unconfirmed_email}'
+    hints:
+      leave_blank: "(dejar en blanco si no quieres cambiarlo)"
+      length: mínimo %{password_length} caracteres
+      need_password: "(necesitamos tu contraseña actual para confirmar tus cambios)"
+    buttons:
+      resend_confirm: Reenviar instrucciones de confirmación
+      change_password: Cambiar mi contraseña
+      reset_password: Restablecer contraseña por correo
+      cancel_account: Cancelar mi cuenta
+      resend_unlock: Reenviar instrucciones de desbloqueo
+    links:
+      account: "¿No tienes una cuenta?"
+      have_account: "¿Ya tienes una cuenta?"
+      forgot_password: "¿Olvidaste tu contraseña?"
+      log_in: Iniciar sesión
+      sign_up: Registrarse
+      new_confirm: "¿No recibiste las instrucciones de confirmación?"
+      new_unlock: "¿No recibiste las instrucciones de desbloqueo?"
+      sign_in_with: Iniciar sesión con %{provider}
+    confirmations:
+      confirmed: Tu dirección de correo ha sido confirmada exitosamente.
+      send_instructions: Recibirás un correo con instrucciones sobre cómo confirmar
+        tu dirección de correo en unos minutos.
+      send_paranoid_instructions: Si tu dirección de correo existe en nuestra base
+        de datos, recibirás un correo con instrucciones sobre cómo confirmar tu dirección
+        de correo en unos minutos.
+    failure:
+      already_authenticated: Ya has iniciado sesión.
+      inactive: Tu cuenta aún no está activada.
+      invalid: "%{authentication_keys} o contraseña inválidos."
+      locked: Tu cuenta está bloqueada.
+      last_attempt: Tienes un intento más antes de que tu cuenta se bloquee.
+      not_found_in_database: "%{authentication_keys} o contraseña inválidos."
+      timeout: Tu sesión ha expirado. Por favor inicia sesión nuevamente para continuar.
+      unauthenticated: Necesitas iniciar sesión o registrarte antes de continuar.
+      unconfirmed: Tienes que confirmar tu dirección de correo antes de continuar.
+    mailer:
+      confirmation_instructions:
+        subject: Instrucciones de confirmación
+        welcome: "¡Bienvenido %{email}!"
+        description: 'Puedes confirmar el correo de tu cuenta a través del siguiente
+          enlace:'
+        confirm_account: Confirmar mi cuenta
+      reset_password_instructions:
+        subject: Instrucciones para restablecer contraseña
+        hello: "¡Hola %{email}!"
+        requested_change: Alguien ha solicitado un enlace para cambiar tu contraseña.
+          Puedes hacerlo a través del siguiente enlace.
+        ignore: Si no lo solicitaste, por favor ignora este correo.
+        access_change: Tu contraseña no cambiará hasta que accedas al enlace anterior
+          y crees una nueva.
+        change_password: Cambiar mi contraseña
+      unlock_instructions:
+        subject: Instrucciones de desbloqueo
+        hello: "¡Hola %{email}!"
+        account_blocked: Tu cuenta ha sido bloqueada debido a un número excesivo de
+          intentos de inicio de sesión fallidos.
+        click_link: 'Haz clic en el siguiente enlace para desbloquear tu cuenta:'
+        unlock: Desbloquear mi cuenta
+      password_change:
+        subject: Contraseña cambiada
+        hello: "¡Hola %{email}!"
+        description: Te contactamos para notificarte que tu contraseña ha sido cambiada.
+      email_changed:
+        subject: Correo cambiado
+        hello: "¡Hola %{email}!"
+        description: Te contactamos para notificarte que tu correo ha sido cambiado
+          a %{email}
+    omniauth_callbacks:
+      failure: No pudimos autenticarte desde %{kind} porque "%{reason}".
+      success: Autenticado exitosamente desde la cuenta %{kind}.
+    passwords:
+      no_token: No puedes acceder a esta página sin venir de un correo de restablecimiento
+        de contraseña. Si vienes de un correo de restablecimiento de contraseña, por
+        favor asegúrate de usar la URL completa proporcionada.
+      send_instructions: Recibirás un correo con instrucciones sobre cómo restablecer
+        tu contraseña en unos minutos.
+      send_paranoid_instructions: Si tu dirección de correo existe en nuestra base
+        de datos, recibirás un enlace de recuperación de contraseña en tu dirección
+        de correo en unos minutos.
+      updated: Tu contraseña ha sido cambiada exitosamente. Ahora has iniciado sesión.
+      updated_not_active: Tu contraseña ha sido cambiada exitosamente.
+    registrations:
+      destroyed: "¡Adiós! Tu cuenta ha sido cancelada exitosamente. Esperamos verte
+        de nuevo pronto."
+      signed_up: "¡Bienvenido! Te has registrado exitosamente."
+      signed_up_but_inactive: Te has registrado exitosamente. Sin embargo, no pudimos
+        iniciar tu sesión porque tu cuenta aún no está activada.
+      signed_up_but_locked: Te has registrado exitosamente. Sin embargo, no pudimos
+        iniciar tu sesión porque tu cuenta está bloqueada.
+      signed_up_but_unconfirmed: Se ha enviado un mensaje con un enlace de confirmación
+        a tu dirección de correo. Por favor sigue el enlace para activar tu cuenta.
+      update_needs_confirmation: Has actualizado tu cuenta exitosamente, pero necesitamos
+        verificar tu nueva dirección de correo. Por favor revisa tu correo y sigue
+        el enlace de confirmación para confirmar tu nueva dirección de correo.
+      updated: Tu cuenta ha sido actualizada exitosamente.
+    sessions:
+      signed_in: Has iniciado sesión exitosamente.
+      signed_out: Has cerrado sesión exitosamente.
+      already_signed_out: Has cerrado sesión exitosamente.
+    unlocks:
+      send_instructions: Recibirás un correo con instrucciones sobre cómo desbloquear
+        tu cuenta en unos minutos.
+      send_paranoid_instructions: Si tu cuenta existe, recibirás un correo con instrucciones
+        sobre cómo desbloquearla en unos minutos.
+      unlocked: Tu cuenta ha sido desbloqueada exitosamente. Por favor inicia sesión
+        para continuar.
+  errors:
+    messages:
+      already_confirmed: ya fue confirmado, por favor intenta iniciar sesión
+      confirmation_period_expired: necesita ser confirmado dentro de %{period}, por
+        favor solicita uno nuevo
+      expired: ha expirado, por favor solicita uno nuevo
+      not_found: no encontrado
+      not_locked: no estaba bloqueado
+      not_saved:
+        one: '1 error impidió que este %{resource} fuera guardado:'
+        other: "%{count} errores impidieron que este %{resource} fuera guardado:"
+      pwned_password: ''

--- a/bullet_train/config/locales/es/memberships.es.yml
+++ b/bullet_train/config/locales/es/memberships.es.yml
@@ -1,0 +1,1098 @@
+---
+es:
+  memberships:
+    label: Miembros del equipo
+    singular: Miembro del equipo
+    navigation:
+      label: Miembros del equipo
+      icon: fa-light fa-users
+    breadcrumbs:
+      label: Miembros del equipo
+    buttons:
+      edit: Ajustes
+      show: Detalles
+      resend: Reenviar
+      update: Actualizar membresía
+      demote: Degradación de administrador
+      promote: Ascender a administrador
+      destroy: Eliminar del equipo
+      destroy_own: Abandona este equipo
+      reinvite: Volver a invitar al equipo
+      confirmations:
+        destroy: "¿Está seguro de que desea eliminar %{membership_name} de %{team_name}?"
+        destroy_own: "¿Estás seguro de que quieres eliminarte de %{team_name}? No
+          podrás deshacer esta acción."
+        reinvite: "¿Estás seguro de que quieres volver a invitar a %{membership_name}
+          a %{team_name}?"
+    fields:
+      id:
+        _: ID de membresía
+        label: ID de membresía
+        heading: ID de membresía
+        api_title: ID de membresía
+        api_description: ID de membresía
+      user_id:
+        name: ID de usuario
+        heading: ID de usuario
+        api_title: ID de usuario
+        api_description: ID de usuario
+      team_id:
+        name: ID del equipo
+        heading: ID del equipo
+        api_title: ID del equipo
+        api_description: ID del equipo
+      invitation_id:
+        name: ID de invitación
+        heading: ID de invitación
+        api_title: ID de invitación
+        api_description: ID de invitación
+      name:
+        name: Nombre completo
+        heading: Nombre completo
+        api_title: Nombre completo
+        api_description: Nombre completo
+      user_first_name:
+        name: Nombre
+        label: Nombre
+        heading: Nombre
+        api_title: Nombre
+        api_description: Nombre
+      user_last_name:
+        name: Apellido
+        label: Apellido
+        heading: Apellido
+        api_title: Apellido
+        api_description: Apellido
+      user_profile_photo_id:
+        name: Foto de perfil
+        label: Foto de perfil
+        heading: Foto de perfil
+        api_title: Foto de perfil
+        api_description: Foto de perfil
+      user_profile_photo:
+        name: Foto de perfil
+        label: Foto de perfil
+        heading: Foto de perfil
+        api_title: Foto de perfil
+        api_description: Foto de perfil
+      user_email:
+        name: Correo del usuario
+        heading: Correo del usuario
+        api_title: Correo del usuario
+        api_description: Correo del usuario
+      added_by_id:
+        name: ID del usuario que agregó
+        heading: ID del usuario que agregó
+        api_title: ID del usuario que agregó
+        api_description: ID del usuario que agregó
+      platform_agent_of_id:
+        name: ID del agente de plataforma de
+        heading: ID del agente de plataforma de
+        api_title: ID del agente de plataforma de
+        api_description: ID del agente de plataforma de
+      platform_agent:
+        name: Agente de plataforma
+        heading: Agente de plataforma
+        api_title: Agente de plataforma
+        api_description: Agente de plataforma
+      role_ids:
+        name: Rol
+        label: Rol
+        heading: Rol
+        api_title: Rol
+        api_description: Rol
+        options:
+          default:
+            label: Visualizador
+            description: Solo puede ver los datos del equipo
+          admin:
+            label: Administrador del equipo
+            description: Los administradores del equipo pueden gestionar la facturación
+              y los privilegios especiales de otros usuarios.
+          editor:
+            label: Editor
+            description: Puede editar todos los recursos de este equipo y permitir
+              que otros hagan lo mismo.
+        none: Visualizador
+      created_at:
+        _: Creado el
+        heading: Creado el
+        api_title: Creado el
+        api_description: Creado el
+      updated_at:
+        _: Actualizado el
+        heading: Actualizado el
+        api_title: Actualizado el
+        api_description: Actualizado el
+    index:
+      section: Miembros del equipo %{team_name}
+      contexts:
+        team:
+          header: Miembros del equipo
+          description: Las siguientes personas son miembros de tu equipo. También
+            puedes invitar nuevos miembros del equipo.
+          fields:
+            id:
+              _: ID de membresía
+              label: ID de membresía
+              heading: ID de membresía
+              api_title: ID de membresía
+              api_description: ID de membresía
+            user_id:
+              name: ID de usuario
+              heading: ID de usuario
+              api_title: ID de usuario
+              api_description: ID de usuario
+            team_id:
+              name: ID del equipo
+              heading: ID del equipo
+              api_title: ID del equipo
+              api_description: ID del equipo
+            invitation_id:
+              name: ID de invitación
+              heading: ID de invitación
+              api_title: ID de invitación
+              api_description: ID de invitación
+            name:
+              name: Nombre completo
+              heading: Nombre completo
+              api_title: Nombre completo
+              api_description: Nombre completo
+            user_first_name:
+              name: Nombre
+              label: Nombre
+              heading: Nombre
+              api_title: Nombre
+              api_description: Nombre
+            user_last_name:
+              name: Apellido
+              label: Apellido
+              heading: Apellido
+              api_title: Apellido
+              api_description: Apellido
+            user_profile_photo_id:
+              name: Foto de perfil
+              label: Foto de perfil
+              heading: Foto de perfil
+              api_title: Foto de perfil
+              api_description: Foto de perfil
+            user_profile_photo:
+              name: Foto de perfil
+              label: Foto de perfil
+              heading: Foto de perfil
+              api_title: Foto de perfil
+              api_description: Foto de perfil
+            user_email:
+              name: Correo del usuario
+              heading: Correo del usuario
+              api_title: Correo del usuario
+              api_description: Correo del usuario
+            added_by_id:
+              name: ID del usuario que agregó
+              heading: ID del usuario que agregó
+              api_title: ID del usuario que agregó
+              api_description: ID del usuario que agregó
+            platform_agent_of_id:
+              name: ID del agente de plataforma de
+              heading: ID del agente de plataforma de
+              api_title: ID del agente de plataforma de
+              api_description: ID del agente de plataforma de
+            platform_agent:
+              name: Agente de plataforma
+              heading: Agente de plataforma
+              api_title: Agente de plataforma
+              api_description: Agente de plataforma
+            role_ids:
+              name: Rol
+              label: Rol
+              heading: Rol
+              api_title: Rol
+              api_description: Rol
+              options:
+                default:
+                  label: Visualizador
+                  description: Solo puede ver los datos del equipo
+                admin:
+                  label: Administrador del equipo
+                  description: Los administradores del equipo pueden gestionar la
+                    facturación y los privilegios especiales de otros usuarios.
+                editor:
+                  label: Editor
+                  description: Puede editar todos los recursos de este equipo y permitir
+                    que otros hagan lo mismo.
+              none: Visualizador
+            created_at:
+              _: Creado el
+              heading: Creado el
+              api_title: Creado el
+              api_description: Creado el
+            updated_at:
+              _: Actualizado el
+              heading: Actualizado el
+              api_title: Actualizado el
+              api_description: Actualizado el
+      buttons:
+        edit: Configuración
+        show: Detalles
+        resend: Reenviar
+        update: Actualizar membresía
+        demote: Degradar de administrador
+        promote: Promover a administrador
+        destroy: Eliminar del equipo
+        destroy_own: Abandonar este equipo
+        reinvite: Invitar al equipo
+        confirmations:
+          destroy: "¿Seguro que deseas eliminar a %{membership_name} de %{team_name}?"
+          destroy_own: "¿Seguro que deseas eliminarte de %{team_name}? No podrás deshacer
+            esta acción."
+          reinvite: "¿Seguro que deseas invitar a %{membership_name} a %{team_name}?"
+    tombstones:
+      contexts:
+        team:
+          header: Miembros en espera de invitación
+          description: Las siguientes personas han sido eliminadas de %{team_name},
+            pero aún puedes administrar su perfil y reasignar sus asignaciones a otros
+            miembros del equipo.
+      buttons:
+        edit: Configuración
+        show: Detalles
+        resend: Reenviar
+        update: Actualizar membresía
+        demote: Degradar de administrador
+        promote: Promover a administrador
+        destroy: Eliminar del equipo
+        destroy_own: Abandonar este equipo
+        reinvite: Invitar al equipo
+        confirmations:
+          destroy: "¿Seguro que deseas eliminar a %{membership_name} de %{team_name}?"
+          destroy_own: "¿Seguro que deseas eliminarte de %{team_name}? No podrás deshacer
+            esta acción."
+          reinvite: "¿Seguro que deseas invitar a %{membership_name} a %{team_name}?"
+    form:
+      grant_privileges_of: Conceder privilegios de %{role_key}
+      buttons:
+        edit: Configuración
+        show: Detalles
+        resend: Reenviar
+        update: Actualizar membresía
+        demote: Degradar de administrador
+        promote: Promover a administrador
+        destroy: Eliminar del equipo
+        destroy_own: Abandonar este equipo
+        reinvite: Invitar al equipo
+        confirmations:
+          destroy: "¿Seguro que deseas eliminar a %{membership_name} de %{team_name}?"
+          destroy_own: "¿Seguro que deseas eliminarte de %{team_name}? No podrás deshacer
+            esta acción."
+          reinvite: "¿Seguro que deseas invitar a %{membership_name} a %{team_name}?"
+      fields:
+        id:
+          _: ID de membresía
+          label: ID de membresía
+          heading: ID de membresía
+          api_title: ID de membresía
+          api_description: ID de membresía
+        user_id:
+          name: ID de usuario
+          heading: ID de usuario
+          api_title: ID de usuario
+          api_description: ID de usuario
+        team_id:
+          name: ID del equipo
+          heading: ID del equipo
+          api_title: ID del equipo
+          api_description: ID del equipo
+        invitation_id:
+          name: ID de invitación
+          heading: ID de invitación
+          api_title: ID de invitación
+          api_description: ID de invitación
+        name:
+          name: Nombre completo
+          heading: Nombre completo
+          api_title: Nombre completo
+          api_description: Nombre completo
+        user_first_name:
+          name: Nombre
+          label: Nombre
+          heading: Nombre
+          api_title: Nombre
+          api_description: Nombre
+        user_last_name:
+          name: Apellido
+          label: Apellido
+          heading: Apellido
+          api_title: Apellido
+          api_description: Apellido
+        user_profile_photo_id:
+          name: Foto de perfil
+          label: Foto de perfil
+          heading: Foto de perfil
+          api_title: Foto de perfil
+          api_description: Foto de perfil
+        user_profile_photo:
+          name: Foto de perfil
+          label: Foto de perfil
+          heading: Foto de perfil
+          api_title: Foto de perfil
+          api_description: Foto de perfil
+        user_email:
+          name: Correo del usuario
+          heading: Correo del usuario
+          api_title: Correo del usuario
+          api_description: Correo del usuario
+        added_by_id:
+          name: ID del usuario que agregó
+          heading: ID del usuario que agregó
+          api_title: ID del usuario que agregó
+          api_description: ID del usuario que agregó
+        platform_agent_of_id:
+          name: ID del agente de plataforma de
+          heading: ID del agente de plataforma de
+          api_title: ID del agente de plataforma de
+          api_description: ID del agente de plataforma de
+        platform_agent:
+          name: Agente de plataforma
+          heading: Agente de plataforma
+          api_title: Agente de plataforma
+          api_description: Agente de plataforma
+        role_ids:
+          name: Rol
+          label: Rol
+          heading: Rol
+          api_title: Rol
+          api_description: Rol
+          options:
+            default:
+              label: Visualizador
+              description: Solo puede ver los datos del equipo
+            admin:
+              label: Administrador del equipo
+              description: Los administradores del equipo pueden gestionar la facturación
+                y los privilegios especiales de otros usuarios.
+            editor:
+              label: Editor
+              description: Puede editar todos los recursos de este equipo y permitir
+                que otros hagan lo mismo.
+          none: Visualizador
+        created_at:
+          _: Creado el
+          heading: Creado el
+          api_title: Creado el
+          api_description: Creado el
+        updated_at:
+          _: Actualizado el
+          heading: Actualizado el
+          api_title: Actualizado el
+          api_description: Actualizado el
+    edit:
+      section: "%{membership_name} en %{team_name}"
+      header: Actualizar configuración de membresía
+      description: Puedes editar la configuración de la membresía %{memberships_possessive}
+        en %{team_name} a continuación.
+      grant_privileges_of: Conceder privilegios de %{role_key}
+      remove_header: Eliminar miembro del equipo
+      remove_description: Eliminar a %{membership_name} no eliminará ninguna asignación
+        de recursos. En su lugar, tendrás la opción de reasignar recursos a otro miembro
+        del equipo. También podrás volver a invitar a %{membership_name} al equipo
+        en el futuro.
+      buttons:
+        edit: Configuración
+        show: Detalles
+        resend: Reenviar
+        update: Actualizar membresía
+        demote: Degradar de administrador
+        promote: Promover a administrador
+        destroy: Eliminar del equipo
+        destroy_own: Abandonar este equipo
+        reinvite: Invitar al equipo
+        confirmations:
+          destroy: "¿Seguro que deseas eliminar a %{membership_name} de %{team_name}?"
+          destroy_own: "¿Seguro que deseas eliminarte de %{team_name}? No podrás deshacer
+            esta acción."
+          reinvite: "¿Seguro que deseas invitar a %{membership_name} a %{team_name}?"
+    show:
+      section: Membresía %{memberships_possessive} en %{team_name}
+      header: Detalles de la membresía
+      invitation_header: Detalles de la invitación
+      tombstone_header: Exmiembro del equipo
+      description: A continuación se detallan los datos de la membresía %{memberships_possessive}
+        en %{team_name}.
+      buttons:
+        edit: Configuración
+        show: Detalles
+        resend: Reenviar
+        update: Actualizar membresía
+        demote: Degradar de administrador
+        promote: Promover a administrador
+        destroy: Eliminar del equipo
+        destroy_own: Abandonar este equipo
+        reinvite: Invitar al equipo
+        confirmations:
+          destroy: "¿Seguro que deseas eliminar a %{membership_name} de %{team_name}?"
+          destroy_own: "¿Seguro que deseas eliminarte de %{team_name}? No podrás deshacer
+            esta acción."
+          reinvite: "¿Seguro que deseas invitar a %{membership_name} a %{team_name}?"
+      fields:
+        id:
+          _: ID de membresía
+          label: ID de membresía
+          heading: ID de membresía
+          api_title: ID de membresía
+          api_description: ID de membresía
+        user_id:
+          name: ID de usuario
+          heading: ID de usuario
+          api_title: ID de usuario
+          api_description: ID de usuario
+        team_id:
+          name: ID del equipo
+          heading: ID del equipo
+          api_title: ID del equipo
+          api_description: ID del equipo
+        invitation_id:
+          name: ID de invitación
+          heading: ID de invitación
+          api_title: ID de invitación
+          api_description: ID de invitación
+        name:
+          name: Nombre completo
+          heading: Nombre completo
+          api_title: Nombre completo
+          api_description: Nombre completo
+        user_first_name:
+          name: Nombre
+          label: Nombre
+          heading: Nombre
+          api_title: Nombre
+          api_description: Nombre
+        user_last_name:
+          name: Apellido
+          label: Apellido
+          heading: Apellido
+          api_title: Apellido
+          api_description: Apellido
+        user_profile_photo_id:
+          name: Foto de perfil
+          label: Foto de perfil
+          heading: Foto de perfil
+          api_title: Foto de perfil
+          api_description: Foto de perfil
+        user_profile_photo:
+          name: Foto de perfil
+          label: Foto de perfil
+          heading: Foto de perfil
+          api_title: Foto de perfil
+          api_description: Foto de perfil
+        user_email:
+          name: Correo del usuario
+          heading: Correo del usuario
+          api_title: Correo del usuario
+          api_description: Correo del usuario
+        added_by_id:
+          name: ID del usuario que agregó
+          heading: ID del usuario que agregó
+          api_title: ID del usuario que agregó
+          api_description: ID del usuario que agregó
+        platform_agent_of_id:
+          name: ID del agente de plataforma de
+          heading: ID del agente de plataforma de
+          api_title: ID del agente de plataforma de
+          api_description: ID del agente de plataforma de
+        platform_agent:
+          name: Agente de plataforma
+          heading: Agente de plataforma
+          api_title: Agente de plataforma
+          api_description: Agente de plataforma
+        role_ids:
+          name: Rol
+          label: Rol
+          heading: Rol
+          api_title: Rol
+          api_description: Rol
+          options:
+            default:
+              label: Visualizador
+              description: Solo puede ver los datos del equipo
+            admin:
+              label: Administrador del equipo
+              description: Los administradores del equipo pueden gestionar la facturación
+                y los privilegios especiales de otros usuarios.
+            editor:
+              label: Editor
+              description: Puede editar todos los recursos de este equipo y permitir
+                que otros hagan lo mismo.
+          none: Visualizador
+        created_at:
+          _: Creado el
+          heading: Creado el
+          api_title: Creado el
+          api_description: Creado el
+        updated_at:
+          _: Actualizado el
+          heading: Actualizado el
+          api_title: Actualizado el
+          api_description: Actualizado el
+    notifications:
+      updated: Membresía actualizada correctamente.
+      destroyed: Ese usuario ha sido eliminado del equipo correctamente.
+      no_members: "¡Aún no tienes otros miembros del equipo! Comienza enviando una
+        invitación."
+      cant_demote: No puedes degradar al último administrador de un equipo. Primero
+        asigna a otra persona como administrador.
+      cant_remove: No puedes eliminar al último administrador de un equipo. Primero
+        asigna a otra persona como administrador.
+      you_removed_yourself: Te has eliminado a ti mismo de %{team_name}.
+      reinvited: El usuario ha sido invitado correctamente. Recibirá un correo para
+        unirse al equipo.
+  account:
+    memberships:
+      label: Miembros del equipo
+      singular: Miembro del equipo
+      navigation:
+        label: Miembros del equipo
+        icon: fa-light fa-users
+      breadcrumbs:
+        label: Miembros del equipo
+      buttons:
+        edit: Ajustes
+        show: Detalles
+        resend: Reenviar
+        update: Actualizar membresía
+        demote: Degradación de administrador
+        promote: Ascender a administrador
+        destroy: Eliminar del equipo
+        destroy_own: Abandona este equipo
+        reinvite: Volver a invitar al equipo
+        confirmations:
+          destroy: "¿Está seguro de que desea eliminar %{membership_name} de %{team_name}?"
+          destroy_own: "¿Estás seguro de que quieres eliminarte de %{team_name}? No
+            podrás deshacer esta acción."
+          reinvite: "¿Estás seguro de que quieres volver a invitar a %{membership_name}
+            a %{team_name}?"
+      fields:
+        id:
+          _: ID de membresía
+          label: ID de membresía
+          heading: ID de membresía
+          api_title: ID de membresía
+          api_description: ID de membresía
+        user_id:
+          name: ID de usuario
+          heading: ID de usuario
+          api_title: ID de usuario
+          api_description: ID de usuario
+        team_id:
+          name: ID del equipo
+          heading: ID del equipo
+          api_title: ID del equipo
+          api_description: ID del equipo
+        invitation_id:
+          name: ID de invitación
+          heading: ID de invitación
+          api_title: ID de invitación
+          api_description: ID de invitación
+        name:
+          name: Nombre completo
+          heading: Nombre completo
+          api_title: Nombre completo
+          api_description: Nombre completo
+        user_first_name:
+          name: Nombre
+          label: Nombre
+          heading: Nombre
+          api_title: Nombre
+          api_description: Nombre
+        user_last_name:
+          name: Apellido
+          label: Apellido
+          heading: Apellido
+          api_title: Apellido
+          api_description: Apellido
+        user_profile_photo_id:
+          name: Foto de perfil
+          label: Foto de perfil
+          heading: Foto de perfil
+          api_title: Foto de perfil
+          api_description: Foto de perfil
+        user_profile_photo:
+          name: Foto de perfil
+          label: Foto de perfil
+          heading: Foto de perfil
+          api_title: Foto de perfil
+          api_description: Foto de perfil
+        user_email:
+          name: Correo del usuario
+          heading: Correo del usuario
+          api_title: Correo del usuario
+          api_description: Correo del usuario
+        added_by_id:
+          name: ID del usuario que agregó
+          heading: ID del usuario que agregó
+          api_title: ID del usuario que agregó
+          api_description: ID del usuario que agregó
+        platform_agent_of_id:
+          name: ID del agente de plataforma de
+          heading: ID del agente de plataforma de
+          api_title: ID del agente de plataforma de
+          api_description: ID del agente de plataforma de
+        platform_agent:
+          name: Agente de plataforma
+          heading: Agente de plataforma
+          api_title: Agente de plataforma
+          api_description: Agente de plataforma
+        role_ids:
+          name: Rol
+          label: Rol
+          heading: Rol
+          api_title: Rol
+          api_description: Rol
+          options:
+            default:
+              label: Visualizador
+              description: Solo puede ver los datos del equipo
+            admin:
+              label: Administrador del equipo
+              description: Los administradores del equipo pueden gestionar la facturación
+                y los privilegios especiales de otros usuarios.
+            editor:
+              label: Editor
+              description: Puede editar todos los recursos de este equipo y permitir
+                que otros hagan lo mismo.
+          none: Visualizador
+        created_at:
+          _: Creado el
+          heading: Creado el
+          api_title: Creado el
+          api_description: Creado el
+        updated_at:
+          _: Actualizado el
+          heading: Actualizado el
+          api_title: Actualizado el
+          api_description: Actualizado el
+      index:
+        section: Miembros del equipo %{team_name}
+        contexts:
+          team:
+            header: Miembros del equipo
+            description: Las siguientes personas son miembros de tu equipo. También
+              puedes invitar nuevos miembros del equipo.
+            fields:
+              id:
+                _: ID de membresía
+                label: ID de membresía
+                heading: ID de membresía
+                api_title: ID de membresía
+                api_description: ID de membresía
+              user_id:
+                name: ID de usuario
+                heading: ID de usuario
+                api_title: ID de usuario
+                api_description: ID de usuario
+              team_id:
+                name: ID del equipo
+                heading: ID del equipo
+                api_title: ID del equipo
+                api_description: ID del equipo
+              invitation_id:
+                name: ID de invitación
+                heading: ID de invitación
+                api_title: ID de invitación
+                api_description: ID de invitación
+              name:
+                name: Nombre completo
+                heading: Nombre completo
+                api_title: Nombre completo
+                api_description: Nombre completo
+              user_first_name:
+                name: Nombre
+                label: Nombre
+                heading: Nombre
+                api_title: Nombre
+                api_description: Nombre
+              user_last_name:
+                name: Apellido
+                label: Apellido
+                heading: Apellido
+                api_title: Apellido
+                api_description: Apellido
+              user_profile_photo_id:
+                name: Foto de perfil
+                label: Foto de perfil
+                heading: Foto de perfil
+                api_title: Foto de perfil
+                api_description: Foto de perfil
+              user_profile_photo:
+                name: Foto de perfil
+                label: Foto de perfil
+                heading: Foto de perfil
+                api_title: Foto de perfil
+                api_description: Foto de perfil
+              user_email:
+                name: Correo del usuario
+                heading: Correo del usuario
+                api_title: Correo del usuario
+                api_description: Correo del usuario
+              added_by_id:
+                name: ID del usuario que agregó
+                heading: ID del usuario que agregó
+                api_title: ID del usuario que agregó
+                api_description: ID del usuario que agregó
+              platform_agent_of_id:
+                name: ID del agente de plataforma de
+                heading: ID del agente de plataforma de
+                api_title: ID del agente de plataforma de
+                api_description: ID del agente de plataforma de
+              platform_agent:
+                name: Agente de plataforma
+                heading: Agente de plataforma
+                api_title: Agente de plataforma
+                api_description: Agente de plataforma
+              role_ids:
+                name: Rol
+                label: Rol
+                heading: Rol
+                api_title: Rol
+                api_description: Rol
+                options:
+                  default:
+                    label: Visualizador
+                    description: Solo puede ver los datos del equipo
+                  admin:
+                    label: Administrador del equipo
+                    description: Los administradores del equipo pueden gestionar la
+                      facturación y los privilegios especiales de otros usuarios.
+                  editor:
+                    label: Editor
+                    description: Puede editar todos los recursos de este equipo y
+                      permitir que otros hagan lo mismo.
+                none: Visualizador
+              created_at:
+                _: Creado el
+                heading: Creado el
+                api_title: Creado el
+                api_description: Creado el
+              updated_at:
+                _: Actualizado el
+                heading: Actualizado el
+                api_title: Actualizado el
+                api_description: Actualizado el
+        buttons:
+          edit: Configuración
+          show: Detalles
+          resend: Reenviar
+          update: Actualizar membresía
+          demote: Degradar de administrador
+          promote: Promover a administrador
+          destroy: Eliminar del equipo
+          destroy_own: Abandonar este equipo
+          reinvite: Invitar al equipo
+          confirmations:
+            destroy: "¿Seguro que deseas eliminar a %{membership_name} de %{team_name}?"
+            destroy_own: "¿Seguro que deseas eliminarte de %{team_name}? No podrás
+              deshacer esta acción."
+            reinvite: "¿Seguro que deseas invitar a %{membership_name} a %{team_name}?"
+      tombstones:
+        contexts:
+          team:
+            header: Miembros en espera de invitación
+            description: Las siguientes personas han sido eliminadas de %{team_name},
+              pero aún puedes administrar su perfil y reasignar sus asignaciones a
+              otros miembros del equipo.
+        buttons:
+          edit: Configuración
+          show: Detalles
+          resend: Reenviar
+          update: Actualizar membresía
+          demote: Degradar de administrador
+          promote: Promover a administrador
+          destroy: Eliminar del equipo
+          destroy_own: Abandonar este equipo
+          reinvite: Invitar al equipo
+          confirmations:
+            destroy: "¿Seguro que deseas eliminar a %{membership_name} de %{team_name}?"
+            destroy_own: "¿Seguro que deseas eliminarte de %{team_name}? No podrás
+              deshacer esta acción."
+            reinvite: "¿Seguro que deseas invitar a %{membership_name} a %{team_name}?"
+      form:
+        grant_privileges_of: Conceder privilegios de %{role_key}
+        buttons:
+          edit: Configuración
+          show: Detalles
+          resend: Reenviar
+          update: Actualizar membresía
+          demote: Degradar de administrador
+          promote: Promover a administrador
+          destroy: Eliminar del equipo
+          destroy_own: Abandonar este equipo
+          reinvite: Invitar al equipo
+          confirmations:
+            destroy: "¿Seguro que deseas eliminar a %{membership_name} de %{team_name}?"
+            destroy_own: "¿Seguro que deseas eliminarte de %{team_name}? No podrás
+              deshacer esta acción."
+            reinvite: "¿Seguro que deseas invitar a %{membership_name} a %{team_name}?"
+        fields:
+          id:
+            _: ID de membresía
+            label: ID de membresía
+            heading: ID de membresía
+            api_title: ID de membresía
+            api_description: ID de membresía
+          user_id:
+            name: ID de usuario
+            heading: ID de usuario
+            api_title: ID de usuario
+            api_description: ID de usuario
+          team_id:
+            name: ID del equipo
+            heading: ID del equipo
+            api_title: ID del equipo
+            api_description: ID del equipo
+          invitation_id:
+            name: ID de invitación
+            heading: ID de invitación
+            api_title: ID de invitación
+            api_description: ID de invitación
+          name:
+            name: Nombre completo
+            heading: Nombre completo
+            api_title: Nombre completo
+            api_description: Nombre completo
+          user_first_name:
+            name: Nombre
+            label: Nombre
+            heading: Nombre
+            api_title: Nombre
+            api_description: Nombre
+          user_last_name:
+            name: Apellido
+            label: Apellido
+            heading: Apellido
+            api_title: Apellido
+            api_description: Apellido
+          user_profile_photo_id:
+            name: Foto de perfil
+            label: Foto de perfil
+            heading: Foto de perfil
+            api_title: Foto de perfil
+            api_description: Foto de perfil
+          user_profile_photo:
+            name: Foto de perfil
+            label: Foto de perfil
+            heading: Foto de perfil
+            api_title: Foto de perfil
+            api_description: Foto de perfil
+          user_email:
+            name: Correo del usuario
+            heading: Correo del usuario
+            api_title: Correo del usuario
+            api_description: Correo del usuario
+          added_by_id:
+            name: ID del usuario que agregó
+            heading: ID del usuario que agregó
+            api_title: ID del usuario que agregó
+            api_description: ID del usuario que agregó
+          platform_agent_of_id:
+            name: ID del agente de plataforma de
+            heading: ID del agente de plataforma de
+            api_title: ID del agente de plataforma de
+            api_description: ID del agente de plataforma de
+          platform_agent:
+            name: Agente de plataforma
+            heading: Agente de plataforma
+            api_title: Agente de plataforma
+            api_description: Agente de plataforma
+          role_ids:
+            name: Rol
+            label: Rol
+            heading: Rol
+            api_title: Rol
+            api_description: Rol
+            options:
+              default:
+                label: Visualizador
+                description: Solo puede ver los datos del equipo
+              admin:
+                label: Administrador del equipo
+                description: Los administradores del equipo pueden gestionar la facturación
+                  y los privilegios especiales de otros usuarios.
+              editor:
+                label: Editor
+                description: Puede editar todos los recursos de este equipo y permitir
+                  que otros hagan lo mismo.
+            none: Visualizador
+          created_at:
+            _: Creado el
+            heading: Creado el
+            api_title: Creado el
+            api_description: Creado el
+          updated_at:
+            _: Actualizado el
+            heading: Actualizado el
+            api_title: Actualizado el
+            api_description: Actualizado el
+      edit:
+        section: "%{membership_name} en %{team_name}"
+        header: Actualizar configuración de membresía
+        description: Puedes editar la configuración de la membresía %{memberships_possessive}
+          en %{team_name} a continuación.
+        grant_privileges_of: Conceder privilegios de %{role_key}
+        remove_header: Eliminar miembro del equipo
+        remove_description: Eliminar a %{membership_name} no eliminará ninguna asignación
+          de recursos. En su lugar, tendrás la opción de reasignar recursos a otro
+          miembro del equipo. También podrás volver a invitar a %{membership_name}
+          al equipo en el futuro.
+        buttons:
+          edit: Configuración
+          show: Detalles
+          resend: Reenviar
+          update: Actualizar membresía
+          demote: Degradar de administrador
+          promote: Promover a administrador
+          destroy: Eliminar del equipo
+          destroy_own: Abandonar este equipo
+          reinvite: Invitar al equipo
+          confirmations:
+            destroy: "¿Seguro que deseas eliminar a %{membership_name} de %{team_name}?"
+            destroy_own: "¿Seguro que deseas eliminarte de %{team_name}? No podrás
+              deshacer esta acción."
+            reinvite: "¿Seguro que deseas invitar a %{membership_name} a %{team_name}?"
+      show:
+        section: Membresía %{memberships_possessive} en %{team_name}
+        header: Detalles de la membresía
+        invitation_header: Detalles de la invitación
+        tombstone_header: Exmiembro del equipo
+        description: A continuación se detallan los datos de la membresía %{memberships_possessive}
+          en %{team_name}.
+        buttons:
+          edit: Configuración
+          show: Detalles
+          resend: Reenviar
+          update: Actualizar membresía
+          demote: Degradar de administrador
+          promote: Promover a administrador
+          destroy: Eliminar del equipo
+          destroy_own: Abandonar este equipo
+          reinvite: Invitar al equipo
+          confirmations:
+            destroy: "¿Seguro que deseas eliminar a %{membership_name} de %{team_name}?"
+            destroy_own: "¿Seguro que deseas eliminarte de %{team_name}? No podrás
+              deshacer esta acción."
+            reinvite: "¿Seguro que deseas invitar a %{membership_name} a %{team_name}?"
+        fields:
+          id:
+            _: ID de membresía
+            label: ID de membresía
+            heading: ID de membresía
+            api_title: ID de membresía
+            api_description: ID de membresía
+          user_id:
+            name: ID de usuario
+            heading: ID de usuario
+            api_title: ID de usuario
+            api_description: ID de usuario
+          team_id:
+            name: ID del equipo
+            heading: ID del equipo
+            api_title: ID del equipo
+            api_description: ID del equipo
+          invitation_id:
+            name: ID de invitación
+            heading: ID de invitación
+            api_title: ID de invitación
+            api_description: ID de invitación
+          name:
+            name: Nombre completo
+            heading: Nombre completo
+            api_title: Nombre completo
+            api_description: Nombre completo
+          user_first_name:
+            name: Nombre
+            label: Nombre
+            heading: Nombre
+            api_title: Nombre
+            api_description: Nombre
+          user_last_name:
+            name: Apellido
+            label: Apellido
+            heading: Apellido
+            api_title: Apellido
+            api_description: Apellido
+          user_profile_photo_id:
+            name: Foto de perfil
+            label: Foto de perfil
+            heading: Foto de perfil
+            api_title: Foto de perfil
+            api_description: Foto de perfil
+          user_profile_photo:
+            name: Foto de perfil
+            label: Foto de perfil
+            heading: Foto de perfil
+            api_title: Foto de perfil
+            api_description: Foto de perfil
+          user_email:
+            name: Correo del usuario
+            heading: Correo del usuario
+            api_title: Correo del usuario
+            api_description: Correo del usuario
+          added_by_id:
+            name: ID del usuario que agregó
+            heading: ID del usuario que agregó
+            api_title: ID del usuario que agregó
+            api_description: ID del usuario que agregó
+          platform_agent_of_id:
+            name: ID del agente de plataforma de
+            heading: ID del agente de plataforma de
+            api_title: ID del agente de plataforma de
+            api_description: ID del agente de plataforma de
+          platform_agent:
+            name: Agente de plataforma
+            heading: Agente de plataforma
+            api_title: Agente de plataforma
+            api_description: Agente de plataforma
+          role_ids:
+            name: Rol
+            label: Rol
+            heading: Rol
+            api_title: Rol
+            api_description: Rol
+            options:
+              default:
+                label: Visualizador
+                description: Solo puede ver los datos del equipo
+              admin:
+                label: Administrador del equipo
+                description: Los administradores del equipo pueden gestionar la facturación
+                  y los privilegios especiales de otros usuarios.
+              editor:
+                label: Editor
+                description: Puede editar todos los recursos de este equipo y permitir
+                  que otros hagan lo mismo.
+            none: Visualizador
+          created_at:
+            _: Creado el
+            heading: Creado el
+            api_title: Creado el
+            api_description: Creado el
+          updated_at:
+            _: Actualizado el
+            heading: Actualizado el
+            api_title: Actualizado el
+            api_description: Actualizado el
+      notifications:
+        updated: Membresía actualizada correctamente.
+        destroyed: Ese usuario ha sido eliminado del equipo correctamente.
+        no_members: "¡Aún no tienes otros miembros del equipo! Comienza enviando una
+          invitación."
+        cant_demote: No puedes degradar al último administrador de un equipo. Primero
+          asigna a otra persona como administrador.
+        cant_remove: No puedes eliminar al último administrador de un equipo. Primero
+          asigna a otra persona como administrador.
+        you_removed_yourself: Te has eliminado a ti mismo de %{team_name}.
+        reinvited: El usuario ha sido invitado correctamente. Recibirá un correo para
+          unirse al equipo.
+  activerecord:
+    attributes:
+      memberships:
+        user_first_name: Nombre
+        user_last_name: Apellido

--- a/bullet_train/config/locales/es/onboarding/user_details.es.yml
+++ b/bullet_train/config/locales/es/onboarding/user_details.es.yml
@@ -1,0 +1,19 @@
+---
+es:
+  onboarding:
+    user_details:
+      buttons:
+        next: Próximo
+      edit:
+        header: Cuéntanos sobre ti
+        buttons:
+          next: Próximo
+  account:
+    onboarding:
+      user_details:
+        buttons:
+          next: Próximo
+        edit:
+          header: Cuéntanos sobre ti
+          buttons:
+            next: Próximo

--- a/bullet_train/config/locales/es/teams.es.yml
+++ b/bullet_train/config/locales/es/teams.es.yml
@@ -1,0 +1,386 @@
+---
+es:
+  teams:
+    label: Equipos
+    singular: Equipo
+    breadcrumbs:
+      label: Equipos
+      team_settings: Configuración del equipo
+      dashboard: Panel
+    navigation:
+      label: Equipo
+    buttons:
+      new: Agregar nuevo equipo
+      create: Crear equipo
+      edit: Editar equipo
+      update: Actualizar equipo
+      destroy: Eliminar equipo
+      confirmations:
+        destroy: "¿Estás seguro de que quieres eliminar este equipo?"
+    index:
+      section: Equipos
+      header: Tus equipos
+      create: Crear nuevo equipo
+      buttons:
+        new: Agregar nuevo equipo
+        create: Crear equipo
+        edit: Editar equipo
+        update: Actualizar equipo
+        destroy: Eliminar equipo
+        confirmations:
+          destroy: "¿Estás seguro de que quieres eliminar este equipo?"
+    show:
+      header: Dashboard de %{teams_possessive}
+    new:
+      header: Crear un nuevo equipo
+      former_user_header: Unirse a un equipo
+      default_team_name: Tu equipo
+      buttons:
+        new: Agregar nuevo equipo
+        create: Crear equipo
+        edit: Editar equipo
+        update: Actualizar equipo
+        destroy: Eliminar equipo
+        confirmations:
+          destroy: "¿Estás seguro de que quieres eliminar este equipo?"
+      you_can: 'Puedes:'
+      invitation_header: Aceptar una invitación
+      logout_header: Cerrar sesión de esta cuenta
+      new_team_header: Crear un nuevo equipo
+      alert: La cuenta <b>%{user_email}</b> no es actualmente miembro de ningún equipo.
+      invitation: Si has recibido un correo electrónico invitándote a unirte a un
+        nuevo equipo, haz clic en el enlace de ese correo para aceptar la invitación.
+      log_out: Puedes cerrar sesión de esta cuenta e iniciar sesión con una cuenta
+        diferente que sea miembro de un equipo.
+      new_team: Puedes usar el formulario a continuación para crear un nuevo equipo
+        propio.
+    edit:
+      section: "%{team_name}"
+      header: Editar detalles del equipo
+      description: Puedes actualizar los detalles y configuraciones de este equipo
+        a continuación.
+    notifications:
+      created: El equipo se creó exitosamente.
+      updated: El equipo se actualizó exitosamente.
+      destroyed: El equipo se eliminó exitosamente.
+      invitation_only: Actualmente, la creación de nuevos equipos está limitada a
+        los usuarios que han recibido una invitación para el acceso anticipado. Si
+        ha recibido un enlace de acceso anticipado, visítelo antes de intentarlo de
+        nuevo.
+      cannot_delete_last_team: No puedes eliminar el último equipo al que perteneciste.
+    form:
+      buttons:
+        new: Agregar nuevo equipo
+        create: Crear equipo
+        edit: Editar equipo
+        update: Actualizar equipo
+        destroy: Eliminar equipo
+        confirmations:
+          destroy: "¿Estás seguro de que quieres eliminar este equipo?"
+    fields:
+      id:
+        _: ID del equipo
+        label: ID del equipo
+        heading: ID del equipo
+        api_title: ID del equipo
+        api_description: ID del equipo
+      name:
+        _: Nombre del equipo
+        label: Nombre del equipo
+        heading: Equipo
+        api_title: Nombre del equipo
+        api_description: Nombre del equipo
+      time_zone:
+        _: Zona horaria principal
+        label: Zona horaria principal
+        heading: Zona horaria principal
+        api_title: Zona horaria principal
+        api_description: Zona horaria principal
+      locale:
+        _: Idioma
+        label: Idioma principal
+        heading: Idioma
+        api_title: Idioma
+        api_description: Idioma
+      created_at:
+        _: Fecha de registro
+        heading: Fecha de registro
+        api_title: Fecha de registro
+        api_description: Fecha de registro
+      updated_at:
+        _: Actualizado el
+        heading: Actualizado el
+        api_title: Actualizado el
+        api_description: Actualizado el
+    _:
+      name:
+        label: Nombre de tu equipo
+    self:
+      id:
+        _: ID del equipo
+        label: ID del equipo
+        heading: ID del equipo
+        api_title: ID del equipo
+        api_description: ID del equipo
+      name:
+        label: Nombre de tu equipo
+      time_zone:
+        _: Zona horaria principal
+        label: Zona horaria principal
+        heading: Zona horaria principal
+        api_title: Zona horaria principal
+        api_description: Zona horaria principal
+      locale:
+        _: Idioma
+        label: Idioma principal
+        heading: Idioma
+        api_title: Idioma
+        api_description: Idioma
+      created_at:
+        _: Fecha de registro
+        heading: Fecha de registro
+        api_title: Fecha de registro
+        api_description: Fecha de registro
+      updated_at:
+        _: Actualizado el
+        heading: Actualizado el
+        api_title: Actualizado el
+        api_description: Actualizado el
+    api:
+      actions: Acciones para equipos
+      index: Listar equipos
+      create: Agregar un nuevo equipo
+      show: Recuperar un equipo
+      update: Actualizar un equipo
+      fields:
+        id:
+          _: ID del equipo
+          label: ID del equipo
+          heading: ID del equipo
+          api_title: ID del equipo
+          api_description: ID del equipo
+        name:
+          _: Nombre del equipo
+          label: Nombre del equipo
+          heading: Equipo
+          api_title: Nombre del equipo
+          api_description: Nombre del equipo
+        time_zone:
+          _: Zona horaria principal
+          label: Zona horaria principal
+          heading: Zona horaria principal
+          api_title: Zona horaria principal
+          api_description: Zona horaria principal
+        locale:
+          _: Idioma
+          label: Idioma principal
+          heading: Idioma
+          api_title: Idioma
+          api_description: Idioma
+        created_at:
+          _: Fecha de registro
+          heading: Fecha de registro
+          api_title: Fecha de registro
+          api_description: Fecha de registro
+        updated_at:
+          _: Actualizado el
+          heading: Actualizado el
+          api_title: Actualizado el
+          api_description: Actualizado el
+  account:
+    teams:
+      label: Equipos
+      singular: Equipo
+      breadcrumbs:
+        label: Equipos
+        team_settings: Configuración del equipo
+        dashboard: Panel
+      navigation:
+        label: Equipo
+      buttons:
+        new: Agregar nuevo equipo
+        create: Crear equipo
+        edit: Equipo de edición
+        update: Actualizar equipo
+        destroy: Eliminar equipo
+        confirmations:
+          destroy: "¿Estás seguro de que quieres eliminar este equipo?"
+      index:
+        section: Equipos
+        header: Tus equipos
+        create: Crear nuevo equipo
+        buttons:
+          new: Agregar nuevo equipo
+          create: Crear equipo
+          edit: Editar equipo
+          update: Actualizar equipo
+          destroy: Eliminar equipo
+          confirmations:
+            destroy: "¿Estás seguro de que quieres eliminar este equipo?"
+      show:
+        header: Dashboard de %{teams_possessive}
+      new:
+        header: Crear un nuevo equipo
+        former_user_header: Unirse a un equipo
+        default_team_name: Tu equipo
+        buttons:
+          new: Agregar nuevo equipo
+          create: Crear equipo
+          edit: Editar equipo
+          update: Actualizar equipo
+          destroy: Eliminar equipo
+          confirmations:
+            destroy: "¿Estás seguro de que quieres eliminar este equipo?"
+        you_can: 'Puedes:'
+        invitation_header: Aceptar una invitación
+        logout_header: Cerrar sesión de esta cuenta
+        new_team_header: Crear un nuevo equipo
+        alert: La cuenta <b>%{user_email}</b> no es actualmente miembro de ningún
+          equipo.
+        invitation: Si has recibido un correo electrónico invitándote a unirte a un
+          nuevo equipo, haz clic en el enlace de ese correo para aceptar la invitación.
+        log_out: Puedes cerrar sesión de esta cuenta e iniciar sesión con una cuenta
+          diferente que sea miembro de un equipo.
+        new_team: Puedes usar el formulario a continuación para crear un nuevo equipo
+          propio.
+      edit:
+        section: "%{team_name}"
+        header: Editar detalles del equipo
+        description: Puedes actualizar los detalles y configuraciones de este equipo
+          a continuación.
+      notifications:
+        created: El equipo se creó exitosamente.
+        updated: El equipo se actualizó exitosamente.
+        destroyed: El equipo se eliminó exitosamente.
+        invitation_only: Actualmente, la creación de nuevos equipos está limitada
+          a los usuarios que han recibido una invitación para el acceso anticipado.
+          Si ha recibido un enlace de acceso anticipado, visítelo antes de intentarlo
+          de nuevo.
+        cannot_delete_last_team: No puedes eliminar el último equipo al que perteneciste.
+      form:
+        buttons:
+          new: Agregar nuevo equipo
+          create: Crear equipo
+          edit: Editar equipo
+          update: Actualizar equipo
+          destroy: Eliminar equipo
+          confirmations:
+            destroy: "¿Estás seguro de que quieres eliminar este equipo?"
+      fields:
+        id:
+          _: ID del equipo
+          label: ID del equipo
+          heading: ID del equipo
+          api_title: ID del equipo
+          api_description: ID del equipo
+        name:
+          _: Nombre del equipo
+          label: Nombre del equipo
+          heading: Equipo
+          api_title: Nombre del equipo
+          api_description: Nombre del equipo
+        time_zone:
+          _: Zona horaria principal
+          label: Zona horaria principal
+          heading: Zona horaria principal
+          api_title: Zona horaria principal
+          api_description: Zona horaria principal
+        locale:
+          _: Idioma
+          label: Idioma principal
+          heading: Idioma
+          api_title: Idioma
+          api_description: Idioma
+        created_at:
+          _: Me registré en
+          heading: Me registré en
+          api_title: Me registré en
+          api_description: Me registré en
+        updated_at:
+          _: Actualizado en
+          heading: Actualizado en
+          api_title: Actualizado en
+          api_description: Actualizado en
+      _:
+        name:
+          label: Nombre de tu equipo
+      self:
+        id:
+          _: ID del equipo
+          label: ID del equipo
+          heading: ID del equipo
+          api_title: ID del equipo
+          api_description: ID del equipo
+        name:
+          label: Nombre de tu equipo
+        time_zone:
+          _: Zona horaria principal
+          label: Zona horaria principal
+          heading: Zona horaria principal
+          api_title: Zona horaria principal
+          api_description: Zona horaria principal
+        locale:
+          _: Idioma
+          label: Idioma principal
+          heading: Idioma
+          api_title: Idioma
+          api_description: Idioma
+        created_at:
+          _: Fecha de registro
+          heading: Fecha de registro
+          api_title: Fecha de registro
+          api_description: Fecha de registro
+        updated_at:
+          _: Actualizado el
+          heading: Actualizado el
+          api_title: Actualizado el
+          api_description: Actualizado el
+      api:
+        actions: Acciones para equipos
+        index: Listar equipos
+        create: Agregar un nuevo equipo
+        show: Recuperar un equipo
+        update: Actualizar un equipo
+        fields:
+          id:
+            _: ID del equipo
+            label: ID del equipo
+            heading: ID del equipo
+            api_title: ID del equipo
+            api_description: ID del equipo
+          name:
+            _: Nombre del equipo
+            label: Nombre del equipo
+            heading: Equipo
+            api_title: Nombre del equipo
+            api_description: Nombre del equipo
+          time_zone:
+            _: Zona horaria principal
+            label: Zona horaria principal
+            heading: Zona horaria principal
+            api_title: Zona horaria principal
+            api_description: Zona horaria principal
+          locale:
+            _: Idioma
+            label: Idioma principal
+            heading: Idioma
+            api_title: Idioma
+            api_description: Idioma
+          created_at:
+            _: Fecha de registro
+            heading: Fecha de registro
+            api_title: Fecha de registro
+            api_description: Fecha de registro
+          updated_at:
+            _: Actualizado el
+            heading: Actualizado el
+            api_title: Actualizado el
+            api_description: Actualizado el
+  activerecord:
+    attributes:
+      team:
+        name: Nombre del equipo
+        time_zone: Zona horaria principal
+        locale: Idioma
+        created_at: Fecha de registro
+        updated_at: Actualizado el

--- a/bullet_train/config/locales/fr/devise.fr.yml
+++ b/bullet_train/config/locales/fr/devise.fr.yml
@@ -1,0 +1,144 @@
+---
+fr:
+  devise:
+    titles:
+      reset_password: Réinitialiser votre mot de passe
+      sign_in: Se connecter
+    headers:
+      resend_confirm: Renvoyer les instructions de confirmation
+      change_password: Changez votre mot de passe
+      reset_password: Réinitialiser le mot de passe
+      edit_registration: Modifier %{resource_name}
+      cancel_account: Annuler mon compte
+      create_account: Créez votre compte
+      sign_in: Se connecter
+      resend_unlock: Renvoyer les instructions de déverrouillage
+    labels:
+      wait_confirm: 'En attente de confirmation pour : %{unconfirmed_email}'
+    hints:
+      leave_blank: "(laisser vide si vous ne souhaitez pas le modifier)"
+      length: "%{password_length} caractères minimum"
+      need_password: "(Nous avons besoin de votre mot de passe actuel pour confirmer
+        vos modifications.)"
+    buttons:
+      resend_confirm: Renvoyer les instructions de confirmation
+      change_password: Changer mon mot de passe
+      reset_password: Réinitialiser le mot de passe par e-mail
+      cancel_account: Annuler mon compte
+      resend_unlock: Renvoyer les instructions de déverrouillage
+    links:
+      account: Vous n'avez pas de compte ?
+      have_account: Vous avez déjà un compte ?
+      forgot_password: Mot de passe oublié ?
+      log_in: Se connecter
+      sign_up: S'inscrire
+      new_confirm: Vous n'avez pas reçu les instructions de confirmation ?
+      new_unlock: Vous n'avez pas reçu les instructions de déverrouillage ?
+      sign_in_with: Connectez-vous avec %{provider}
+    confirmations:
+      confirmed: Votre adresse e-mail a été confirmée avec succès.
+      send_instructions: Vous recevrez dans quelques minutes un courriel contenant
+        les instructions pour confirmer votre adresse électronique.
+      send_paranoid_instructions: Si votre adresse électronique figure dans notre
+        base de données, vous recevrez dans quelques minutes un courriel contenant
+        les instructions pour la confirmer.
+    failure:
+      already_authenticated: Vous êtes déjà connecté.
+      inactive: Votre compte n'est pas encore activé.
+      invalid: "%{authentication_keys} ou mot de passe invalide."
+      locked: Votre compte est bloqué.
+      last_attempt: Il vous reste une dernière tentative avant que votre compte ne
+        soit bloqué.
+      not_found_in_database: "%{authentication_keys} ou mot de passe invalide."
+      timeout: Votre session a expiré. Veuillez vous reconnecter pour continuer.
+      unauthenticated: Vous devez vous connecter ou créer un compte avant de continuer.
+      unconfirmed: Vous devez confirmer votre adresse électronique avant de continuer.
+    mailer:
+      confirmation_instructions:
+        subject: Instructions de confirmation
+        welcome: Bienvenue %{email} !
+        description: 'Vous pouvez confirmer l''adresse e-mail de votre compte via
+          le lien ci-dessous :'
+        confirm_account: Confirmer mon compte
+      reset_password_instructions:
+        subject: Instructions de réinitialisation du mot de passe
+        hello: Bonjour %{email} !
+        requested_change: Quelqu'un a demandé un lien pour modifier votre mot de passe.
+          Vous pouvez le faire via le lien ci-dessous.
+        ignore: Si vous n'avez pas fait cette demande, veuillez ignorer ce courriel.
+        access_change: Votre mot de passe ne changera pas tant que vous n'aurez pas
+          accédé au lien ci-dessus et créé un nouveau.
+        change_password: Changer mon mot de passe
+      unlock_instructions:
+        subject: Instructions de déverrouillage
+        hello: Bonjour %{email} !
+        account_blocked: Votre compte a été bloqué en raison d'un nombre excessif
+          de tentatives de connexion infructueuses.
+        click_link: 'Cliquez sur le lien ci-dessous pour déverrouiller votre compte :'
+        unlock: Débloquer mon compte
+      password_change:
+        subject: Mot de passe modifié
+        hello: Bonjour %{email} !
+        description: Nous vous contactons pour vous informer que votre mot de passe
+          a été modifié.
+      email_changed:
+        subject: Adresse électronique modifiée
+        hello: Bonjour %{email} !
+        description: Nous vous contactons pour vous informer que votre adresse e-mail
+          a été modifiée et est désormais %{email}.
+    omniauth_callbacks:
+      failure: Impossible de vous authentifier depuis %{kind} car "%{reason}".
+      success: Authentification réussie depuis le compte %{kind}.
+    passwords:
+      no_token: Vous ne pouvez accéder à cette page qu'après avoir reçu un e-mail
+        de réinitialisation de mot de passe. Si vous avez reçu un tel e-mail, veuillez
+        vérifier que vous avez bien utilisé l'URL complète.
+      send_instructions: Vous recevrez dans quelques minutes un courriel contenant
+        les instructions pour réinitialiser votre mot de passe.
+      send_paranoid_instructions: Si votre adresse électronique figure dans notre
+        base de données, vous recevrez un lien de récupération de mot de passe à cette
+        adresse dans quelques minutes.
+      updated: Votre mot de passe a été modifié avec succès. Vous êtes maintenant
+        connecté.
+      updated_not_active: Votre mot de passe a été modifié avec succès.
+    registrations:
+      destroyed: Au revoir ! Votre compte a bien été supprimé. Nous espérons vous
+        revoir bientôt.
+      signed_up: Bienvenue ! Votre inscription a bien été prise en compte.
+      signed_up_but_inactive: Votre inscription a bien été prise en compte. Cependant,
+        nous n'avons pas pu vous connecter car votre compte n'est pas encore activé.
+      signed_up_but_locked: Votre inscription a bien été prise en compte. Cependant,
+        nous n'avons pas pu vous connecter car votre compte est verrouillé.
+      signed_up_but_unconfirmed: Un message contenant un lien de confirmation a été
+        envoyé à votre adresse courriel. Veuillez suivre ce lien pour activer votre
+        compte.
+      update_needs_confirmation: Votre compte a bien été mis à jour, mais nous devons
+        vérifier votre nouvelle adresse courriel. Veuillez consulter votre boîte de
+        réception et suivre le lien de confirmation pour valider votre nouvelle adresse
+        courriel.
+      updated: Votre compte a été mis à jour avec succès.
+    sessions:
+      signed_in: Connexion réussie.
+      signed_out: Déconnexion réussie.
+      already_signed_out: Déconnexion réussie.
+    unlocks:
+      send_instructions: Vous recevrez dans quelques minutes un courriel contenant
+        les instructions pour déverrouiller votre compte.
+      send_paranoid_instructions: Si votre compte existe, vous recevrez dans quelques
+        minutes un courriel contenant les instructions pour le déverrouiller.
+      unlocked: Votre compte a été déverrouillé avec succès. Veuillez vous connecter
+        pour continuer.
+  errors:
+    messages:
+      already_confirmed: Votre demande a déjà été confirmée. Veuillez essayer de vous
+        connecter.
+      confirmation_period_expired: Cela doit être confirmé dans les %{period}, veuillez
+        en demander un nouveau.
+      expired: a expiré, veuillez en demander un nouveau
+      not_found: introuvable
+      not_locked: n'était pas verrouillé
+      not_saved:
+        one: 'Une erreur a empêché l''enregistrement de ce %{resource} :'
+        other: 'Des erreurs %{count} ont empêché l''enregistrement de ce %{resource} :'
+      pwned_password: a déjà été utilisée lors d'une fuite de données et ne devrait
+        jamais être utilisée

--- a/bullet_train/config/locales/fr/memberships.fr.yml
+++ b/bullet_train/config/locales/fr/memberships.fr.yml
@@ -1,0 +1,1108 @@
+---
+fr:
+  memberships:
+    label: Membres de l'équipe
+    singular: Membre de l'équipe
+    navigation:
+      label: Membres de l'équipe
+      icon: fa-light fa-utilisateurs
+    breadcrumbs:
+      label: Membres de l'équipe
+    buttons:
+      edit: Paramètres
+      show: Détails
+      resend: Renvoyer
+      update: Mettre à jour mon abonnement
+      demote: Rétrograder du rôle d'administrateur
+      promote: Promotion au poste d'administrateur
+      destroy: Retirer de l'équipe
+      destroy_own: Quitter cette équipe
+      reinvite: Réinviter à l'équipe
+      confirmations:
+        destroy: Êtes-vous sûr de vouloir supprimer %{membership_name} de %{team_name} ?
+        destroy_own: Êtes-vous sûr de vouloir vous désinscrire de %{team_name} ? Cette
+          action est irréversible.
+        reinvite: Êtes-vous sûr de vouloir réinviter %{membership_name} à %{team_name}
+          ?
+    fields:
+      id:
+        _: Numéro de membre
+        label: Numéro de membre
+        heading: Numéro de membre
+        api_title: Numéro de membre
+        api_description: Numéro de membre
+      user_id:
+        name: ID de l'utilisateur
+        heading: ID de l'utilisateur
+        api_title: ID de l'utilisateur
+        api_description: ID de l'utilisateur
+      team_id:
+        name: ID d'équipe
+        heading: ID d'équipe
+        api_title: ID d'équipe
+        api_description: ID d'équipe
+      invitation_id:
+        name: ID d'invitation
+        heading: ID d'invitation
+        api_title: ID d'invitation
+        api_description: ID d'invitation
+      name:
+        name: Nom et prénom
+        heading: Nom et prénom
+        api_title: Nom et prénom
+        api_description: Nom et prénom
+      user_first_name:
+        name: Prénom
+        label: Prénom
+        heading: Prénom
+        api_title: Prénom
+        api_description: Prénom
+      user_last_name:
+        name: Nom de famille
+        label: Nom de famille
+        heading: Nom de famille
+        api_title: Nom de famille
+        api_description: Nom de famille
+      user_profile_photo_id:
+        name: Photo de profil
+        label: Photo de profil
+        heading: Photo de profil
+        api_title: Photo de profil
+        api_description: Photo de profil
+      user_profile_photo:
+        name: Photo de profil
+        label: Photo de profil
+        heading: Photo de profil
+        api_title: Photo de profil
+        api_description: Photo de profil
+      user_email:
+        name: Courriel de l'utilisateur
+        heading: Courriel de l'utilisateur
+        api_title: Courriel de l'utilisateur
+        api_description: Courriel de l'utilisateur
+      added_by_id:
+        name: Ajouté par l'identifiant utilisateur
+        heading: Ajouté par l'identifiant utilisateur
+        api_title: Ajouté par l'identifiant utilisateur
+        api_description: Ajouté par l'identifiant utilisateur
+      platform_agent_of_id:
+        name: Agent de plateforme d'identification
+        heading: Agent de plateforme d'identification
+        api_title: Agent de plateforme d'identification
+        api_description: Agent de plateforme d'identification
+      platform_agent:
+        name: Agent de plateforme
+        heading: Agent de plateforme
+        api_title: Agent de plateforme
+        api_description: Agent de plateforme
+      role_ids:
+        name: Rôle
+        label: Rôle
+        heading: Rôle
+        api_title: Rôle
+        api_description: Rôle
+        options:
+          default:
+            label: Téléspectateur
+            description: Accès limité aux données de l'équipe
+          admin:
+            label: Administrateur d'équipe
+            description: Les administrateurs d'équipe peuvent gérer la facturation
+              et les privilèges spéciaux des autres utilisateurs.
+          editor:
+            label: Éditeur
+            description: Peut modifier toutes les ressources de cette équipe et autoriser
+              les autres à faire de même.
+        none: Téléspectateur
+      created_at:
+        _: Créé à
+        heading: Créé à
+        api_title: Créé à
+        api_description: Créé à
+      updated_at:
+        _: Mise à jour le
+        heading: Mise à jour le
+        api_title: Mise à jour le
+        api_description: Mise à jour le
+    index:
+      section: "%{team_name} membres de l'équipe"
+      contexts:
+        team:
+          header: Membres de l'équipe
+          description: Voici les membres de votre équipe. Vous pouvez également inviter
+            de nouveaux membres.
+          fields:
+            id:
+              _: Numéro de membre
+              label: Numéro de membre
+              heading: Numéro de membre
+              api_title: Numéro de membre
+              api_description: Numéro de membre
+            user_id:
+              name: ID de l'utilisateur
+              heading: ID de l'utilisateur
+              api_title: ID de l'utilisateur
+              api_description: ID de l'utilisateur
+            team_id:
+              name: ID d'équipe
+              heading: ID d'équipe
+              api_title: ID d'équipe
+              api_description: ID d'équipe
+            invitation_id:
+              name: ID d'invitation
+              heading: ID d'invitation
+              api_title: ID d'invitation
+              api_description: ID d'invitation
+            name:
+              name: Nom et prénom
+              heading: Nom et prénom
+              api_title: Nom et prénom
+              api_description: Nom et prénom
+            user_first_name:
+              name: Prénom
+              label: Prénom
+              heading: Prénom
+              api_title: Prénom
+              api_description: Prénom
+            user_last_name:
+              name: Nom de famille
+              label: Nom de famille
+              heading: Nom de famille
+              api_title: Nom de famille
+              api_description: Nom de famille
+            user_profile_photo_id:
+              name: Photo de profil
+              label: Photo de profil
+              heading: Photo de profil
+              api_title: Photo de profil
+              api_description: Photo de profil
+            user_profile_photo:
+              name: Photo de profil
+              label: Photo de profil
+              heading: Photo de profil
+              api_title: Photo de profil
+              api_description: Photo de profil
+            user_email:
+              name: Courriel de l'utilisateur
+              heading: Courriel de l'utilisateur
+              api_title: Courriel de l'utilisateur
+              api_description: Courriel de l'utilisateur
+            added_by_id:
+              name: Ajouté par l'identifiant utilisateur
+              heading: Ajouté par l'identifiant utilisateur
+              api_title: Ajouté par l'identifiant utilisateur
+              api_description: Ajouté par l'identifiant utilisateur
+            platform_agent_of_id:
+              name: Agent de plateforme d'identification
+              heading: Agent de plateforme d'identification
+              api_title: Agent de plateforme d'identification
+              api_description: Agent de plateforme d'identification
+            platform_agent:
+              name: Agent de plateforme
+              heading: Agent de plateforme
+              api_title: Agent de plateforme
+              api_description: Agent de plateforme
+            role_ids:
+              name: Rôle
+              label: Rôle
+              heading: Rôle
+              api_title: Rôle
+              api_description: Rôle
+              options:
+                default:
+                  label: Téléspectateur
+                  description: Accès limité aux données de l'équipe
+                admin:
+                  label: Administrateur d'équipe
+                  description: Les administrateurs d'équipe peuvent gérer la facturation
+                    et les privilèges spéciaux des autres utilisateurs.
+                editor:
+                  label: Éditeur
+                  description: Peut modifier toutes les ressources de cette équipe
+                    et autoriser les autres à faire de même.
+              none: Téléspectateur
+            created_at:
+              _: Créé à
+              heading: Créé à
+              api_title: Créé à
+              api_description: Créé à
+            updated_at:
+              _: Mise à jour le
+              heading: Mise à jour le
+              api_title: Mise à jour le
+              api_description: Mise à jour le
+      buttons:
+        edit: Paramètres
+        show: Détails
+        resend: Renvoyer
+        update: Mettre à jour mon abonnement
+        demote: Rétrograder du rôle d'administrateur
+        promote: Promotion au poste d'administrateur
+        destroy: Retirer de l'équipe
+        destroy_own: Quitter cette équipe
+        reinvite: Invitation à rejoindre l'équipe
+        confirmations:
+          destroy: Êtes-vous sûr de vouloir supprimer %{membership_name} de %{team_name} ?
+          destroy_own: Êtes-vous sûr de vouloir vous désinscrire de %{team_name} ?
+            Cette action est irréversible.
+          reinvite: Êtes-vous sûr de vouloir inviter %{membership_name} à %{team_name}
+            ?
+    tombstones:
+      contexts:
+        team:
+          header: Membres en attente d'invitation
+          description: Les personnes suivantes ont été retirées de %{team_name}, mais
+            vous pouvez toujours gérer leur profil et réattribuer leurs tâches à d'autres
+            membres de l'équipe.
+      buttons:
+        edit: Paramètres
+        show: Détails
+        resend: Renvoyer
+        update: Mettre à jour mon abonnement
+        demote: Rétrograder du rôle d'administrateur
+        promote: Promotion au poste d'administrateur
+        destroy: Retirer de l'équipe
+        destroy_own: Quitter cette équipe
+        reinvite: Invitation à rejoindre l'équipe
+        confirmations:
+          destroy: Êtes-vous sûr de vouloir supprimer %{membership_name} de %{team_name} ?
+          destroy_own: Êtes-vous sûr de vouloir vous désinscrire de %{team_name} ?
+            Cette action est irréversible.
+          reinvite: Êtes-vous sûr de vouloir inviter %{membership_name} à %{team_name}
+            ?
+    form:
+      grant_privileges_of: Octroi des privilèges de %{role_key}
+      buttons:
+        edit: Paramètres
+        show: Détails
+        resend: Renvoyer
+        update: Mettre à jour mon abonnement
+        demote: Rétrograder du rôle d'administrateur
+        promote: Promotion au poste d'administrateur
+        destroy: Retirer de l'équipe
+        destroy_own: Quitter cette équipe
+        reinvite: Invitation à rejoindre l'équipe
+        confirmations:
+          destroy: Êtes-vous sûr de vouloir supprimer %{membership_name} de %{team_name} ?
+          destroy_own: Êtes-vous sûr de vouloir vous désinscrire de %{team_name} ?
+            Cette action est irréversible.
+          reinvite: Êtes-vous sûr de vouloir inviter %{membership_name} à %{team_name}
+            ?
+      fields:
+        id:
+          _: Numéro de membre
+          label: Numéro de membre
+          heading: Numéro de membre
+          api_title: Numéro de membre
+          api_description: Numéro de membre
+        user_id:
+          name: ID de l'utilisateur
+          heading: ID de l'utilisateur
+          api_title: ID de l'utilisateur
+          api_description: ID de l'utilisateur
+        team_id:
+          name: ID d'équipe
+          heading: ID d'équipe
+          api_title: ID d'équipe
+          api_description: ID d'équipe
+        invitation_id:
+          name: ID d'invitation
+          heading: ID d'invitation
+          api_title: ID d'invitation
+          api_description: ID d'invitation
+        name:
+          name: Nom et prénom
+          heading: Nom et prénom
+          api_title: Nom et prénom
+          api_description: Nom et prénom
+        user_first_name:
+          name: Prénom
+          label: Prénom
+          heading: Prénom
+          api_title: Prénom
+          api_description: Prénom
+        user_last_name:
+          name: Nom de famille
+          label: Nom de famille
+          heading: Nom de famille
+          api_title: Nom de famille
+          api_description: Nom de famille
+        user_profile_photo_id:
+          name: Photo de profil
+          label: Photo de profil
+          heading: Photo de profil
+          api_title: Photo de profil
+          api_description: Photo de profil
+        user_profile_photo:
+          name: Photo de profil
+          label: Photo de profil
+          heading: Photo de profil
+          api_title: Photo de profil
+          api_description: Photo de profil
+        user_email:
+          name: Courriel de l'utilisateur
+          heading: Courriel de l'utilisateur
+          api_title: Courriel de l'utilisateur
+          api_description: Courriel de l'utilisateur
+        added_by_id:
+          name: Ajouté par l'identifiant utilisateur
+          heading: Ajouté par l'identifiant utilisateur
+          api_title: Ajouté par l'identifiant utilisateur
+          api_description: Ajouté par l'identifiant utilisateur
+        platform_agent_of_id:
+          name: Agent de plateforme d'identification
+          heading: Agent de plateforme d'identification
+          api_title: Agent de plateforme d'identification
+          api_description: Agent de plateforme d'identification
+        platform_agent:
+          name: Agent de plateforme
+          heading: Agent de plateforme
+          api_title: Agent de plateforme
+          api_description: Agent de plateforme
+        role_ids:
+          name: Rôle
+          label: Rôle
+          heading: Rôle
+          api_title: Rôle
+          api_description: Rôle
+          options:
+            default:
+              label: Téléspectateur
+              description: Accès limité aux données de l'équipe
+            admin:
+              label: Administrateur d'équipe
+              description: Les administrateurs d'équipe peuvent gérer la facturation
+                et les privilèges spéciaux des autres utilisateurs.
+            editor:
+              label: Éditeur
+              description: Peut modifier toutes les ressources de cette équipe et
+                autoriser les autres à faire de même.
+          none: Téléspectateur
+        created_at:
+          _: Créé à
+          heading: Créé à
+          api_title: Créé à
+          api_description: Créé à
+        updated_at:
+          _: Mise à jour le
+          heading: Mise à jour le
+          api_title: Mise à jour le
+          api_description: Mise à jour le
+    edit:
+      section: "%{membership_name} sur %{team_name}"
+      header: Mettre à jour les paramètres d'abonnement
+      description: Vous pouvez modifier ci-dessous les paramètres d'abonnement de
+        %{memberships_possessive} sur %{team_name}.
+      grant_privileges_of: Octroi des privilèges de %{role_key}
+      remove_header: Supprimer un membre de l'équipe
+      remove_description: Supprimer %{membership_name} ne supprimera aucune ressource
+        qui lui est attribuée. Vous aurez la possibilité de réaffecter des ressources
+        à un autre membre de l'équipe. Vous pourrez également réinviter %{membership_name}
+        dans l'équipe ultérieurement.
+      buttons:
+        edit: Paramètres
+        show: Détails
+        resend: Renvoyer
+        update: Mettre à jour mon abonnement
+        demote: Rétrograder du rôle d'administrateur
+        promote: Promotion au poste d'administrateur
+        destroy: Retirer de l'équipe
+        destroy_own: Quitter cette équipe
+        reinvite: Invitation à rejoindre l'équipe
+        confirmations:
+          destroy: Êtes-vous sûr de vouloir supprimer %{membership_name} de %{team_name} ?
+          destroy_own: Êtes-vous sûr de vouloir vous désinscrire de %{team_name} ?
+            Cette action est irréversible.
+          reinvite: Êtes-vous sûr de vouloir inviter %{membership_name} à %{team_name}
+            ?
+    show:
+      section: L'abonnement de %{memberships_possessive} à %{team_name}
+      header: Détails de l'adhésion
+      invitation_header: Détails de l'invitation
+      tombstone_header: Ancien membre de l'équipe
+      description: Voici les détails de l'adhésion de %{memberships_possessive} à
+        %{team_name}.
+      buttons:
+        edit: Paramètres
+        show: Détails
+        resend: Renvoyer
+        update: Mettre à jour mon abonnement
+        demote: Rétrograder du rôle d'administrateur
+        promote: Promotion au poste d'administrateur
+        destroy: Retirer de l'équipe
+        destroy_own: Quitter cette équipe
+        reinvite: Invitation à rejoindre l'équipe
+        confirmations:
+          destroy: Êtes-vous sûr de vouloir supprimer %{membership_name} de %{team_name} ?
+          destroy_own: Êtes-vous sûr de vouloir vous désinscrire de %{team_name} ?
+            Cette action est irréversible.
+          reinvite: Êtes-vous sûr de vouloir inviter %{membership_name} à %{team_name}
+            ?
+      fields:
+        id:
+          _: Numéro de membre
+          label: Numéro de membre
+          heading: Numéro de membre
+          api_title: Numéro de membre
+          api_description: Numéro de membre
+        user_id:
+          name: ID de l'utilisateur
+          heading: ID de l'utilisateur
+          api_title: ID de l'utilisateur
+          api_description: ID de l'utilisateur
+        team_id:
+          name: ID d'équipe
+          heading: ID d'équipe
+          api_title: ID d'équipe
+          api_description: ID d'équipe
+        invitation_id:
+          name: ID d'invitation
+          heading: ID d'invitation
+          api_title: ID d'invitation
+          api_description: ID d'invitation
+        name:
+          name: Nom et prénom
+          heading: Nom et prénom
+          api_title: Nom et prénom
+          api_description: Nom et prénom
+        user_first_name:
+          name: Prénom
+          label: Prénom
+          heading: Prénom
+          api_title: Prénom
+          api_description: Prénom
+        user_last_name:
+          name: Nom de famille
+          label: Nom de famille
+          heading: Nom de famille
+          api_title: Nom de famille
+          api_description: Nom de famille
+        user_profile_photo_id:
+          name: Photo de profil
+          label: Photo de profil
+          heading: Photo de profil
+          api_title: Photo de profil
+          api_description: Photo de profil
+        user_profile_photo:
+          name: Photo de profil
+          label: Photo de profil
+          heading: Photo de profil
+          api_title: Photo de profil
+          api_description: Photo de profil
+        user_email:
+          name: Courriel de l'utilisateur
+          heading: Courriel de l'utilisateur
+          api_title: Courriel de l'utilisateur
+          api_description: Courriel de l'utilisateur
+        added_by_id:
+          name: Ajouté par l'identifiant utilisateur
+          heading: Ajouté par l'identifiant utilisateur
+          api_title: Ajouté par l'identifiant utilisateur
+          api_description: Ajouté par l'identifiant utilisateur
+        platform_agent_of_id:
+          name: Agent de plateforme d'identification
+          heading: Agent de plateforme d'identification
+          api_title: Agent de plateforme d'identification
+          api_description: Agent de plateforme d'identification
+        platform_agent:
+          name: Agent de plateforme
+          heading: Agent de plateforme
+          api_title: Agent de plateforme
+          api_description: Agent de plateforme
+        role_ids:
+          name: Rôle
+          label: Rôle
+          heading: Rôle
+          api_title: Rôle
+          api_description: Rôle
+          options:
+            default:
+              label: Téléspectateur
+              description: Impossible de consulter uniquement les données de l'équipe
+            admin:
+              label: Administrateur d'équipe
+              description: Les administrateurs d'équipe peuvent gérer la facturation
+                et les privilèges spéciaux des autres utilisateurs.
+            editor:
+              label: Éditeur
+              description: Peut modifier toutes les ressources de cette équipe et
+                autoriser les autres à faire de même.
+          none: Téléspectateur
+        created_at:
+          _: Créé à
+          heading: Créé à
+          api_title: Créé à
+          api_description: Créé à
+        updated_at:
+          _: Mise à jour le
+          heading: Mise à jour le
+          api_title: Mise à jour le
+          api_description: Mise à jour le
+    notifications:
+      updated: L'abonnement a été mis à jour avec succès.
+      destroyed: Cet utilisateur a été retiré de l'équipe avec succès.
+      no_members: Vous n'avez pas encore d'autres membres dans votre équipe ! Commencez
+        par envoyer une invitation.
+      cant_demote: Désolé, il est impossible de rétrograder le dernier administrateur
+        d'une équipe. Veuillez d'abord nommer quelqu'un d'autre administrateur.
+      cant_remove: Désolé, il est impossible de supprimer le dernier administrateur
+        d'une équipe. Veuillez d'abord nommer un autre administrateur.
+      you_removed_yourself: Vous vous êtes retiré(e) avec succès de %{team_name}.
+      reinvited: L'utilisateur a bien été invité. Il recevra un courriel pour rejoindre
+        l'équipe.
+  account:
+    memberships:
+      label: Membres de l'équipe
+      singular: Membre de l'équipe
+      navigation:
+        label: Membres de l'équipe
+        icon: fa-light fa-utilisateurs
+      breadcrumbs:
+        label: Membres de l'équipe
+      buttons:
+        edit: Paramètres
+        show: Détails
+        resend: Renvoyer
+        update: Mettre à jour mon abonnement
+        demote: Rétrograder du rôle d'administrateur
+        promote: Promotion au poste d'administrateur
+        destroy: Retirer de l'équipe
+        destroy_own: Quitter cette équipe
+        reinvite: Réinviter à l'équipe
+        confirmations:
+          destroy: Êtes-vous sûr de vouloir supprimer %{membership_name} de %{team_name} ?
+          destroy_own: Êtes-vous sûr de vouloir vous désinscrire de %{team_name} ?
+            Cette action est irréversible.
+          reinvite: Êtes-vous sûr de vouloir réinviter %{membership_name} à %{team_name}
+            ?
+      fields:
+        id:
+          _: Numéro de membre
+          label: Numéro de membre
+          heading: Numéro de membre
+          api_title: Numéro de membre
+          api_description: Numéro de membre
+        user_id:
+          name: ID de l'utilisateur
+          heading: ID de l'utilisateur
+          api_title: ID de l'utilisateur
+          api_description: ID de l'utilisateur
+        team_id:
+          name: ID d'équipe
+          heading: ID d'équipe
+          api_title: ID d'équipe
+          api_description: ID d'équipe
+        invitation_id:
+          name: ID d'invitation
+          heading: ID d'invitation
+          api_title: ID d'invitation
+          api_description: ID d'invitation
+        name:
+          name: Nom et prénom
+          heading: Nom et prénom
+          api_title: Nom et prénom
+          api_description: Nom et prénom
+        user_first_name:
+          name: Prénom
+          label: Prénom
+          heading: Prénom
+          api_title: Prénom
+          api_description: Prénom
+        user_last_name:
+          name: Nom de famille
+          label: Nom de famille
+          heading: Nom de famille
+          api_title: Nom de famille
+          api_description: Nom de famille
+        user_profile_photo_id:
+          name: Photo de profil
+          label: Photo de profil
+          heading: Photo de profil
+          api_title: Photo de profil
+          api_description: Photo de profil
+        user_profile_photo:
+          name: Photo de profil
+          label: Photo de profil
+          heading: Photo de profil
+          api_title: Photo de profil
+          api_description: Photo de profil
+        user_email:
+          name: Courriel de l'utilisateur
+          heading: Courriel de l'utilisateur
+          api_title: Courriel de l'utilisateur
+          api_description: Courriel de l'utilisateur
+        added_by_id:
+          name: Ajouté par l'identifiant utilisateur
+          heading: Ajouté par l'identifiant utilisateur
+          api_title: Ajouté par l'identifiant utilisateur
+          api_description: Ajouté par l'identifiant utilisateur
+        platform_agent_of_id:
+          name: Agent de plateforme d'identification
+          heading: Agent de plateforme d'identification
+          api_title: Agent de plateforme d'identification
+          api_description: Agent de plateforme d'identification
+        platform_agent:
+          name: Agent de plateforme
+          heading: Agent de plateforme
+          api_title: Agent de plateforme
+          api_description: Agent de plateforme
+        role_ids:
+          name: Rôle
+          label: Rôle
+          heading: Rôle
+          api_title: Rôle
+          api_description: Rôle
+          options:
+            default:
+              label: Téléspectateur
+              description: Accès limité aux données de l'équipe
+            admin:
+              label: Administrateur d'équipe
+              description: Les administrateurs d'équipe peuvent gérer la facturation
+                et les privilèges spéciaux des autres utilisateurs.
+            editor:
+              label: Éditeur
+              description: Peut modifier toutes les ressources de cette équipe et
+                autoriser les autres à faire de même.
+          none: Téléspectateur
+        created_at:
+          _: Créé à
+          heading: Créé à
+          api_title: Créé à
+          api_description: Créé à
+        updated_at:
+          _: Mise à jour le
+          heading: Mise à jour le
+          api_title: Mise à jour le
+          api_description: Mise à jour le
+      index:
+        section: "%{team_name} membres de l'équipe"
+        contexts:
+          team:
+            header: Membres de l'équipe
+            description: Voici les membres de votre équipe. Vous pouvez également
+              inviter de nouveaux membres.
+            fields:
+              id:
+                _: Numéro de membre
+                label: Numéro de membre
+                heading: Numéro de membre
+                api_title: Numéro de membre
+                api_description: Numéro de membre
+              user_id:
+                name: ID de l'utilisateur
+                heading: ID de l'utilisateur
+                api_title: ID de l'utilisateur
+                api_description: ID de l'utilisateur
+              team_id:
+                name: ID d'équipe
+                heading: ID d'équipe
+                api_title: ID d'équipe
+                api_description: ID d'équipe
+              invitation_id:
+                name: ID d'invitation
+                heading: ID d'invitation
+                api_title: ID d'invitation
+                api_description: ID d'invitation
+              name:
+                name: Nom et prénom
+                heading: Nom et prénom
+                api_title: Nom et prénom
+                api_description: Nom et prénom
+              user_first_name:
+                name: Prénom
+                label: Prénom
+                heading: Prénom
+                api_title: Prénom
+                api_description: Prénom
+              user_last_name:
+                name: Nom de famille
+                label: Nom de famille
+                heading: Nom de famille
+                api_title: Nom de famille
+                api_description: Nom de famille
+              user_profile_photo_id:
+                name: Photo de profil
+                label: Photo de profil
+                heading: Photo de profil
+                api_title: Photo de profil
+                api_description: Photo de profil
+              user_profile_photo:
+                name: Photo de profil
+                label: Photo de profil
+                heading: Photo de profil
+                api_title: Photo de profil
+                api_description: Photo de profil
+              user_email:
+                name: Courriel de l'utilisateur
+                heading: Courriel de l'utilisateur
+                api_title: Courriel de l'utilisateur
+                api_description: Courriel de l'utilisateur
+              added_by_id:
+                name: Ajouté par l'identifiant utilisateur
+                heading: Ajouté par l'identifiant utilisateur
+                api_title: Ajouté par l'identifiant utilisateur
+                api_description: Ajouté par l'identifiant utilisateur
+              platform_agent_of_id:
+                name: Agent de plateforme d'identification
+                heading: Agent de plateforme d'identification
+                api_title: Agent de plateforme d'identification
+                api_description: Agent de plateforme d'identification
+              platform_agent:
+                name: Agent de plateforme
+                heading: Agent de plateforme
+                api_title: Agent de plateforme
+                api_description: Agent de plateforme
+              role_ids:
+                name: Rôle
+                label: Rôle
+                heading: Rôle
+                api_title: Rôle
+                api_description: Rôle
+                options:
+                  default:
+                    label: Téléspectateur
+                    description: Accès limité aux données de l'équipe
+                  admin:
+                    label: Administrateur d'équipe
+                    description: Les administrateurs d'équipe peuvent gérer la facturation
+                      et les privilèges spéciaux des autres utilisateurs.
+                  editor:
+                    label: Éditeur
+                    description: Peut modifier toutes les ressources de cette équipe
+                      et autoriser les autres à faire de même.
+                none: Téléspectateur
+              created_at:
+                _: Créé à
+                heading: Créé à
+                api_title: Créé à
+                api_description: Créé à
+              updated_at:
+                _: Mise à jour le
+                heading: Mise à jour le
+                api_title: Mise à jour le
+                api_description: Mise à jour le
+        buttons:
+          edit: Paramètres
+          show: Détails
+          resend: Renvoyer
+          update: Mettre à jour mon abonnement
+          demote: Rétrograder du rôle d'administrateur
+          promote: Promotion au poste d'administrateur
+          destroy: Retirer de l'équipe
+          destroy_own: Quitter cette équipe
+          reinvite: Invitation à rejoindre l'équipe
+          confirmations:
+            destroy: Êtes-vous sûr de vouloir supprimer %{membership_name} de %{team_name} ?
+            destroy_own: Êtes-vous sûr de vouloir vous désinscrire de %{team_name} ?
+              Cette action est irréversible.
+            reinvite: Êtes-vous sûr de vouloir inviter %{membership_name} à %{team_name}
+              ?
+      tombstones:
+        contexts:
+          team:
+            header: Membres en attente d'invitation
+            description: Les personnes suivantes ont été retirées de %{team_name},
+              mais vous pouvez toujours gérer leur profil et réattribuer leurs tâches
+              à d'autres membres de l'équipe.
+        buttons:
+          edit: Paramètres
+          show: Détails
+          resend: Renvoyer
+          update: Mettre à jour mon abonnement
+          demote: Rétrograder du rôle d'administrateur
+          promote: Promotion au poste d'administrateur
+          destroy: Retirer de l'équipe
+          destroy_own: Quitter cette équipe
+          reinvite: Invitation à rejoindre l'équipe
+          confirmations:
+            destroy: Êtes-vous sûr de vouloir supprimer %{membership_name} de %{team_name} ?
+            destroy_own: Êtes-vous sûr de vouloir vous désinscrire de %{team_name} ?
+              Cette action est irréversible.
+            reinvite: Êtes-vous sûr de vouloir inviter %{membership_name} à %{team_name}
+              ?
+      form:
+        grant_privileges_of: Octroi des privilèges de %{role_key}
+        buttons:
+          edit: Paramètres
+          show: Détails
+          resend: Renvoyer
+          update: Mettre à jour mon abonnement
+          demote: Rétrograder du rôle d'administrateur
+          promote: Promotion au poste d'administrateur
+          destroy: Retirer de l'équipe
+          destroy_own: Quitter cette équipe
+          reinvite: Invitation à rejoindre l'équipe
+          confirmations:
+            destroy: Êtes-vous sûr de vouloir supprimer %{membership_name} de %{team_name} ?
+            destroy_own: Êtes-vous sûr de vouloir vous désinscrire de %{team_name} ?
+              Cette action est irréversible.
+            reinvite: Êtes-vous sûr de vouloir inviter %{membership_name} à %{team_name}
+              ?
+        fields:
+          id:
+            _: Numéro de membre
+            label: Numéro de membre
+            heading: Numéro de membre
+            api_title: Numéro de membre
+            api_description: Numéro de membre
+          user_id:
+            name: ID de l'utilisateur
+            heading: ID de l'utilisateur
+            api_title: ID de l'utilisateur
+            api_description: ID de l'utilisateur
+          team_id:
+            name: ID d'équipe
+            heading: ID d'équipe
+            api_title: ID d'équipe
+            api_description: ID d'équipe
+          invitation_id:
+            name: ID d'invitation
+            heading: ID d'invitation
+            api_title: ID d'invitation
+            api_description: ID d'invitation
+          name:
+            name: Nom et prénom
+            heading: Nom et prénom
+            api_title: Nom et prénom
+            api_description: Nom et prénom
+          user_first_name:
+            name: Prénom
+            label: Prénom
+            heading: Prénom
+            api_title: Prénom
+            api_description: Prénom
+          user_last_name:
+            name: Nom de famille
+            label: Nom de famille
+            heading: Nom de famille
+            api_title: Nom de famille
+            api_description: Nom de famille
+          user_profile_photo_id:
+            name: Photo de profil
+            label: Photo de profil
+            heading: Photo de profil
+            api_title: Photo de profil
+            api_description: Photo de profil
+          user_profile_photo:
+            name: Photo de profil
+            label: Photo de profil
+            heading: Photo de profil
+            api_title: Photo de profil
+            api_description: Photo de profil
+          user_email:
+            name: Courriel de l'utilisateur
+            heading: Courriel de l'utilisateur
+            api_title: Courriel de l'utilisateur
+            api_description: Courriel de l'utilisateur
+          added_by_id:
+            name: Ajouté par l'identifiant utilisateur
+            heading: Ajouté par l'identifiant utilisateur
+            api_title: Ajouté par l'identifiant utilisateur
+            api_description: Ajouté par l'identifiant utilisateur
+          platform_agent_of_id:
+            name: Agent de plateforme d'identification
+            heading: Agent de plateforme d'identification
+            api_title: Agent de plateforme d'identification
+            api_description: Agent de plateforme d'identification
+          platform_agent:
+            name: Agent de plateforme
+            heading: Agent de plateforme
+            api_title: Agent de plateforme
+            api_description: Agent de plateforme
+          role_ids:
+            name: Rôle
+            label: Rôle
+            heading: Rôle
+            api_title: Rôle
+            api_description: Rôle
+            options:
+              default:
+                label: Téléspectateur
+                description: Accès limité aux données de l'équipe
+              admin:
+                label: Administrateur d'équipe
+                description: Les administrateurs d'équipe peuvent gérer la facturation
+                  et les privilèges spéciaux des autres utilisateurs.
+              editor:
+                label: Éditeur
+                description: Peut modifier toutes les ressources de cette équipe et
+                  autoriser les autres à faire de même.
+            none: Téléspectateur
+          created_at:
+            _: Créé à
+            heading: Créé à
+            api_title: Créé à
+            api_description: Créé à
+          updated_at:
+            _: Mise à jour le
+            heading: Mise à jour le
+            api_title: Mise à jour le
+            api_description: Mise à jour le
+      edit:
+        section: "%{membership_name} sur %{team_name}"
+        header: Mettre à jour les paramètres d'abonnement
+        description: Vous pouvez modifier ci-dessous les paramètres d'abonnement de
+          %{memberships_possessive} sur %{team_name}.
+        grant_privileges_of: Octroi des privilèges de %{role_key}
+        remove_header: Supprimer un membre de l'équipe
+        remove_description: Supprimer %{membership_name} ne supprimera aucune ressource
+          qui lui est attribuée. Vous aurez la possibilité de réattribuer des ressources
+          à un autre membre de l'équipe. Vous pourrez également réinviter %{membership_name}
+          dans l'équipe ultérieurement.
+        buttons:
+          edit: Paramètres
+          show: Détails
+          resend: Renvoyer
+          update: Mettre à jour mon abonnement
+          demote: Rétrograder du rôle d'administrateur
+          promote: Promotion au poste d'administrateur
+          destroy: Retirer de l'équipe
+          destroy_own: Quitter cette équipe
+          reinvite: Invitation à rejoindre l'équipe
+          confirmations:
+            destroy: Êtes-vous sûr de vouloir supprimer %{membership_name} de %{team_name} ?
+            destroy_own: Êtes-vous sûr de vouloir vous désinscrire de %{team_name} ?
+              Cette action est irréversible.
+            reinvite: Êtes-vous sûr de vouloir inviter %{membership_name} à %{team_name}
+              ?
+      show:
+        section: L'abonnement de %{memberships_possessive} à %{team_name}
+        header: Détails de l'adhésion
+        invitation_header: Détails de l'invitation
+        tombstone_header: Ancien membre de l'équipe
+        description: Voici les détails de l'adhésion de %{memberships_possessive}
+          à %{team_name}.
+        buttons:
+          edit: Paramètres
+          show: Détails
+          resend: Renvoyer
+          update: Mettre à jour mon abonnement
+          demote: Rétrograder du rôle d'administrateur
+          promote: Promotion au poste d'administrateur
+          destroy: Retirer de l'équipe
+          destroy_own: Quitter cette équipe
+          reinvite: Invitation à rejoindre l'équipe
+          confirmations:
+            destroy: Êtes-vous sûr de vouloir supprimer %{membership_name} de %{team_name} ?
+            destroy_own: Êtes-vous sûr de vouloir vous désinscrire de %{team_name} ?
+              Cette action est irréversible.
+            reinvite: Êtes-vous sûr de vouloir inviter %{membership_name} à %{team_name}
+              ?
+        fields:
+          id:
+            _: Numéro de membre
+            label: Numéro de membre
+            heading: Numéro de membre
+            api_title: Numéro de membre
+            api_description: Numéro de membre
+          user_id:
+            name: ID de l'utilisateur
+            heading: ID de l'utilisateur
+            api_title: ID de l'utilisateur
+            api_description: ID de l'utilisateur
+          team_id:
+            name: ID d'équipe
+            heading: ID d'équipe
+            api_title: ID d'équipe
+            api_description: ID d'équipe
+          invitation_id:
+            name: ID d'invitation
+            heading: ID d'invitation
+            api_title: ID d'invitation
+            api_description: ID d'invitation
+          name:
+            name: Nom et prénom
+            heading: Nom et prénom
+            api_title: Nom et prénom
+            api_description: Nom et prénom
+          user_first_name:
+            name: Prénom
+            label: Prénom
+            heading: Prénom
+            api_title: Prénom
+            api_description: Prénom
+          user_last_name:
+            name: Nom de famille
+            label: Nom de famille
+            heading: Nom de famille
+            api_title: Nom de famille
+            api_description: Nom de famille
+          user_profile_photo_id:
+            name: Photo de profil
+            label: Photo de profil
+            heading: Photo de profil
+            api_title: Photo de profil
+            api_description: Photo de profil
+          user_profile_photo:
+            name: Photo de profil
+            label: Photo de profil
+            heading: Photo de profil
+            api_title: Photo de profil
+            api_description: Photo de profil
+          user_email:
+            name: Courriel de l'utilisateur
+            heading: Courriel de l'utilisateur
+            api_title: Courriel de l'utilisateur
+            api_description: Courriel de l'utilisateur
+          added_by_id:
+            name: Ajouté par l'identifiant utilisateur
+            heading: Ajouté par l'identifiant utilisateur
+            api_title: Ajouté par l'identifiant utilisateur
+            api_description: Ajouté par l'identifiant utilisateur
+          platform_agent_of_id:
+            name: Agent de plateforme d'identification
+            heading: Agent de plateforme d'identification
+            api_title: Agent de plateforme d'identification
+            api_description: Agent de plateforme d'identification
+          platform_agent:
+            name: Agent de plateforme
+            heading: Agent de plateforme
+            api_title: Agent de plateforme
+            api_description: Agent de plateforme
+          role_ids:
+            name: Rôle
+            label: Rôle
+            heading: Rôle
+            api_title: Rôle
+            api_description: Rôle
+            options:
+              default:
+                label: Téléspectateur
+                description: Accès limité aux données de l'équipe
+              admin:
+                label: Administrateur d'équipe
+                description: Les administrateurs d'équipe peuvent gérer la facturation
+                  et les privilèges spéciaux des autres utilisateurs.
+              editor:
+                label: Éditeur
+                description: Peut modifier toutes les ressources de cette équipe et
+                  autoriser les autres à faire de même.
+            none: Téléspectateur
+          created_at:
+            _: Créé à
+            heading: Créé à
+            api_title: Créé à
+            api_description: Créé à
+          updated_at:
+            _: Mise à jour le
+            heading: Mise à jour le
+            api_title: Mise à jour le
+            api_description: Mise à jour le
+      notifications:
+        updated: L'abonnement a été mis à jour avec succès.
+        destroyed: Cet utilisateur a été retiré de l'équipe avec succès.
+        no_members: Vous n'avez pas encore d'autres membres dans votre équipe ! Commencez
+          par envoyer une invitation.
+        cant_demote: Désolé, il est impossible de rétrograder le dernier administrateur
+          d'une équipe. Veuillez d'abord nommer quelqu'un d'autre administrateur.
+        cant_remove: Désolé, il est impossible de supprimer le dernier administrateur
+          d'une équipe. Veuillez d'abord nommer un autre administrateur.
+        you_removed_yourself: Vous vous êtes retiré(e) avec succès de %{team_name}.
+        reinvited: L'utilisateur a bien été invité. Il recevra un courriel pour rejoindre
+          l'équipe.
+  activerecord:
+    attributes:
+      memberships:
+        user_first_name: Prénom
+        user_last_name: Nom de famille

--- a/bullet_train/config/locales/fr/onboarding/user_details.fr.yml
+++ b/bullet_train/config/locales/fr/onboarding/user_details.fr.yml
@@ -1,0 +1,19 @@
+---
+fr:
+  onboarding:
+    user_details:
+      buttons:
+        next: Suivant
+      edit:
+        header: Parlez-nous de vous
+        buttons:
+          next: Suivant
+  account:
+    onboarding:
+      user_details:
+        buttons:
+          next: Suivant
+        edit:
+          header: Parlez-nous de vous
+          buttons:
+            next: Suivant

--- a/bullet_train/config/locales/fr/teams.fr.yml
+++ b/bullet_train/config/locales/fr/teams.fr.yml
@@ -1,0 +1,385 @@
+---
+fr:
+  teams:
+    label: Label
+    singular: Équipe
+    breadcrumbs:
+      label: Équipes
+      team_settings: Paramètres d'équipe
+      dashboard: Tableau de bord
+    navigation:
+      label: Équipe
+    buttons:
+      new: Ajouter une nouvelle équipe
+      create: Créer une équipe
+      edit: Modifier l'équipe
+      update: Mettre à jour l'équipe
+      destroy: Supprimer l'équipe
+      confirmations:
+        destroy: Êtes-vous sûr de vouloir supprimer cette équipe ?
+    index:
+      section: Équipes
+      header: Vos équipes
+      create: Créer une nouvelle équipe
+      buttons:
+        new: Ajouter une nouvelle équipe
+        create: Créer une équipe
+        edit: Équipe de montage
+        update: Équipe de mise à jour
+        destroy: Supprimer l'équipe
+        confirmations:
+          destroy: Êtes-vous sûr de vouloir supprimer cette équipe ?
+    show:
+      header: Tableau de bord de conformité %{teams_possessive}
+    new:
+      header: Créer une nouvelle équipe
+      former_user_header: Rejoignez une équipe
+      default_team_name: Votre équipe
+      buttons:
+        new: Ajouter une nouvelle équipe
+        create: Créer une équipe
+        edit: Équipe de montage
+        update: Équipe de mise à jour
+        destroy: Supprimer l'équipe
+        confirmations:
+          destroy: Êtes-vous sûr de vouloir supprimer cette équipe ?
+      you_can: 'Vous pouvez soit :'
+      invitation_header: Accepter une invitation
+      logout_header: Déconnectez-vous de ce compte
+      new_team_header: Créer une nouvelle équipe
+      alert: Le compte <b>%{user_email}</b> n'est actuellement membre d'aucune équipe.
+      invitation: Si vous avez reçu un courriel vous invitant à rejoindre une nouvelle
+        équipe, cliquez sur le lien contenu dans ce courriel pour accepter l'invitation.
+      log_out: Vous pouvez vous déconnecter de ce compte et vous connecter avec un
+        autre compte membre d'une équipe.
+      new_team: Vous pouvez utiliser le formulaire ci-dessous pour créer votre propre
+        équipe.
+    edit:
+      section: "%{team_name}"
+      header: Modifier les détails de l'équipe
+      description: Vous pouvez mettre à jour les informations et les paramètres de
+        cette équipe ci-dessous.
+    notifications:
+      created: L'équipe a été créée avec succès.
+      updated: L'équipe a été mise à jour avec succès.
+      destroyed: L'équipe a été supprimée avec succès.
+      invitation_only: La création de nouvelles équipes est actuellement réservée
+        aux utilisateurs ayant reçu une invitation pour un accès anticipé. Si vous
+        avez reçu une URL d'accès anticipé, veuillez la consulter avant de réessayer.
+      cannot_delete_last_team: Vous ne pouvez pas supprimer la dernière équipe à laquelle
+        vous appartenez.
+    form:
+      buttons:
+        new: Ajouter une nouvelle équipe
+        create: Créer une équipe
+        edit: Équipe de montage
+        update: Équipe de mise à jour
+        destroy: Supprimer l'équipe
+        confirmations:
+          destroy: Êtes-vous sûr de vouloir supprimer cette équipe ?
+    fields:
+      id:
+        _: ID d'équipe
+        label: ID d'équipe
+        heading: ID d'équipe
+        api_title: ID d'équipe
+        api_description: ID d'équipe
+      name:
+        _: Nom de l'équipe
+        label: Nom de l'équipe
+        heading: Nom de l'équipe
+        api_title: Nom de l'équipe
+        api_description: Nom de l'équipe
+      time_zone:
+        _: Fuseau horaire principal
+        label: Fuseau horaire principal
+        heading: Fuseau horaire principal
+        api_title: Fuseau horaire principal
+        api_description: Fuseau horaire principal
+      locale:
+        _: Langue principale
+        label: Langue principale
+        heading: Langue principale
+        api_title: Langue principale
+        api_description: Langue principale
+      created_at:
+        _: Inscrit à
+        heading: Inscrit à
+        api_title: Inscrit à
+        api_description: Inscrit à
+      updated_at:
+        _: Mise à jour le
+        heading: Mise à jour le
+        api_title: Mise à jour le
+        api_description: Mise à jour le
+    _:
+      name:
+        label: Nom de votre équipe
+    self:
+      id:
+        _: ID d'équipe
+        label: ID d'équipe
+        heading: ID d'équipe
+        api_title: ID d'équipe
+        api_description: ID d'équipe
+      name:
+        label: Nom de votre équipe
+      time_zone:
+        _: Fuseau horaire principal
+        label: Fuseau horaire principal
+        heading: Fuseau horaire principal
+        api_title: Fuseau horaire principal
+        api_description: Fuseau horaire principal
+      locale:
+        _: Langue
+        label: Langue principale
+        heading: Langue
+        api_title: Langue
+        api_description: Langue
+      created_at:
+        _: Inscrit à
+        heading: Inscrit à
+        api_title: Inscrit à
+        api_description: Inscrit à
+      updated_at:
+        _: Mise à jour le
+        heading: Mise à jour le
+        api_title: Mise à jour le
+        api_description: Mise à jour le
+    api:
+      actions: Actions pour les équipes
+      index: Liste des équipes
+      create: Ajouter une nouvelle équipe
+      show: Récupérer une équipe
+      update: Mettre à jour une équipe
+      fields:
+        id:
+          _: ID d'équipe
+          label: ID d'équipe
+          heading: ID d'équipe
+          api_title: ID d'équipe
+          api_description: ID d'équipe
+        name:
+          _: Nom de l'équipe
+          label: Nom de l'équipe
+          heading: Équipe
+          api_title: Nom de l'équipe
+          api_description: Nom de l'équipe
+        time_zone:
+          _: Fuseau horaire principal
+          label: Fuseau horaire principal
+          heading: Fuseau horaire principal
+          api_title: Fuseau horaire principal
+          api_description: Fuseau horaire principal
+        locale:
+          _: Langue
+          label: Langue principale
+          heading: Langue
+          api_title: Langue
+          api_description: Langue
+        created_at:
+          _: Inscrit à
+          heading: Inscrit à
+          api_title: Inscrit à
+          api_description: Inscrit à
+        updated_at:
+          _: Mise à jour le
+          heading: Mise à jour le
+          api_title: Mise à jour le
+          api_description: Mise à jour le
+  account:
+    teams:
+      label: Équipes
+      singular: Équipe
+      breadcrumbs:
+        label: Équipes
+        team_settings: Paramètres d'équipe
+        dashboard: Tableau de bord
+      navigation:
+        label: Équipe
+      buttons:
+        new: Ajouter une nouvelle équipe
+        create: Créer une équipe
+        edit: Modifier l'équipe
+        update: Mettre à jour l'équipe
+        destroy: Supprimer l'équipe
+        confirmations:
+          destroy: Êtes-vous sûr de vouloir supprimer cette équipe ?
+      index:
+        section: Équipes
+        header: Vos équipes
+        create: Créer une nouvelle équipe
+        buttons:
+          new: Ajouter une nouvelle équipe
+          create: Créer une équipe
+          edit: Équipe de montage
+          update: Équipe de mise à jour
+          destroy: Supprimer l'équipe
+          confirmations:
+            destroy: Êtes-vous sûr de vouloir supprimer cette équipe ?
+      show:
+        header: Tableau de bord de conformité %{teams_possessive}
+      new:
+        header: Créer une nouvelle équipe
+        former_user_header: Rejoignez une équipe
+        default_team_name: Votre équipe
+        buttons:
+          new: Ajouter une nouvelle équipe
+          create: Créer une équipe
+          edit: Équipe de montage
+          update: Équipe de mise à jour
+          destroy: Supprimer l'équipe
+          confirmations:
+            destroy: Êtes-vous sûr de vouloir supprimer cette équipe ?
+        you_can: 'Vous pouvez soit :'
+        invitation_header: Accepter une invitation
+        logout_header: Déconnectez-vous de ce compte
+        new_team_header: Créer une nouvelle équipe
+        alert: Le compte <b>%{user_email}</b> n'est actuellement membre d'aucune équipe.
+        invitation: Si vous avez reçu un courriel vous invitant à rejoindre une nouvelle
+          équipe, cliquez sur le lien contenu dans ce courriel pour accepter l'invitation.
+        log_out: Vous pouvez vous déconnecter de ce compte et vous connecter avec
+          un autre compte membre d'une équipe.
+        new_team: Vous pouvez utiliser le formulaire ci-dessous pour créer votre propre
+          équipe.
+      edit:
+        section: "%{team_name}"
+        header: Modifier les détails de l'équipe
+        description: Vous pouvez mettre à jour les informations et les paramètres
+          de cette équipe ci-dessous.
+      notifications:
+        created: L'équipe a été créée avec succès.
+        updated: L'équipe a été mise à jour avec succès.
+        destroyed: L'équipe a été supprimée avec succès.
+        invitation_only: La création de nouvelles équipes est actuellement réservée
+          aux utilisateurs ayant reçu une invitation pour un accès anticipé. Si vous
+          avez reçu une URL d'accès anticipé, veuillez la consulter avant de réessayer.
+        cannot_delete_last_team: Vous ne pouvez pas supprimer la dernière équipe à
+          laquelle vous appartenez.
+      form:
+        buttons:
+          new: Ajouter une nouvelle équipe
+          create: Create
+          edit: Équipe de montage
+          update: Update
+          destroy: Supprimer l'équipe
+          confirmations:
+            destroy: Êtes-vous sûr de vouloir supprimer cette équipe ?
+      fields:
+        id:
+          _: ID d'équipe
+          label: ID d'équipe
+          heading: ID d'équipe
+          api_title: ID d'équipe
+          api_description: ID d'équipe
+        name:
+          _: Nom de l'équipe
+          label: Nom de l'équipe
+          heading: Nom de l'équipe
+          api_title: Nom de l'équipe
+          api_description: Nom de l'équipe
+        time_zone:
+          _: Fuseau horaire principal
+          label: Fuseau horaire principal
+          heading: Fuseau horaire principal
+          api_title: Fuseau horaire principal
+          api_description: Fuseau horaire principal
+        locale:
+          _: Langue principale
+          label: Langue principale
+          heading: Langue principale
+          api_title: Langue principale
+          api_description: Langue principale
+        created_at:
+          _: Inscrit à
+          heading: Inscrit à
+          api_title: Inscrit à
+          api_description: Inscrit à
+        updated_at:
+          _: Mise à jour le
+          heading: Mise à jour le
+          api_title: Mise à jour le
+          api_description: Mise à jour le
+      _:
+        name:
+          label: Nom de votre équipe
+      self:
+        id:
+          _: ID d'équipe
+          label: ID d'équipe
+          heading: ID d'équipe
+          api_title: ID d'équipe
+          api_description: ID d'équipe
+        name:
+          label: Nom de votre équipe
+        time_zone:
+          _: Fuseau horaire principal
+          label: Fuseau horaire principal
+          heading: Fuseau horaire principal
+          api_title: Fuseau horaire principal
+          api_description: Fuseau horaire principal
+        locale:
+          _: Langue
+          label: Langue principale
+          heading: Langue
+          api_title: Langue
+          api_description: Langue
+        created_at:
+          _: Inscrit à
+          heading: Inscrit à
+          api_title: Inscrit à
+          api_description: Inscrit à
+        updated_at:
+          _: Mise à jour le
+          heading: Mise à jour le
+          api_title: Mise à jour le
+          api_description: Mise à jour le
+      api:
+        actions: Actions pour les équipes
+        index: Liste des équipes
+        create: Ajouter une nouvelle équipe
+        show: Récupérer une équipe
+        update: Mettre à jour une équipe
+        fields:
+          id:
+            _: ID d'équipe
+            label: ID d'équipe
+            heading: ID d'équipe
+            api_title: ID d'équipe
+            api_description: ID d'équipe
+          name:
+            _: Nom de l'équipe
+            label: Nom de l'équipe
+            heading: Équipe
+            api_title: Nom de l'équipe
+            api_description: Nom de l'équipe
+          time_zone:
+            _: Fuseau horaire principal
+            label: Fuseau horaire principal
+            heading: Fuseau horaire principal
+            api_title: Fuseau horaire principal
+            api_description: Fuseau horaire principal
+          locale:
+            _: Langue
+            label: Langue principale
+            heading: Langue
+            api_title: Langue
+            api_description: Langue
+          created_at:
+            _: Inscrit à
+            heading: Inscrit à
+            api_title: Inscrit à
+            api_description: Inscrit à
+          updated_at:
+            _: Mise à jour le
+            heading: Mise à jour le
+            api_title: Mise à jour le
+            api_description: Mise à jour le
+  activerecord:
+    attributes:
+      team:
+        name: Nom de l'équipe
+        time_zone: Fuseau horaire principal
+        locale: Langue
+        created_at: Inscrit à
+        updated_at: Mise à jour le

--- a/bullet_train/config/locales/zh-CN/devise.zh-CN.yml
+++ b/bullet_train/config/locales/zh-CN/devise.zh-CN.yml
@@ -1,0 +1,113 @@
+---
+zh-CN:
+  devise:
+    titles:
+      reset_password: 重置密码
+      sign_in: 登入
+    headers:
+      resend_confirm: 重新发送确认说明
+      change_password: 更改密码
+      reset_password: 重置密码
+      edit_registration: 编辑 %{resource_name}
+      cancel_account: 取消我的帐户
+      create_account: 创建您的帐户
+      sign_in: 登入
+      resend_unlock: 重新发送解锁说明
+    labels:
+      wait_confirm: 目前正在等待确认：%{unconfirmed_email}
+    hints:
+      leave_blank: "（如果您不想更改，请留空）"
+      length: "%{password_length} 字符数最少"
+      need_password: "（我们需要您当前的密码来确认您的更改）"
+    buttons:
+      resend_confirm: 重新发送确认说明
+      change_password: 更改我的密码
+      reset_password: 通过电子邮件重置密码
+      cancel_account: 取消我的帐户
+      resend_unlock: 重新发送解锁说明
+    links:
+      account: 还没有账号？
+      have_account: 已有账号？
+      forgot_password: 忘记密码了吗？
+      log_in: 登录
+      sign_up: 报名
+      new_confirm: 没有收到确认说明？
+      new_unlock: 没有收到解锁说明？
+      sign_in_with: 使用 %{provider} 登录
+    confirmations:
+      confirmed: 您的电子邮件地址已成功验证。
+      send_instructions: 几分钟后，您将收到一封电子邮件，其中包含如何验证您的电子邮件地址的说明。
+      send_paranoid_instructions: 如果您的电子邮件地址已存在于我们的数据库中，您将在几分钟内收到一封电子邮件，其中包含如何确认您的电子邮件地址的说明。
+    failure:
+      already_authenticated: 您已登录。
+      inactive: 您的账户尚未激活。
+      invalid: 无效的 %{authentication_keys} 或密码。
+      locked: 您的账户已被锁定。
+      last_attempt: 你的账号将被锁定，你还有最后一次尝试机会。
+      not_found_in_database: 无效的 %{authentication_keys} 或密码。
+      timeout: 您的会话已过期。请重新登录以继续。
+      unauthenticated: 您需要先登录或注册才能继续。
+      unconfirmed: 您必须先确认您的电子邮件地址才能继续。
+    mailer:
+      confirmation_instructions:
+        subject: 确认说明
+        welcome: 欢迎来到%{email}！
+        description: 您可以通过以下链接确认您的账户邮箱：
+        confirm_account: 确认我的账户
+      reset_password_instructions:
+        subject: 重置密码说明
+        hello: 你好 %{email}！
+        requested_change: 有人请求提供修改密码的链接。您可以通过以下链接进行修改。
+        ignore: 如果您没有提出此项请求，请忽略此邮件。
+        access_change: 您的密码不会更改，直到您访问上面的链接并创建一个新密码。
+        change_password: 更改我的密码
+      unlock_instructions:
+        subject: 解锁说明
+        hello: 你好 %{email}！
+        account_blocked: 由于登录失败次数过多，您的账户已被锁定。
+        click_link: 点击下方链接解锁您的账户：
+        unlock: 解锁我的账户
+      password_change:
+        subject: 密码已更改
+        hello: 你好 %{email}！
+        description: 我们联系您是为了通知您，您的密码已更改。
+      email_changed:
+        subject: 电子邮件已更改
+        hello: 你好 %{email}！
+        description: 我们联系您是为了通知您，您的电子邮件地址已更改为 %{email}。
+    omniauth_callbacks:
+      failure: 无法通过 %{kind} 验证您的身份，因为“%{reason}”。
+      success: 已成功通过 %{kind} 帐户进行身份验证。
+    passwords:
+      no_token: 您必须通过密码重置邮件才能访问此页面。如果您是通过密码重置邮件访问的，请确保您使用了邮件中提供的完整URL。
+      send_instructions: 几分钟后，您将收到一封电子邮件，其中包含重置密码的说明。
+      send_paranoid_instructions: 如果您的电子邮件地址存在于我们的数据库中，您将在几分钟内收到一封包含密码恢复链接的电子邮件。
+      updated: 您的密码已成功更改。您现在已登录。
+      updated_not_active: 您的密码已成功更改。
+    registrations:
+      destroyed: 再见！您的账户已成功注销。希望很快能再次见到您。
+      signed_up: 欢迎！您已成功注册。
+      signed_up_but_inactive: 您已成功注册。但是，由于您的帐户尚未激活，我们无法让您登录。
+      signed_up_but_locked: 您已成功注册。但是，由于您的帐户已被锁定，我们无法让您登录。
+      signed_up_but_unconfirmed: 我们已向您的邮箱发送了一封包含确认链接的邮件。请点击链接激活您的账户。
+      update_needs_confirmation: 您已成功更新账户，但我们需要验证您的新邮箱地址。请查看您的邮箱并点击确认链接以验证您的新邮箱地址。
+      updated: 您的账户已成功更新。
+    sessions:
+      signed_in: 登录成功。
+      signed_out: 已成功登出。
+      already_signed_out: 已成功登出。
+    unlocks:
+      send_instructions: 几分钟后，您将收到一封电子邮件，其中包含解锁帐户的说明。
+      send_paranoid_instructions: 如果您的账户存在，您将在几分钟内收到一封电子邮件，其中包含解锁账户的说明。
+      unlocked: 您的账户已成功解锁。请登录以继续。
+  errors:
+    messages:
+      already_confirmed: 已确认，请尝试登录。
+      confirmation_period_expired: 需要在%{period}范围内确认，请申请新的确认。
+      expired: 已过期，请申请新的。
+      not_found: 未找到
+      not_locked: 未锁定
+      not_saved:
+        one: 1 个错误导致此 %{resource} 无法保存：
+        other: 由于 %{count} 错误，无法保存此 %{resource}：
+      pwned_password: 曾出现在数据泄露事件中，绝对不应该使用。

--- a/bullet_train/config/locales/zh-CN/memberships.zh-CN.yml
+++ b/bullet_train/config/locales/zh-CN/memberships.zh-CN.yml
@@ -1,0 +1,1044 @@
+---
+zh-CN:
+  memberships:
+    label: 团队成员
+    singular: 队员
+    navigation:
+      label: 团队成员
+      icon: fa-light fa-users
+    breadcrumbs:
+      label: 团队成员
+    buttons:
+      edit: 设置
+      show: 细节
+      resend: 重新发送
+      update: 更新会员资格
+      demote: 从管理员降级
+      promote: 晋升为管理员
+      destroy: 从团队中移除
+      destroy_own: 离开这个团队
+      reinvite: 重新邀请加入团队
+      confirmations:
+        destroy: 您确定要从 %{team_name} 中删除 %{membership_name} 吗？
+        destroy_own: 您确定要从 %{team_name} 移除您的帐户吗？此操作无法撤销。
+        reinvite: 您确定要将 %{membership_name} 重新邀请到 %{team_name} 吗？
+    fields:
+      id:
+        _: 会员ID
+        label: 会员ID
+        heading: 会员ID
+        api_title: 会员ID
+        api_description: 会员ID
+      user_id:
+        name: 用户身份
+        heading: 用户身份
+        api_title: 用户身份
+        api_description: 用户身份
+      team_id:
+        name: 团队 ID
+        heading: 团队 ID
+        api_title: 团队 ID
+        api_description: 团队 ID
+      invitation_id:
+        name: 邀请码
+        heading: 邀请码
+        api_title: 邀请码
+        api_description: 邀请码
+      name:
+        name: 姓名
+        heading: 姓名
+        api_title: 姓名
+        api_description: 姓名
+      user_first_name:
+        name: 名
+        label: 名
+        heading: 名
+        api_title: 名
+        api_description: 名
+      user_last_name:
+        name: 姓
+        label: 姓
+        heading: 姓
+        api_title: 姓
+        api_description: 姓
+      user_profile_photo_id:
+        name: 个人资料照片
+        label: 个人资料照片
+        heading: 个人资料照片
+        api_title: 个人资料照片
+        api_description: 个人资料照片
+      user_profile_photo:
+        name: 个人资料照片
+        label: 个人资料照片
+        heading: 个人资料照片
+        api_title: 个人资料照片
+        api_description: 个人资料照片
+      user_email:
+        name: 用户邮箱
+        heading: 用户邮箱
+        api_title: 用户邮箱
+        api_description: 用户邮箱
+      added_by_id:
+        name: 用户 ID 添加
+        heading: 用户 ID 添加
+        api_title: 用户 ID 添加
+        api_description: 用户 ID 添加
+      platform_agent_of_id:
+        name: 平台代理 ID
+        heading: 平台代理 ID
+        api_title: 平台代理 ID
+        api_description: 平台代理 ID
+      platform_agent:
+        name: 平台代理
+        heading: 平台代理
+        api_title: 平台代理
+        api_description: 平台代理
+      role_ids:
+        name: 角色
+        label: 角色
+        heading: 角色
+        api_title: 角色
+        api_description: 角色
+        options:
+          default:
+            label: 观众
+            description: 只能查看团队数据
+          admin:
+            label: 团队管理员
+            description: 团队管理员可以管理账单并管理其他用户的特殊权限。
+          editor:
+            label: 编辑
+            description: 可以编辑此团队中的所有资源，并允许其他人执行相同的操作。
+        none: 观众
+      created_at:
+        _: 创建于
+        heading: 创建于
+        api_title: 创建于
+        api_description: 创建于
+      updated_at:
+        _: 更新于
+        heading: 更新于
+        api_title: 更新于
+        api_description: 更新于
+    index:
+      section: "%{team_name} 团队成员"
+      contexts:
+        team:
+          header: 团队成员
+          description: 以下人员是您的团队成员。您也可以邀请新的团队成员。
+          fields:
+            id:
+              _: 会员ID
+              label: 会员ID
+              heading: 会员ID
+              api_title: 会员ID
+              api_description: 会员ID
+            user_id:
+              name: 用户身份
+              heading: 用户身份
+              api_title: 用户身份
+              api_description: 用户身份
+            team_id:
+              name: 团队 ID
+              heading: 团队 ID
+              api_title: 团队 ID
+              api_description: 团队 ID
+            invitation_id:
+              name: 邀请码
+              heading: 邀请码
+              api_title: 邀请码
+              api_description: 邀请码
+            name:
+              name: 姓名
+              heading: 姓名
+              api_title: 姓名
+              api_description: 姓名
+            user_first_name:
+              name: 名
+              label: 名
+              heading: 名
+              api_title: 名
+              api_description: 名
+            user_last_name:
+              name: 姓
+              label: 姓
+              heading: 姓
+              api_title: 姓
+              api_description: 姓
+            user_profile_photo_id:
+              name: 个人资料照片
+              label: 个人资料照片
+              heading: 个人资料照片
+              api_title: 个人资料照片
+              api_description: 个人资料照片
+            user_profile_photo:
+              name: 个人资料照片
+              label: 个人资料照片
+              heading: 个人资料照片
+              api_title: 个人资料照片
+              api_description: 个人资料照片
+            user_email:
+              name: 用户邮箱
+              heading: 用户邮箱
+              api_title: 用户邮箱
+              api_description: 用户邮箱
+            added_by_id:
+              name: 用户 ID 添加
+              heading: 用户 ID 添加
+              api_title: 用户 ID 添加
+              api_description: 用户 ID 添加
+            platform_agent_of_id:
+              name: 平台代理 ID
+              heading: 平台代理 ID
+              api_title: 平台代理 ID
+              api_description: 平台代理 ID
+            platform_agent:
+              name: 平台代理
+              heading: 平台代理
+              api_title: 平台代理
+              api_description: 平台代理
+            role_ids:
+              name: 角色
+              label: 角色
+              heading: 角色
+              api_title: 角色
+              api_description: 角色
+              options:
+                default:
+                  label: 观众
+                  description: 只能查看团队数据
+                admin:
+                  label: 团队管理员
+                  description: 团队管理员可以管理账单并管理其他用户的特殊权限。
+                editor:
+                  label: 编辑
+                  description: 可以编辑此团队中的所有资源，并允许其他人执行相同的操作。
+              none: 观众
+            created_at:
+              _: 创建于
+              heading: 创建于
+              api_title: 创建于
+              api_description: 创建于
+            updated_at:
+              _: 更新于
+              heading: 更新于
+              api_title: 更新于
+              api_description: 更新于
+      buttons:
+        edit: 设置
+        show: 细节
+        resend: 重新发送
+        update: 更新会员资格
+        demote: 从管理员降级
+        promote: 晋升为管理员
+        destroy: 从团队中移除
+        destroy_own: 离开这个团队
+        reinvite: 邀请加入团队
+        confirmations:
+          destroy: 您确定要从 %{team_name} 中移除 %{membership_name} 吗？
+          destroy_own: 你确定要从 %{team_name} 中移除自己吗？此操作无法撤销。
+          reinvite: 你确定要邀请 %{membership_name} 到 %{team_name} 吗？
+    tombstones:
+      contexts:
+        team:
+          header: 等待邀请的成员
+          description: 以下人员已从 %{team_name} 中移除，但您仍然可以管理他们的个人资料并将他们的任务重新分配给其他团队成员。
+      buttons:
+        edit: 设置
+        show: 细节
+        resend: 重新发送
+        update: 更新会员资格
+        demote: 从管理员降级
+        promote: 晋升为管理员
+        destroy: 从团队中移除
+        destroy_own: 离开这个团队
+        reinvite: 邀请加入团队
+        confirmations:
+          destroy: 您确定要从 %{team_name} 中移除 %{membership_name} 吗？
+          destroy_own: 你确定要从 %{team_name} 中移除自己吗？此操作无法撤销。
+          reinvite: 你确定要邀请 %{membership_name} 到 %{team_name} 吗？
+    form:
+      grant_privileges_of: 授予 %{role_key} 的权限
+      buttons:
+        edit: 设置
+        show: 细节
+        resend: 重新发送
+        update: 更新会员资格
+        demote: 从管理员降级
+        promote: 晋升为管理员
+        destroy: 从团队中移除
+        destroy_own: 离开这个团队
+        reinvite: 邀请加入团队
+        confirmations:
+          destroy: 您确定要从 %{team_name} 中移除 %{membership_name} 吗？
+          destroy_own: 你确定要从 %{team_name} 中移除自己吗？此操作无法撤销。
+          reinvite: 你确定要邀请 %{membership_name} 到 %{team_name} 吗？
+      fields:
+        id:
+          _: 会员ID
+          label: 会员ID
+          heading: 会员ID
+          api_title: 会员ID
+          api_description: 会员ID
+        user_id:
+          name: 用户身份
+          heading: 用户身份
+          api_title: 用户身份
+          api_description: 用户身份
+        team_id:
+          name: 团队 ID
+          heading: 团队 ID
+          api_title: 团队 ID
+          api_description: 团队 ID
+        invitation_id:
+          name: 邀请码
+          heading: 邀请码
+          api_title: 邀请码
+          api_description: 邀请码
+        name:
+          name: 姓名
+          heading: 姓名
+          api_title: 姓名
+          api_description: 姓名
+        user_first_name:
+          name: 名
+          label: 名
+          heading: 名
+          api_title: 名
+          api_description: 名
+        user_last_name:
+          name: 姓
+          label: 姓
+          heading: 姓
+          api_title: 姓
+          api_description: 姓
+        user_profile_photo_id:
+          name: 个人资料照片
+          label: 个人资料照片
+          heading: 个人资料照片
+          api_title: 个人资料照片
+          api_description: 个人资料照片
+        user_profile_photo:
+          name: 个人资料照片
+          label: 个人资料照片
+          heading: 个人资料照片
+          api_title: 个人资料照片
+          api_description: 个人资料照片
+        user_email:
+          name: 用户邮箱
+          heading: 用户邮箱
+          api_title: 用户邮箱
+          api_description: 用户邮箱
+        added_by_id:
+          name: 用户 ID 添加
+          heading: 用户 ID 添加
+          api_title: 用户 ID 添加
+          api_description: 用户 ID 添加
+        platform_agent_of_id:
+          name: 平台代理 ID
+          heading: 平台代理 ID
+          api_title: 平台代理 ID
+          api_description: 平台代理 ID
+        platform_agent:
+          name: 平台代理
+          heading: 平台代理
+          api_title: 平台代理
+          api_description: 平台代理
+        role_ids:
+          name: 角色
+          label: 角色
+          heading: 角色
+          api_title: 角色
+          api_description: 角色
+          options:
+            default:
+              label: 观众
+              description: 只能查看团队数据
+            admin:
+              label: 团队管理员
+              description: 团队管理员可以管理账单并管理其他用户的特殊权限。
+            editor:
+              label: 编辑
+              description: 可以编辑此团队中的所有资源，并允许其他人执行相同的操作。
+          none: 观众
+        created_at:
+          _: 创建于
+          heading: 创建于
+          api_title: 创建于
+          api_description: 创建于
+        updated_at:
+          _: 更新于
+          heading: 更新于
+          api_title: 更新于
+          api_description: 更新于
+    edit:
+      section: "%{membership_name} 在 %{team_name} 上"
+      header: 更新会员设置
+      description: 您可以在下面通过 %{team_name} 编辑 %{memberships_possessive} 会员资格的设置。
+      grant_privileges_of: 授予 %{role_key} 的权限
+      remove_header: 移除团队成员
+      remove_description: 移除 %{membership_name} 不会移除任何资源分配。相反，您可以选择将资源重新分配给其他团队成员。将来您还可以重新邀请 %{membership_name} 加入团队。
+      buttons:
+        edit: 设置
+        show: 细节
+        resend: 重新发送
+        update: 更新会员资格
+        demote: 从管理员降级
+        promote: 晋升为管理员
+        destroy: 从团队中移除
+        destroy_own: 离开这个团队
+        reinvite: 邀请加入团队
+        confirmations:
+          destroy: 您确定要从 %{team_name} 中移除 %{membership_name} 吗？
+          destroy_own: 你确定要从 %{team_name} 中移除自己吗？此操作无法撤销。
+          reinvite: 你确定要邀请 %{membership_name} 到 %{team_name} 吗？
+    show:
+      section: "%{memberships_possessive} 会员资格在 %{team_name} 上"
+      header: 会员详情
+      invitation_header: 邀请函详情
+      tombstone_header: 前团队成员
+      description: 以下是%{memberships_possessive}在%{team_name}上的会员资格详情。
+      buttons:
+        edit: 设置
+        show: 细节
+        resend: 重新发送
+        update: 更新会员资格
+        demote: 从管理员降级
+        promote: 晋升为管理员
+        destroy: 从团队中移除
+        destroy_own: 离开这个团队
+        reinvite: 邀请加入团队
+        confirmations:
+          destroy: 您确定要从 %{team_name} 中移除 %{membership_name} 吗？
+          destroy_own: 你确定要从 %{team_name} 中移除自己吗？此操作无法撤销。
+          reinvite: 你确定要邀请 %{membership_name} 到 %{team_name} 吗？
+      fields:
+        id:
+          _: 会员ID
+          label: 会员ID
+          heading: 会员ID
+          api_title: 会员ID
+          api_description: 会员ID
+        user_id:
+          name: 用户身份
+          heading: 用户身份
+          api_title: 用户身份
+          api_description: 用户身份
+        team_id:
+          name: 团队 ID
+          heading: 团队 ID
+          api_title: 团队 ID
+          api_description: 团队 ID
+        invitation_id:
+          name: 邀请码
+          heading: 邀请码
+          api_title: 邀请码
+          api_description: 邀请码
+        name:
+          name: 姓名
+          heading: 姓名
+          api_title: 姓名
+          api_description: 姓名
+        user_first_name:
+          name: 名
+          label: 名
+          heading: 名
+          api_title: 名
+          api_description: 名
+        user_last_name:
+          name: 姓
+          label: 姓
+          heading: 姓
+          api_title: 姓
+          api_description: 姓
+        user_profile_photo_id:
+          name: 个人资料照片
+          label: 个人资料照片
+          heading: 个人资料照片
+          api_title: 个人资料照片
+          api_description: 个人资料照片
+        user_profile_photo:
+          name: 个人资料照片
+          label: 个人资料照片
+          heading: 个人资料照片
+          api_title: 个人资料照片
+          api_description: 个人资料照片
+        user_email:
+          name: 用户邮箱
+          heading: 用户邮箱
+          api_title: 用户邮箱
+          api_description: 用户邮箱
+        added_by_id:
+          name: 用户 ID 添加
+          heading: 用户 ID 添加
+          api_title: 用户 ID 添加
+          api_description: 用户 ID 添加
+        platform_agent_of_id:
+          name: 平台代理 ID
+          heading: 平台代理 ID
+          api_title: 平台代理 ID
+          api_description: 平台代理 ID
+        platform_agent:
+          name: 平台代理
+          heading: 平台代理
+          api_title: 平台代理
+          api_description: 平台代理
+        role_ids:
+          name: 角色
+          label: 角色
+          heading: 角色
+          api_title: 角色
+          api_description: 角色
+          options:
+            default:
+              label: 观众
+              description: 只能查看团队数据
+            admin:
+              label: 团队管理员
+              description: 团队管理员可以管理账单并管理其他用户的特殊权限。
+            editor:
+              label: 编辑
+              description: 可以编辑此团队中的所有资源，并允许其他人执行相同的操作。
+          none: 观众
+        created_at:
+          _: 创建于
+          heading: 创建于
+          api_title: 创建于
+          api_description: 创建于
+        updated_at:
+          _: 更新于
+          heading: 更新于
+          api_title: 更新于
+          api_description: 更新于
+    notifications:
+      updated: 会员信息已成功更新。
+      destroyed: 该用户已成功从团队中移除。
+      no_members: 你的团队目前还没有其他成员！立即发送邀请，开始组建团队吧！
+      cant_demote: 抱歉，您无法降级团队中最后一位管理员。请先将其他人设为管理员。
+      cant_remove: 抱歉，您无法移除团队中的最后一位管理员。请先将其他人添加为管理员。
+      you_removed_yourself: 您已成功从 %{team_name} 中移除自己。
+      reinvited: 用户已成功受邀。他们将收到一封加入团队的电子邮件。
+  account:
+    memberships:
+      label: 团队成员
+      singular: 队员
+      navigation:
+        label: 团队成员
+        icon: fa-light fa-users
+      breadcrumbs:
+        label: 团队成员
+      buttons:
+        edit: 设置
+        show: 细节
+        resend: 重新发送
+        update: 更新会员资格
+        demote: 从管理员降级
+        promote: 晋升为管理员
+        destroy: 从团队中移除
+        destroy_own: 离开这个团队
+        reinvite: 重新邀请加入团队
+        confirmations:
+          destroy: 您确定要从 %{team_name} 中删除 %{membership_name} 吗？
+          destroy_own: 您确定要从 %{team_name} 移除您的帐户吗？此操作无法撤销。
+          reinvite: 您确定要将 %{membership_name} 重新邀请到 %{team_name} 吗？
+      fields:
+        id:
+          _: 会员ID
+          label: 会员ID
+          heading: 会员ID
+          api_title: 会员ID
+          api_description: 会员ID
+        user_id:
+          name: 用户身份
+          heading: 用户身份
+          api_title: 用户身份
+          api_description: 用户身份
+        team_id:
+          name: 团队 ID
+          heading: 团队 ID
+          api_title: 团队 ID
+          api_description: 团队 ID
+        invitation_id:
+          name: 邀请码
+          heading: 邀请码
+          api_title: 邀请码
+          api_description: 邀请码
+        name:
+          name: 姓名
+          heading: 姓名
+          api_title: 姓名
+          api_description: 姓名
+        user_first_name:
+          name: 名
+          label: 名
+          heading: 名
+          api_title: 名
+          api_description: 名
+        user_last_name:
+          name: 姓
+          label: 姓
+          heading: 姓
+          api_title: 姓
+          api_description: 姓
+        user_profile_photo_id:
+          name: 个人资料照片
+          label: 个人资料照片
+          heading: 个人资料照片
+          api_title: 个人资料照片
+          api_description: 个人资料照片
+        user_profile_photo:
+          name: 个人资料照片
+          label: 个人资料照片
+          heading: 个人资料照片
+          api_title: 个人资料照片
+          api_description: 个人资料照片
+        user_email:
+          name: 用户邮箱
+          heading: 用户邮箱
+          api_title: 用户邮箱
+          api_description: 用户邮箱
+        added_by_id:
+          name: 用户 ID 添加
+          heading: 用户 ID 添加
+          api_title: 用户 ID 添加
+          api_description: 用户 ID 添加
+        platform_agent_of_id:
+          name: 平台代理 ID
+          heading: 平台代理 ID
+          api_title: 平台代理 ID
+          api_description: 平台代理 ID
+        platform_agent:
+          name: 平台代理
+          heading: 平台代理
+          api_title: 平台代理
+          api_description: 平台代理
+        role_ids:
+          name: 角色
+          label: 角色
+          heading: 角色
+          api_title: 角色
+          api_description: 角色
+          options:
+            default:
+              label: 观众
+              description: 只能查看团队数据
+            admin:
+              label: 团队管理员
+              description: 团队管理员可以管理账单并管理其他用户的特殊权限。
+            editor:
+              label: 编辑
+              description: 可以编辑此团队中的所有资源，并允许其他人执行相同的操作。
+          none: 观众
+        created_at:
+          _: 创建于
+          heading: 创建于
+          api_title: 创建于
+          api_description: 创建于
+        updated_at:
+          _: 更新于
+          heading: 更新于
+          api_title: 更新于
+          api_description: 更新于
+      index:
+        section: "%{team_name} 团队成员"
+        contexts:
+          team:
+            header: 团队成员
+            description: 以下人员是您的团队成员。您也可以邀请新的团队成员。
+            fields:
+              id:
+                _: 会员ID
+                label: 会员ID
+                heading: 会员ID
+                api_title: 会员ID
+                api_description: 会员ID
+              user_id:
+                name: 用户身份
+                heading: 用户身份
+                api_title: 用户身份
+                api_description: 用户身份
+              team_id:
+                name: 团队 ID
+                heading: 团队 ID
+                api_title: 团队 ID
+                api_description: 团队 ID
+              invitation_id:
+                name: 邀请码
+                heading: 邀请码
+                api_title: 邀请码
+                api_description: 邀请码
+              name:
+                name: 姓名
+                heading: 姓名
+                api_title: 姓名
+                api_description: 姓名
+              user_first_name:
+                name: 名
+                label: 名
+                heading: 名
+                api_title: 名
+                api_description: 名
+              user_last_name:
+                name: 姓
+                label: 姓
+                heading: 姓
+                api_title: 姓
+                api_description: 姓
+              user_profile_photo_id:
+                name: 个人资料照片
+                label: 个人资料照片
+                heading: 个人资料照片
+                api_title: 个人资料照片
+                api_description: 个人资料照片
+              user_profile_photo:
+                name: 个人资料照片
+                label: 个人资料照片
+                heading: 个人资料照片
+                api_title: 个人资料照片
+                api_description: 个人资料照片
+              user_email:
+                name: 用户邮箱
+                heading: 用户邮箱
+                api_title: 用户邮箱
+                api_description: 用户邮箱
+              added_by_id:
+                name: 用户 ID 添加
+                heading: 用户 ID 添加
+                api_title: 用户 ID 添加
+                api_description: 用户 ID 添加
+              platform_agent_of_id:
+                name: 平台代理 ID
+                heading: 平台代理 ID
+                api_title: 平台代理 ID
+                api_description: 平台代理 ID
+              platform_agent:
+                name: 平台代理
+                heading: 平台代理
+                api_title: 平台代理
+                api_description: 平台代理
+              role_ids:
+                name: 角色
+                label: 角色
+                heading: 角色
+                api_title: 角色
+                api_description: 角色
+                options:
+                  default:
+                    label: 观众
+                    description: 只能查看团队数据
+                  admin:
+                    label: 团队管理员
+                    description: 团队管理员可以管理账单并管理其他用户的特殊权限。
+                  editor:
+                    label: 编辑
+                    description: 可以编辑此团队中的所有资源，并允许其他人执行相同的操作。
+                none: 观众
+              created_at:
+                _: 创建于
+                heading: 创建于
+                api_title: 创建于
+                api_description: 创建于
+              updated_at:
+                _: 更新于
+                heading: 更新于
+                api_title: 更新于
+                api_description: 更新于
+        buttons:
+          edit: 设置
+          show: 细节
+          resend: 重新发送
+          update: 更新会员资格
+          demote: 从管理员降级
+          promote: 晋升为管理员
+          destroy: 从团队中移除
+          destroy_own: 离开这个团队
+          reinvite: 邀请加入团队
+          confirmations:
+            destroy: 您确定要从 %{team_name} 中移除 %{membership_name} 吗？
+            destroy_own: 你确定要从 %{team_name} 中移除自己吗？此操作无法撤销。
+            reinvite: 你确定要邀请 %{membership_name} 到 %{team_name} 吗？
+      tombstones:
+        contexts:
+          team:
+            header: 等待邀请的成员
+            description: 以下人员已从 %{team_name} 中移除，但您仍然可以管理他们的个人资料并将他们的任务重新分配给其他团队成员。
+        buttons:
+          edit: 设置
+          show: 细节
+          resend: 重新发送
+          update: 更新会员资格
+          demote: 从管理员降级
+          promote: 晋升为管理员
+          destroy: 从团队中移除
+          destroy_own: 离开这个团队
+          reinvite: 邀请加入团队
+          confirmations:
+            destroy: 您确定要从 %{team_name} 中移除 %{membership_name} 吗？
+            destroy_own: 你确定要从 %{team_name} 中移除自己吗？此操作无法撤销。
+            reinvite: 你确定要邀请 %{membership_name} 到 %{team_name} 吗？
+      form:
+        grant_privileges_of: 授予 %{role_key} 的权限
+        buttons:
+          edit: 设置
+          show: 细节
+          resend: 重新发送
+          update: 更新会员资格
+          demote: 从管理员降级
+          promote: 晋升为管理员
+          destroy: 从团队中移除
+          destroy_own: 离开这个团队
+          reinvite: 邀请加入团队
+          confirmations:
+            destroy: 您确定要从 %{team_name} 中移除 %{membership_name} 吗？
+            destroy_own: 你确定要从 %{team_name} 中移除自己吗？此操作无法撤销。
+            reinvite: 你确定要邀请 %{membership_name} 到 %{team_name} 吗？
+        fields:
+          id:
+            _: 会员ID
+            label: 会员ID
+            heading: 会员ID
+            api_title: 会员ID
+            api_description: 会员ID
+          user_id:
+            name: 用户身份
+            heading: 用户身份
+            api_title: 用户身份
+            api_description: 用户身份
+          team_id:
+            name: 团队 ID
+            heading: 团队 ID
+            api_title: 团队 ID
+            api_description: 团队 ID
+          invitation_id:
+            name: 邀请码
+            heading: 邀请码
+            api_title: 邀请码
+            api_description: 邀请码
+          name:
+            name: 姓名
+            heading: 姓名
+            api_title: 姓名
+            api_description: 姓名
+          user_first_name:
+            name: 名
+            label: 名
+            heading: 名
+            api_title: 名
+            api_description: 名
+          user_last_name:
+            name: 姓
+            label: 姓
+            heading: 姓
+            api_title: 姓
+            api_description: 姓
+          user_profile_photo_id:
+            name: 个人资料照片
+            label: 个人资料照片
+            heading: 个人资料照片
+            api_title: 个人资料照片
+            api_description: 个人资料照片
+          user_profile_photo:
+            name: 个人资料照片
+            label: 个人资料照片
+            heading: 个人资料照片
+            api_title: 个人资料照片
+            api_description: 个人资料照片
+          user_email:
+            name: 用户邮箱
+            heading: 用户邮箱
+            api_title: 用户邮箱
+            api_description: 用户邮箱
+          added_by_id:
+            name: 用户 ID 添加
+            heading: 用户 ID 添加
+            api_title: 用户 ID 添加
+            api_description: 用户 ID 添加
+          platform_agent_of_id:
+            name: 平台代理 ID
+            heading: 平台代理 ID
+            api_title: 平台代理 ID
+            api_description: 平台代理 ID
+          platform_agent:
+            name: 平台代理
+            heading: 平台代理
+            api_title: 平台代理
+            api_description: 平台代理
+          role_ids:
+            name: 角色
+            label: 角色
+            heading: 角色
+            api_title: 角色
+            api_description: 角色
+            options:
+              default:
+                label: 观众
+                description: 只能查看团队数据
+              admin:
+                label: 团队管理员
+                description: 团队管理员可以管理账单并管理其他用户的特殊权限。
+              editor:
+                label: 编辑
+                description: 可以编辑此团队中的所有资源，并允许其他人执行相同的操作。
+            none: 观众
+          created_at:
+            _: 创建于
+            heading: 创建于
+            api_title: 创建于
+            api_description: 创建于
+          updated_at:
+            _: 更新于
+            heading: 更新于
+            api_title: 更新于
+            api_description: 更新于
+      edit:
+        section: "%{membership_name} 在 %{team_name} 上"
+        header: 更新会员设置
+        description: 您可以在下面通过 %{team_name} 编辑 %{memberships_possessive} 会员资格的设置。
+        grant_privileges_of: 授予 %{role_key} 的权限
+        remove_header: 移除团队成员
+        remove_description: 移除 %{membership_name} 不会移除任何资源分配。相反，您可以选择将资源重新分配给其他团队成员。将来您还可以重新邀请 %{membership_name} 加入团队。
+        buttons:
+          edit: 设置
+          show: 细节
+          resend: 重新发送
+          update: 更新会员资格
+          demote: 从管理员降级
+          promote: 晋升为管理员
+          destroy: 从团队中移除
+          destroy_own: 离开这个团队
+          reinvite: 邀请加入团队
+          confirmations:
+            destroy: 您确定要从 %{team_name} 中移除 %{membership_name} 吗？
+            destroy_own: 你确定要从 %{team_name} 中移除自己吗？此操作无法撤销。
+            reinvite: 你确定要邀请 %{membership_name} 到 %{team_name} 吗？
+      show:
+        section: "%{memberships_possessive} 会员资格在 %{team_name} 上"
+        header: 会员详情
+        invitation_header: 邀请函详情
+        tombstone_header: 前团队成员
+        description: 以下是%{memberships_possessive}在%{team_name}上的会员资格详情。
+        buttons:
+          edit: 设置
+          show: 细节
+          resend: 重新发送
+          update: 更新会员资格
+          demote: 从管理员降级
+          promote: 晋升为管理员
+          destroy: 从团队中移除
+          destroy_own: 离开这个团队
+          reinvite: 邀请加入团队
+          confirmations:
+            destroy: 您确定要从 %{team_name} 中移除 %{membership_name} 吗？
+            destroy_own: 你确定要从 %{team_name} 中移除自己吗？此操作无法撤销。
+            reinvite: 你确定要邀请 %{membership_name} 到 %{team_name} 吗？
+        fields:
+          id:
+            _: 会员ID
+            label: 会员ID
+            heading: 会员ID
+            api_title: 会员ID
+            api_description: 会员ID
+          user_id:
+            name: 用户身份
+            heading: 用户身份
+            api_title: 用户身份
+            api_description: 用户身份
+          team_id:
+            name: 团队 ID
+            heading: 团队 ID
+            api_title: 团队 ID
+            api_description: 团队 ID
+          invitation_id:
+            name: 邀请码
+            heading: 邀请码
+            api_title: 邀请码
+            api_description: 邀请码
+          name:
+            name: 姓名
+            heading: 姓名
+            api_title: 姓名
+            api_description: 姓名
+          user_first_name:
+            name: 名
+            label: 名
+            heading: 名
+            api_title: 名
+            api_description: 名
+          user_last_name:
+            name: 姓
+            label: 姓
+            heading: 姓
+            api_title: 姓
+            api_description: 姓
+          user_profile_photo_id:
+            name: 个人资料照片
+            label: 个人资料照片
+            heading: 个人资料照片
+            api_title: 个人资料照片
+            api_description: 个人资料照片
+          user_profile_photo:
+            name: 个人资料照片
+            label: 个人资料照片
+            heading: 个人资料照片
+            api_title: 个人资料照片
+            api_description: 个人资料照片
+          user_email:
+            name: 用户邮箱
+            heading: 用户邮箱
+            api_title: 用户邮箱
+            api_description: 用户邮箱
+          added_by_id:
+            name: 用户 ID 添加
+            heading: 用户 ID 添加
+            api_title: 用户 ID 添加
+            api_description: 用户 ID 添加
+          platform_agent_of_id:
+            name: 平台代理 ID
+            heading: 平台代理 ID
+            api_title: 平台代理 ID
+            api_description: 平台代理 ID
+          platform_agent:
+            name: 平台代理
+            heading: 平台代理
+            api_title: 平台代理
+            api_description: 平台代理
+          role_ids:
+            name: 角色
+            label: 角色
+            heading: 角色
+            api_title: 角色
+            api_description: 角色
+            options:
+              default:
+                label: 观众
+                description: 只能查看团队数据
+              admin:
+                label: 团队管理员
+                description: 团队管理员可以管理账单并管理其他用户的特殊权限。
+              editor:
+                label: 编辑
+                description: 可以编辑此团队中的所有资源，并允许其他人执行相同的操作。
+            none: 观众
+          created_at:
+            _: 创建于
+            heading: 创建于
+            api_title: 创建于
+            api_description: 创建于
+          updated_at:
+            _: 更新于
+            heading: 更新于
+            api_title: 更新于
+            api_description: 更新于
+      notifications:
+        updated: 会员信息已成功更新。
+        destroyed: 该用户已成功从团队中移除。
+        no_members: 你的团队目前还没有其他成员！立即发送邀请，开始组建团队吧！
+        cant_demote: 抱歉，您无法降级团队中最后一位管理员。请先将其他人设为管理员。
+        cant_remove: 抱歉，您无法移除团队中的最后一位管理员。请先将其他人添加为管理员。
+        you_removed_yourself: 您已成功从 %{team_name} 中移除自己。
+        reinvited: 用户已成功受邀。他们将收到一封加入团队的电子邮件。
+  activerecord:
+    attributes:
+      memberships:
+        user_first_name: 名
+        user_last_name: 姓

--- a/bullet_train/config/locales/zh-CN/onboarding/user_details.zh-CN.yml
+++ b/bullet_train/config/locales/zh-CN/onboarding/user_details.zh-CN.yml
@@ -1,0 +1,19 @@
+---
+zh-CN:
+  onboarding:
+    user_details:
+      buttons:
+        next: 下一个
+      edit:
+        header: 请告诉我们您的情况。
+        buttons:
+          next: 下一个
+  account:
+    onboarding:
+      user_details:
+        buttons:
+          next: 下一个
+        edit:
+          header: 请告诉我们您的情况。
+          buttons:
+            next: 下一个

--- a/bullet_train/config/locales/zh-CN/teams.zh-CN.yml
+++ b/bullet_train/config/locales/zh-CN/teams.zh-CN.yml
@@ -1,0 +1,371 @@
+---
+zh-CN:
+  teams:
+    label: 团队
+    singular: 团队
+    breadcrumbs:
+      label: 团队
+      team_settings: 团队设置
+      dashboard: 仪表板
+    navigation:
+      label: 团队
+    buttons:
+      new: 添加新团队
+      create: 创建团队
+      edit: 编辑团队
+      update: 更新团队
+      destroy: 删除团队
+      confirmations:
+        destroy: 您确定要删除此团队吗？
+    index:
+      section: 团队
+      header: 您的团队
+      create: 创建新团队
+      buttons:
+        new: 添加新团队
+        create: 创建团队
+        edit: 编辑团队
+        update: 更新团队
+        destroy: 删除团队
+        confirmations:
+          destroy: 您确定要删除此团队吗？
+    show:
+      header: "%{teams_possessive} 合规性仪表盘"
+    new:
+      header: 创建新团队
+      former_user_header: 加入团队
+      default_team_name: 你的团队
+      buttons:
+        new: 添加新团队
+        create: 创建团队
+        edit: 编辑团队
+        update: 更新团队
+        destroy: 删除团队
+        confirmations:
+          destroy: 您确定要删除此团队吗？
+      you_can: 你可以选择：
+      invitation_header: 接受邀请
+      logout_header: 退出此帐户
+      new_team_header: 组建一支新团队
+      alert: 账户 <b>%{user_email}</b> 目前不属于任何团队。
+      invitation: 如果您收到邀请您加入新团队的电子邮件，请点击该电子邮件中的链接接受邀请。
+      log_out: 您可以注销此帐户，然后使用团队成员的其他帐户登录。
+      new_team: 您可以使用下面的表格创建自己的新团队。
+    edit:
+      section: "%{team_name}"
+      header: 编辑团队详情
+      description: 您可以在下方更新此团队的详细信息和设置。
+    notifications:
+      created: 团队已成功创建。
+      updated: 团队更新已成功。
+      destroyed: 队伍已被成功摧毁。
+      invitation_only: 目前，创建新团队的功能仅限于已受邀参与抢先体验的用户。如果您已收到抢先体验链接，请先访问该链接，然后再尝试创建新团队。
+      cannot_delete_last_team: 您无法删除您所属的最后一个团队。
+    form:
+      buttons:
+        new: 添加新团队
+        create: 创建团队
+        edit: 编辑团队
+        update: 更新团队
+        destroy: 删除团队
+        confirmations:
+          destroy: 您确定要删除此团队吗？
+    fields:
+      id:
+        _: 团队 ID
+        label: 团队 ID
+        heading: 团队 ID
+        api_title: 团队 ID
+        api_description: 团队 ID
+      name:
+        _: 团队名称
+        label: 团队名称
+        heading: 团队名称
+        api_title: 团队名称
+        api_description: 团队名称
+      time_zone:
+        _: 主要时区
+        label: 主要时区
+        heading: 主要时区
+        api_title: 主要时区
+        api_description: 主要时区
+      locale:
+        _: 主要语言
+        label: 主要语言
+        heading: 主要语言
+        api_title: 主要语言
+        api_description: 主要语言
+      created_at:
+        _: 已注册
+        heading: 已注册
+        api_title: 已注册
+        api_description: 已注册
+      updated_at:
+        _: 更新于
+        heading: 更新于
+        api_title: 更新于
+        api_description: 更新于
+    _:
+      name:
+        label: 您的团队名称
+    self:
+      id:
+        _: 团队 ID
+        label: 团队 ID
+        heading: 团队 ID
+        api_title: 团队 ID
+        api_description: 团队 ID
+      name:
+        label: 您的团队名称
+      time_zone:
+        _: 主要时区
+        label: 主要时区
+        heading: 主要时区
+        api_title: 主要时区
+        api_description: 主要时区
+      locale:
+        _: 语言
+        label: 主要语言
+        heading: 语言
+        api_title: 语言
+        api_description: 语言
+      created_at:
+        _: 已注册
+        heading: 已注册
+        api_title: 已注册
+        api_description: 已注册
+      updated_at:
+        _: 更新于
+        heading: 更新于
+        api_title: 更新于
+        api_description: 更新于
+    api:
+      actions: 团队行动
+      index: 列出球队
+      create: 添加新团队
+      show: 找回团队
+      update: 团队更新
+      fields:
+        id:
+          _: 团队 ID
+          label: 团队 ID
+          heading: 团队 ID
+          api_title: 团队 ID
+          api_description: 团队 ID
+        name:
+          _: 团队名称
+          label: 团队名称
+          heading: 团队
+          api_title: 团队名称
+          api_description: 团队名称
+        time_zone:
+          _: 主要时区
+          label: 主要时区
+          heading: 主要时区
+          api_title: 主要时区
+          api_description: 主要时区
+        locale:
+          _: 语言
+          label: 主要语言
+          heading: 语言
+          api_title: 语言
+          api_description: 语言
+        created_at:
+          _: 已注册
+          heading: 已注册
+          api_title: 已注册
+          api_description: 已注册
+        updated_at:
+          _: 更新于
+          heading: 更新于
+          api_title: 更新于
+          api_description: 更新于
+  account:
+    teams:
+      label: 团队
+      singular: 团队
+      breadcrumbs:
+        label: 团队
+        team_settings: 团队设置
+        dashboard: 仪表板
+      navigation:
+        label: 团队
+      buttons:
+        new: 添加新团队
+        create: 创建团队
+        edit: 编辑团队
+        update: 更新团队
+        destroy: 删除团队
+        confirmations:
+          destroy: 您确定要删除此团队吗？
+      index:
+        section: 团队
+        header: 您的团队
+        create: 创建新团队
+        buttons:
+          new: 添加新团队
+          create: 创建团队
+          edit: 编辑团队
+          update: 更新团队
+          destroy: 删除团队
+          confirmations:
+            destroy: 您确定要删除此团队吗？
+      show:
+        header: "%{teams_possessive} 合规性仪表盘"
+      new:
+        header: 创建新团队
+        former_user_header: 加入团队
+        default_team_name: 你的团队
+        buttons:
+          new: 添加新团队
+          create: 创建团队
+          edit: 编辑团队
+          update: 更新团队
+          destroy: 删除团队
+          confirmations:
+            destroy: 您确定要删除此团队吗？
+        you_can: 你可以选择：
+        invitation_header: 接受邀请
+        logout_header: 退出此帐户
+        new_team_header: 组建一支新团队
+        alert: 账户 <b>%{user_email}</b> 目前不属于任何团队。
+        invitation: 如果您收到邀请您加入新团队的电子邮件，请点击该电子邮件中的链接接受邀请。
+        log_out: 您可以注销此帐户，然后使用团队成员的其他帐户登录。
+        new_team: 您可以使用下面的表格创建自己的新团队。
+      edit:
+        section: "%{team_name}"
+        header: 编辑团队详情
+        description: 您可以在下方更新此团队的详细信息和设置。
+      notifications:
+        created: 团队已成功创建。
+        updated: 团队更新已成功。
+        destroyed: 队伍已被成功摧毁。
+        invitation_only: 目前，创建新团队的功能仅限于已受邀参与抢先体验的用户。如果您已收到抢先体验链接，请先访问该链接，然后再尝试创建新团队。
+        cannot_delete_last_team: 您无法删除您所属的最后一个团队。
+      form:
+        buttons:
+          new: 添加新团队
+          create: 创建团队
+          edit: 编辑团队
+          update: 更新团队
+          destroy: 删除团队
+          confirmations:
+            destroy: 您确定要删除此团队吗？
+      fields:
+        id:
+          _: 团队 ID
+          label: 团队 ID
+          heading: 团队 ID
+          api_title: 团队 ID
+          api_description: 团队 ID
+        name:
+          _: 团队名称
+          label: 团队名称
+          heading: 团队名称
+          api_title: 团队名称
+          api_description: 团队名称
+        time_zone:
+          _: 主要时区
+          label: 主要时区
+          heading: 主要时区
+          api_title: 主要时区
+          api_description: 主要时区
+        locale:
+          _: 主要语言
+          label: 主要语言
+          heading: 主要语言
+          api_title: 主要语言
+          api_description: 主要语言
+        created_at:
+          _: 已注册
+          heading: 已注册
+          api_title: 已注册
+          api_description: 已注册
+        updated_at:
+          _: 更新于
+          heading: 更新于
+          api_title: 更新于
+          api_description: 更新于
+      _:
+        name:
+          label: 您的团队名称
+      self:
+        id:
+          _: 团队 ID
+          label: 团队 ID
+          heading: 团队 ID
+          api_title: 团队 ID
+          api_description: 团队 ID
+        name:
+          label: 您的团队名称
+        time_zone:
+          _: 主要时区
+          label: 主要时区
+          heading: 主要时区
+          api_title: 主要时区
+          api_description: 主要时区
+        locale:
+          _: 语言
+          label: 主要语言
+          heading: 语言
+          api_title: 语言
+          api_description: 语言
+        created_at:
+          _: 已注册
+          heading: 已注册
+          api_title: 已注册
+          api_description: 已注册
+        updated_at:
+          _: 更新于
+          heading: 更新于
+          api_title: 更新于
+          api_description: 更新于
+      api:
+        actions: 团队行动
+        index: 列出球队
+        create: 添加新团队
+        show: 找回团队
+        update: 团队更新
+        fields:
+          id:
+            _: 团队 ID
+            label: 团队 ID
+            heading: 团队 ID
+            api_title: 团队 ID
+            api_description: 团队 ID
+          name:
+            _: 团队名称
+            label: 团队名称
+            heading: 团队
+            api_title: 团队名称
+            api_description: 团队名称
+          time_zone:
+            _: 主要时区
+            label: 主要时区
+            heading: 主要时区
+            api_title: 主要时区
+            api_description: 主要时区
+          locale:
+            _: 语言
+            label: 主要语言
+            heading: 语言
+            api_title: 语言
+            api_description: 语言
+          created_at:
+            _: 已注册
+            heading: 已注册
+            api_title: 已注册
+            api_description: 已注册
+          updated_at:
+            _: 更新于
+            heading: 更新于
+            api_title: 更新于
+            api_description: 更新于
+  activerecord:
+    attributes:
+      team:
+        name: 团队名称
+        time_zone: 主要时区
+        locale: 语言
+        created_at: 已注册
+        updated_at: 更新于

--- a/bullet_train/config/locales/zh-TW/devise.zh-TW.yml
+++ b/bullet_train/config/locales/zh-TW/devise.zh-TW.yml
@@ -1,0 +1,113 @@
+---
+zh-TW:
+  devise:
+    titles:
+      reset_password: 重設密碼
+      sign_in: 登入
+    headers:
+      resend_confirm: 重新發送確認說明
+      change_password: 更改密碼
+      reset_password: 重設密碼
+      edit_registration: 編輯 %{resource_name}
+      cancel_account: 取消我的帳戶
+      create_account: 建立您的帳戶
+      sign_in: 登入
+      resend_unlock: 重新發送解鎖說明
+    labels:
+      wait_confirm: 目前正在等待確認：%{unconfirmed_email}
+    hints:
+      leave_blank: "（如果不想更改就留空）"
+      length: 最少 %{password_length} 個字符
+      need_password: "（我們需要您目前的密碼來確認您的變更）"
+    buttons:
+      resend_confirm: 重新發送確認說明
+      change_password: 更改我的密碼
+      reset_password: 透過電子郵件重設密碼
+      cancel_account: 取消我的帳戶
+      resend_unlock: 重新發送解鎖說明
+    links:
+      account: 還沒有帳號？
+      have_account: 已有帳號？
+      forgot_password: 忘記密碼了嗎？
+      log_in: 登入
+      sign_up: 報名
+      new_confirm: 沒有收到確認說明？
+      new_unlock: 沒有收到解鎖說明？
+      sign_in_with: 使用 %{provider} 登入
+    confirmations:
+      confirmed: 您的電子郵件地址已成功確認。
+      send_instructions: 您將在幾分鐘內收到一封電子郵件，其中包含如何確認您的電子郵件地址的說明。
+      send_paranoid_instructions: 如果您的電子郵件地址存在於我們的資料庫中，您將在幾分鐘內收到一封電子郵件，其中包含如何確認您的電子郵件地址的說明。
+    failure:
+      already_authenticated: 您已經登入。
+      inactive: 您的帳戶尚未啟動。
+      invalid: "%{authentication_keys} 或密碼無效。"
+      locked: 您的帳戶已被鎖定。
+      last_attempt: 在您的帳戶被鎖定之前，您還有一次嘗試機會。
+      not_found_in_database: "%{authentication_keys} 或密碼無效。"
+      timeout: 您的會話已過期。請重新登入以繼續。
+      unauthenticated: 您需要登入或註冊才能繼續。
+      unconfirmed: 在繼續之前，您必須確認您的電子郵件地址。
+    mailer:
+      confirmation_instructions:
+        subject: 確認說明
+        welcome: 歡迎 %{email}！
+        description: 您可以透過以下連結確認您的帳戶電子郵件：
+        confirm_account: 確認我的帳戶
+      reset_password_instructions:
+        subject: 重設密碼說明
+        hello: 你好，%{email}！
+        requested_change: 有人請求提供更改密碼的連結。您可以透過下面的連結執行此操作。
+        ignore: 如果您沒有提出此要求，請忽略這封電子郵件。
+        access_change: 在您訪問上面的連結並建立新密碼之前，您的密碼不會更改。
+        change_password: 更改我的密碼
+      unlock_instructions:
+        subject: 解鎖說明
+        hello: 你好，%{email}！
+        account_blocked: 由於登入嘗試失敗次數過多，您的帳戶已被鎖定。
+        click_link: 點擊下面的連結解鎖您的帳戶：
+        unlock: 解鎖我的帳戶
+      password_change:
+        subject: 密碼已更改
+        hello: 你好，%{email}！
+        description: 我們與您聯絡是為了通知您密碼已更改。
+      email_changed:
+        subject: 電子郵件已更改
+        hello: 你好，%{email}！
+        description: 我們聯絡您是為了通知您，您的電子郵件已更改為 %{email}
+    omniauth_callbacks:
+      failure: 由於“%{reason}”，無法透過 %{kind} 對您進行身份驗證。
+      success: 已成功透過 %{kind} 帳戶進行身份驗證。
+    passwords:
+      no_token: 如果沒有密碼重設電子郵件，您將無法存取此頁面。如果您確實收到了密碼重設電子郵件，請確保您使用了提供的完整 URL。
+      send_instructions: 您將在幾分鐘內收到一封電子郵件，其中包含有關如何重設密碼的說明。
+      send_paranoid_instructions: 如果您的電子郵件地址存在於我們的資料庫中，您將在幾分鐘內透過您的電子郵件地址收到密碼恢復連結。
+      updated: 您的密碼已成功變更。您現在已登入。
+      updated_not_active: 您的密碼已成功變更。
+    registrations:
+      destroyed: 再見！您的帳戶已成功取消。我們希望很快能再次見到您。
+      signed_up: 歡迎！您已註冊成功。
+      signed_up_but_inactive: 您已註冊成功。但是，我們無法讓您登錄，因為您的帳戶尚未啟用。
+      signed_up_but_locked: 您已註冊成功。但是，我們無法讓您登錄，因為您的帳戶已被鎖定。
+      signed_up_but_unconfirmed: 帶有確認連結的訊息已發送到您的電子郵件地址。請點擊連結以啟動您的帳戶。
+      update_needs_confirmation: 您已成功更新帳戶，但我們需要驗證您的新電子郵件地址。請檢查您的電子郵件並點擊確認連結來確認您的新電子郵件地址。
+      updated: 您的帳戶已成功更新。
+    sessions:
+      signed_in: 登入成功。
+      signed_out: 已成功登出。
+      already_signed_out: 退出成功。
+    unlocks:
+      send_instructions: 您將在幾分鐘內收到一封電子郵件，其中包含如何解鎖帳戶的說明。
+      send_paranoid_instructions: 如果您的帳戶存在，您將在幾分鐘內收到一封電子郵件，其中包含如何解鎖該帳戶的說明。
+      unlocked: 您的帳戶已成功解鎖。請登入以繼續。
+  errors:
+    messages:
+      already_confirmed: 已確認，請嘗試登入
+      confirmation_period_expired: 需要在 %{period} 內確認，請申請新的
+      expired: 已過期，請申請新的
+      not_found: 未找到
+      not_locked: 沒有被鎖定
+      not_saved:
+        one: 1 個錯誤禁止儲存此 %{resource}：
+        other: "%{count} 錯誤禁止儲存此 %{resource}："
+      pwned_password: 之前曾出現過資料外洩事件，切勿使用

--- a/bullet_train/config/locales/zh-TW/memberships.zh-TW.yml
+++ b/bullet_train/config/locales/zh-TW/memberships.zh-TW.yml
@@ -1,0 +1,1044 @@
+---
+zh-TW:
+  memberships:
+    label: 團隊成員
+    singular: 隊員
+    navigation:
+      label: 團隊成員
+      icon: fa-light fa-users
+    breadcrumbs:
+      label: 團隊成員
+    buttons:
+      edit: 設定
+      show: 細節
+      resend: 重新發送
+      update: 更新會員資格
+      demote: 從管理員降級
+      promote: 晉升為管理員
+      destroy: 從團隊中移除
+      destroy_own: 離開這個團隊
+      reinvite: 重新邀請加入團隊
+      confirmations:
+        destroy: 您確定要從 %{team_name} 中刪除 %{membership_name} 嗎？
+        destroy_own: 您確定要將自己從 %{team_name} 中刪除嗎？您將無法撤銷此操作。
+        reinvite: 您確定要重新邀請 %{membership_name} 加入 %{team_name} 嗎？
+    fields:
+      id:
+        _: 會員ID
+        label: 會員ID
+        heading: 會員ID
+        api_title: 會員ID
+        api_description: 會員ID
+      user_id:
+        name: 使用者身分
+        heading: 使用者身分
+        api_title: 使用者身分
+        api_description: 使用者身分
+      team_id:
+        name: 團隊 ID
+        heading: 團隊 ID
+        api_title: 團隊 ID
+        api_description: 團隊 ID
+      invitation_id:
+        name: 邀請碼
+        heading: 邀請碼
+        api_title: 邀請碼
+        api_description: 邀請碼
+      name:
+        name: 姓名
+        heading: 姓名
+        api_title: 姓名
+        api_description: 姓名
+      user_first_name:
+        name: 名
+        label: 名
+        heading: 名
+        api_title: 名
+        api_description: 名
+      user_last_name:
+        name: 姓
+        label: 姓
+        heading: 姓
+        api_title: 姓
+        api_description: 姓
+      user_profile_photo_id:
+        name: 個人資料照片
+        label: 個人資料照片
+        heading: 個人資料照片
+        api_title: 個人資料照片
+        api_description: 個人資料照片
+      user_profile_photo:
+        name: 個人資料照片
+        label: 個人資料照片
+        heading: 個人資料照片
+        api_title: 個人資料照片
+        api_description: 個人資料照片
+      user_email:
+        name: 使用者信箱
+        heading: 使用者信箱
+        api_title: 使用者信箱
+        api_description: 使用者信箱
+      added_by_id:
+        name: 用戶 ID 新增
+        heading: 用戶 ID 新增
+        api_title: 用戶 ID 新增
+        api_description: 用戶 ID 新增
+      platform_agent_of_id:
+        name: 平台代理 ID
+        heading: 平台代理 ID
+        api_title: 平台代理 ID
+        api_description: 平台代理 ID
+      platform_agent:
+        name: 平台代理
+        heading: 平台代理
+        api_title: 平台代理
+        api_description: 平台代理
+      role_ids:
+        name: 角色
+        label: 角色
+        heading: 角色
+        api_title: 角色
+        api_description: 角色
+        options:
+          default:
+            label: 觀眾
+            description: 只能查看團隊數據
+          admin:
+            label: 團隊管理員
+            description: 團隊管理員可以管理帳單並管理其他使用者的特殊權限。
+          editor:
+            label: 編輯
+            description: 可以編輯此團隊中的所有資源，並允許其他人執行相同的操作。
+        none: 觀眾
+      created_at:
+        _: 創建於
+        heading: 創建於
+        api_title: 創建於
+        api_description: 創建於
+      updated_at:
+        _: 更新於
+        heading: 更新於
+        api_title: 更新於
+        api_description: 更新於
+    index:
+      section: "%{team_name} 團隊成員"
+      contexts:
+        team:
+          header: 團隊成員
+          description: 以下人員是您的團隊成員。您也可以邀請新的團隊成員。
+          fields:
+            id:
+              _: 會員ID
+              label: 會員ID
+              heading: 會員ID
+              api_title: 會員ID
+              api_description: 會員ID
+            user_id:
+              name: 使用者身分
+              heading: 使用者身分
+              api_title: 使用者身分
+              api_description: 使用者身分
+            team_id:
+              name: 團隊 ID
+              heading: 團隊 ID
+              api_title: 團隊 ID
+              api_description: 團隊 ID
+            invitation_id:
+              name: 邀請碼
+              heading: 邀請碼
+              api_title: 邀請碼
+              api_description: 邀請碼
+            name:
+              name: 姓名
+              heading: 姓名
+              api_title: 姓名
+              api_description: 姓名
+            user_first_name:
+              name: 名
+              label: 名
+              heading: 名
+              api_title: 名
+              api_description: 名
+            user_last_name:
+              name: 姓
+              label: 姓
+              heading: 姓
+              api_title: 姓
+              api_description: 姓
+            user_profile_photo_id:
+              name: 個人資料照片
+              label: 個人資料照片
+              heading: 個人資料照片
+              api_title: 個人資料照片
+              api_description: 個人資料照片
+            user_profile_photo:
+              name: 個人資料照片
+              label: 個人資料照片
+              heading: 個人資料照片
+              api_title: 個人資料照片
+              api_description: 個人資料照片
+            user_email:
+              name: 使用者信箱
+              heading: 使用者信箱
+              api_title: 使用者信箱
+              api_description: 使用者信箱
+            added_by_id:
+              name: 用戶 ID 新增
+              heading: 用戶 ID 新增
+              api_title: 用戶 ID 新增
+              api_description: 用戶 ID 新增
+            platform_agent_of_id:
+              name: 平台代理 ID
+              heading: 平台代理 ID
+              api_title: 平台代理 ID
+              api_description: 平台代理 ID
+            platform_agent:
+              name: 平台代理
+              heading: 平台代理
+              api_title: 平台代理
+              api_description: 平台代理
+            role_ids:
+              name: 角色
+              label: 角色
+              heading: 角色
+              api_title: 角色
+              api_description: 角色
+              options:
+                default:
+                  label: 觀眾
+                  description: 只能查看團隊數據
+                admin:
+                  label: 團隊管理員
+                  description: 團隊管理員可以管理帳單並管理其他使用者的特殊權限。
+                editor:
+                  label: 編輯
+                  description: 可以編輯此團隊中的所有資源，並允許其他人執行相同的操作。
+              none: 觀眾
+            created_at:
+              _: 創建於
+              heading: 創建於
+              api_title: 創建於
+              api_description: 創建於
+            updated_at:
+              _: 更新於
+              heading: 更新於
+              api_title: 更新於
+              api_description: 更新於
+      buttons:
+        edit: 設定
+        show: 細節
+        resend: 重新發送
+        update: 更新會員資格
+        demote: 從管理員降級
+        promote: 晉升為管理員
+        destroy: 從團隊中移除
+        destroy_own: 離開這個團隊
+        reinvite: 邀請加入團隊
+        confirmations:
+          destroy: 您確定要從 %{team_name} 移除 %{membership_name} 嗎？
+          destroy_own: 你確定要從 %{team_name} 移除自己嗎？此操作無法撤銷。
+          reinvite: 你確定要邀請 %{membership_name} 到 %{team_name} 嗎？
+    tombstones:
+      contexts:
+        team:
+          header: 等待邀請的成員
+          description: 以下人員已從 %{team_name} 中移除，但您仍然可以管理他們的個人資料並將他們的任務重新分配給其他團隊成員。
+      buttons:
+        edit: 設定
+        show: 細節
+        resend: 重新發送
+        update: 更新會員資格
+        demote: 從管理員降級
+        promote: 晉升為管理員
+        destroy: 從團隊中移除
+        destroy_own: 離開這個團隊
+        reinvite: 邀請加入團隊
+        confirmations:
+          destroy: 您確定要從 %{team_name} 移除 %{membership_name} 嗎？
+          destroy_own: 你確定要從 %{team_name} 移除自己嗎？此操作無法撤銷。
+          reinvite: 你確定要邀請 %{membership_name} 到 %{team_name} 嗎？
+    form:
+      grant_privileges_of: 授予 %{role_key} 的權限
+      buttons:
+        edit: 設定
+        show: 細節
+        resend: 重新發送
+        update: 更新會員資格
+        demote: 從管理員降級
+        promote: 晉升為管理員
+        destroy: 從團隊中移除
+        destroy_own: 離開這個團隊
+        reinvite: 邀請加入團隊
+        confirmations:
+          destroy: 您確定要從 %{team_name} 移除 %{membership_name} 嗎？
+          destroy_own: 你確定要從 %{team_name} 移除自己嗎？此操作無法撤銷。
+          reinvite: 你確定要邀請 %{membership_name} 到 %{team_name} 嗎？
+      fields:
+        id:
+          _: 會員ID
+          label: 會員ID
+          heading: 會員ID
+          api_title: 會員ID
+          api_description: 會員ID
+        user_id:
+          name: 使用者身分
+          heading: 使用者身分
+          api_title: 使用者身分
+          api_description: 使用者身分
+        team_id:
+          name: 團隊 ID
+          heading: 團隊 ID
+          api_title: 團隊 ID
+          api_description: 團隊 ID
+        invitation_id:
+          name: 邀請碼
+          heading: 邀請碼
+          api_title: 邀請碼
+          api_description: 邀請碼
+        name:
+          name: 姓名
+          heading: 姓名
+          api_title: 姓名
+          api_description: 姓名
+        user_first_name:
+          name: 名
+          label: 名
+          heading: 名
+          api_title: 名
+          api_description: 名
+        user_last_name:
+          name: 姓
+          label: 姓
+          heading: 姓
+          api_title: 姓
+          api_description: 姓
+        user_profile_photo_id:
+          name: 個人資料照片
+          label: 個人資料照片
+          heading: 個人資料照片
+          api_title: 個人資料照片
+          api_description: 個人資料照片
+        user_profile_photo:
+          name: 個人資料照片
+          label: 個人資料照片
+          heading: 個人資料照片
+          api_title: 個人資料照片
+          api_description: 個人資料照片
+        user_email:
+          name: 使用者信箱
+          heading: 使用者信箱
+          api_title: 使用者信箱
+          api_description: 使用者信箱
+        added_by_id:
+          name: 用戶 ID 新增
+          heading: 用戶 ID 新增
+          api_title: 用戶 ID 新增
+          api_description: 用戶 ID 新增
+        platform_agent_of_id:
+          name: 平台代理 ID
+          heading: 平台代理 ID
+          api_title: 平台代理 ID
+          api_description: 平台代理 ID
+        platform_agent:
+          name: 平台代理
+          heading: 平台代理
+          api_title: 平台代理
+          api_description: 平台代理
+        role_ids:
+          name: 角色
+          label: 角色
+          heading: 角色
+          api_title: 角色
+          api_description: 角色
+          options:
+            default:
+              label: 觀眾
+              description: 只能查看團隊數據
+            admin:
+              label: 團隊管理員
+              description: 團隊管理員可以管理帳單並管理其他使用者的特殊權限。
+            editor:
+              label: 編輯
+              description: 可以編輯此團隊中的所有資源，並允許其他人執行相同的操作。
+          none: 觀眾
+        created_at:
+          _: 創建於
+          heading: 創建於
+          api_title: 創建於
+          api_description: 創建於
+        updated_at:
+          _: 更新於
+          heading: 更新於
+          api_title: 更新於
+          api_description: 更新於
+    edit:
+      section: "%{membership_name} 在 %{team_name} 上"
+      header: 更新會員設定
+      description: 您可以在下方編輯 %{team_name} 上 %{memberships_possessive} 會員資格的設定。
+      grant_privileges_of: 授予 %{role_key} 的權限
+      remove_header: 移除團隊成員
+      remove_description: 移除 %{membership_name} 不會移除任何資源分配。相反，您可以選擇將資源重新分配給其他團隊成員。將來您也可以重新邀請 %{membership_name} 加入團隊。
+      buttons:
+        edit: 設定
+        show: 細節
+        resend: 重新發送
+        update: 更新會員資格
+        demote: 從管理員降級
+        promote: 晉升為管理員
+        destroy: 從團隊中移除
+        destroy_own: 離開這個團隊
+        reinvite: 邀請加入團隊
+        confirmations:
+          destroy: 您確定要從 %{team_name} 移除 %{membership_name} 嗎？
+          destroy_own: 你確定要從 %{team_name} 移除自己嗎？此操作無法撤銷。
+          reinvite: 你確定要邀請 %{membership_name} 到 %{team_name} 嗎？
+    show:
+      section: "%{memberships_possessive} %{team_name} 會員資格"
+      header: 會員詳情
+      invitation_header: 邀請函詳情
+      tombstone_header: 前團隊成員
+      description: 以下是 %{team_name} 上 %{memberships_possessive} 會員資格的詳細資訊。
+      buttons:
+        edit: 設定
+        show: 細節
+        resend: 重新發送
+        update: 更新會員資格
+        demote: 從管理員降級
+        promote: 晉升為管理員
+        destroy: 從團隊中移除
+        destroy_own: 離開這個團隊
+        reinvite: 邀請加入團隊
+        confirmations:
+          destroy: 您確定要從 %{team_name} 移除 %{membership_name} 嗎？
+          destroy_own: 你確定要從 %{team_name} 移除自己嗎？此操作無法撤銷。
+          reinvite: 你確定要邀請 %{membership_name} 到 %{team_name} 嗎？
+      fields:
+        id:
+          _: 會員ID
+          label: 會員ID
+          heading: 會員ID
+          api_title: 會員ID
+          api_description: 會員ID
+        user_id:
+          name: 使用者身分
+          heading: 使用者身分
+          api_title: 使用者身分
+          api_description: 使用者身分
+        team_id:
+          name: 團隊 ID
+          heading: 團隊 ID
+          api_title: 團隊 ID
+          api_description: 團隊 ID
+        invitation_id:
+          name: 邀請碼
+          heading: 邀請碼
+          api_title: 邀請碼
+          api_description: 邀請碼
+        name:
+          name: 姓名
+          heading: 姓名
+          api_title: 姓名
+          api_description: 姓名
+        user_first_name:
+          name: 名
+          label: 名
+          heading: 名
+          api_title: 名
+          api_description: 名
+        user_last_name:
+          name: 姓
+          label: 姓
+          heading: 姓
+          api_title: 姓
+          api_description: 姓
+        user_profile_photo_id:
+          name: 個人資料照片
+          label: 個人資料照片
+          heading: 個人資料照片
+          api_title: 個人資料照片
+          api_description: 個人資料照片
+        user_profile_photo:
+          name: 個人資料照片
+          label: 個人資料照片
+          heading: 個人資料照片
+          api_title: 個人資料照片
+          api_description: 個人資料照片
+        user_email:
+          name: 使用者信箱
+          heading: 使用者信箱
+          api_title: 使用者信箱
+          api_description: 使用者信箱
+        added_by_id:
+          name: 用戶 ID 新增
+          heading: 用戶 ID 新增
+          api_title: 用戶 ID 新增
+          api_description: 用戶 ID 新增
+        platform_agent_of_id:
+          name: 平台代理 ID
+          heading: 平台代理 ID
+          api_title: 平台代理 ID
+          api_description: 平台代理 ID
+        platform_agent:
+          name: 平台代理
+          heading: 平台代理
+          api_title: 平台代理
+          api_description: 平台代理
+        role_ids:
+          name: 角色
+          label: 角色
+          heading: 角色
+          api_title: 角色
+          api_description: 角色
+          options:
+            default:
+              label: 觀眾
+              description: 只能查看團隊數據
+            admin:
+              label: 團隊管理員
+              description: 團隊管理員可以管理帳單並管理其他使用者的特殊權限。
+            editor:
+              label: 編輯
+              description: 可以編輯此團隊中的所有資源，並允許其他人執行相同的操作。
+          none: 觀眾
+        created_at:
+          _: 創建於
+          heading: 創建於
+          api_title: 創建於
+          api_description: 創建於
+        updated_at:
+          _: 更新於
+          heading: 更新於
+          api_title: 更新於
+          api_description: 更新於
+    notifications:
+      updated: 會員資料已成功更新。
+      destroyed: 該用戶已成功從團隊中移除。
+      no_members: 你的團隊目前還沒有其他成員！立即發送邀請，開始組建團隊吧！
+      cant_demote: 抱歉，您無法降級團隊中最後一位管理員。請先將其他人設為管理員。
+      cant_remove: 抱歉，您無法移除團隊中的最後一位管理員。請先將其他人加入為管理員。
+      you_removed_yourself: 您已成功從 %{team_name} 移除自己。
+      reinvited: 用戶已成功受邀。他們將收到一封加入團隊的電子郵件。
+  account:
+    memberships:
+      label: 團隊成員
+      singular: 隊員
+      navigation:
+        label: 團隊成員
+        icon: fa-light fa-users
+      breadcrumbs:
+        label: 團隊成員
+      buttons:
+        edit: 設定
+        show: 細節
+        resend: 重新發送
+        update: 更新會員資格
+        demote: 從管理員降級
+        promote: 晉升為管理員
+        destroy: 從團隊中刪除
+        destroy_own: 離開這個團隊
+        reinvite: 重新邀請加入團隊
+        confirmations:
+          destroy: 您確定要從 %{team_name} 中刪除 %{membership_name} 嗎？
+          destroy_own: 您確定要將自己從 %{team_name} 中刪除嗎？您將無法撤銷此操作。
+          reinvite: 您確定要重新邀請 %{membership_name} 加入 %{team_name} 嗎？
+      fields:
+        id:
+          _: 會員ID
+          label: 會員ID
+          heading: 會員ID
+          api_title: 會員ID
+          api_description: 會員ID
+        user_id:
+          name: 使用者身分
+          heading: 使用者身分
+          api_title: 使用者身分
+          api_description: 使用者身分
+        team_id:
+          name: 團隊 ID
+          heading: 團隊 ID
+          api_title: 團隊 ID
+          api_description: 團隊 ID
+        invitation_id:
+          name: 邀請碼
+          heading: 邀請碼
+          api_title: 邀請碼
+          api_description: 邀請碼
+        name:
+          name: 姓名
+          heading: 姓名
+          api_title: 姓名
+          api_description: 姓名
+        user_first_name:
+          name: 名
+          label: 名
+          heading: 名
+          api_title: 名
+          api_description: 名
+        user_last_name:
+          name: 姓
+          label: 姓
+          heading: 姓
+          api_title: 姓
+          api_description: 姓
+        user_profile_photo_id:
+          name: 個人資料照片
+          label: 個人資料照片
+          heading: 個人資料照片
+          api_title: 個人資料照片
+          api_description: 個人資料照片
+        user_profile_photo:
+          name: 個人資料照片
+          label: 個人資料照片
+          heading: 個人資料照片
+          api_title: 個人資料照片
+          api_description: 個人資料照片
+        user_email:
+          name: 使用者信箱
+          heading: 使用者信箱
+          api_title: 使用者信箱
+          api_description: 使用者信箱
+        added_by_id:
+          name: 用戶 ID 新增
+          heading: 用戶 ID 新增
+          api_title: 用戶 ID 新增
+          api_description: 用戶 ID 新增
+        platform_agent_of_id:
+          name: 平台代理 ID
+          heading: 平台代理 ID
+          api_title: 平台代理 ID
+          api_description: 平台代理 ID
+        platform_agent:
+          name: 平台代理
+          heading: 平台代理
+          api_title: 平台代理
+          api_description: 平台代理
+        role_ids:
+          name: 角色
+          label: 角色
+          heading: 角色
+          api_title: 角色
+          api_description: 角色
+          options:
+            default:
+              label: 觀眾
+              description: 只能查看團隊數據
+            admin:
+              label: 團隊管理員
+              description: 團隊管理員可以管理帳單並管理其他使用者的特殊權限。
+            editor:
+              label: 編輯
+              description: 可以編輯此團隊中的所有資源，並允許其他人執行相同的操作。
+          none: 觀眾
+        created_at:
+          _: 創建於
+          heading: 創建於
+          api_title: 創建於
+          api_description: 創建於
+        updated_at:
+          _: 更新於
+          heading: 更新於
+          api_title: 更新於
+          api_description: 更新於
+      index:
+        section: "%{team_name} 團隊成員"
+        contexts:
+          team:
+            header: 團隊成員
+            description: 以下人員是您的團隊成員。您也可以邀請新的團隊成員。
+            fields:
+              id:
+                _: 會員ID
+                label: 會員ID
+                heading: 會員ID
+                api_title: 會員ID
+                api_description: 會員ID
+              user_id:
+                name: 使用者身分
+                heading: 使用者身分
+                api_title: 使用者身分
+                api_description: 使用者身分
+              team_id:
+                name: 團隊 ID
+                heading: 團隊 ID
+                api_title: 團隊 ID
+                api_description: 團隊 ID
+              invitation_id:
+                name: 邀請碼
+                heading: 邀請碼
+                api_title: 邀請碼
+                api_description: 邀請碼
+              name:
+                name: 姓名
+                heading: 姓名
+                api_title: 姓名
+                api_description: 姓名
+              user_first_name:
+                name: 名
+                label: 名
+                heading: 名
+                api_title: 名
+                api_description: 名
+              user_last_name:
+                name: 姓
+                label: 姓
+                heading: 姓
+                api_title: 姓
+                api_description: 姓
+              user_profile_photo_id:
+                name: 個人資料照片
+                label: 個人資料照片
+                heading: 個人資料照片
+                api_title: 個人資料照片
+                api_description: 個人資料照片
+              user_profile_photo:
+                name: 個人資料照片
+                label: 個人資料照片
+                heading: 個人資料照片
+                api_title: 個人資料照片
+                api_description: 個人資料照片
+              user_email:
+                name: 使用者信箱
+                heading: 使用者信箱
+                api_title: 使用者信箱
+                api_description: 使用者信箱
+              added_by_id:
+                name: 用戶 ID 新增
+                heading: 用戶 ID 新增
+                api_title: 用戶 ID 新增
+                api_description: 用戶 ID 新增
+              platform_agent_of_id:
+                name: 平台代理 ID
+                heading: 平台代理 ID
+                api_title: 平台代理 ID
+                api_description: 平台代理 ID
+              platform_agent:
+                name: 平台代理
+                heading: 平台代理
+                api_title: 平台代理
+                api_description: 平台代理
+              role_ids:
+                name: 角色
+                label: 角色
+                heading: 角色
+                api_title: 角色
+                api_description: 角色
+                options:
+                  default:
+                    label: 觀眾
+                    description: 只能查看團隊數據
+                  admin:
+                    label: 團隊管理員
+                    description: 團隊管理員可以管理帳單並管理其他使用者的特殊權限。
+                  editor:
+                    label: 編輯
+                    description: 可以編輯此團隊中的所有資源，並允許其他人執行相同的操作。
+                none: 觀眾
+              created_at:
+                _: 創建於
+                heading: 創建於
+                api_title: 創建於
+                api_description: 創建於
+              updated_at:
+                _: 更新於
+                heading: 更新於
+                api_title: 更新於
+                api_description: 更新於
+        buttons:
+          edit: 設定
+          show: 細節
+          resend: 重新發送
+          update: 更新會員資格
+          demote: 從管理員降級
+          promote: 晉升為管理員
+          destroy: 從團隊中移除
+          destroy_own: 離開這個團隊
+          reinvite: 邀請加入團隊
+          confirmations:
+            destroy: 您確定要從 %{team_name} 移除 %{membership_name} 嗎？
+            destroy_own: 你確定要從 %{team_name} 移除自己嗎？此操作無法撤銷。
+            reinvite: 你確定要邀請 %{membership_name} 到 %{team_name} 嗎？
+      tombstones:
+        contexts:
+          team:
+            header: 等待邀請的成員
+            description: 以下人員已從 %{team_name} 中移除，但您仍然可以管理他們的個人資料並將他們的任務重新分配給其他團隊成員。
+        buttons:
+          edit: 設定
+          show: 細節
+          resend: 重新發送
+          update: 更新會員資格
+          demote: 從管理員降級
+          promote: 晉升為管理員
+          destroy: 從團隊中移除
+          destroy_own: 離開這個團隊
+          reinvite: 邀請加入團隊
+          confirmations:
+            destroy: 您確定要從 %{team_name} 移除 %{membership_name} 嗎？
+            destroy_own: 你確定要從 %{team_name} 移除自己嗎？此操作無法撤銷。
+            reinvite: 你確定要邀請 %{membership_name} 到 %{team_name} 嗎？
+      form:
+        grant_privileges_of: 授予 %{role_key} 的權限
+        buttons:
+          edit: 設定
+          show: 細節
+          resend: 重新發送
+          update: 更新會員資格
+          demote: 從管理員降級
+          promote: 晉升為管理員
+          destroy: 從團隊中移除
+          destroy_own: 離開這個團隊
+          reinvite: 邀請加入團隊
+          confirmations:
+            destroy: 您確定要從 %{team_name} 移除 %{membership_name} 嗎？
+            destroy_own: 你確定要從 %{team_name} 移除自己嗎？此操作無法撤銷。
+            reinvite: 你確定要邀請 %{membership_name} 到 %{team_name} 嗎？
+        fields:
+          id:
+            _: 會員ID
+            label: 會員ID
+            heading: 會員ID
+            api_title: 會員ID
+            api_description: 會員ID
+          user_id:
+            name: 使用者身分
+            heading: 使用者身分
+            api_title: 使用者身分
+            api_description: 使用者身分
+          team_id:
+            name: 團隊 ID
+            heading: 團隊 ID
+            api_title: 團隊 ID
+            api_description: 團隊 ID
+          invitation_id:
+            name: 邀請碼
+            heading: 邀請碼
+            api_title: 邀請碼
+            api_description: 邀請碼
+          name:
+            name: 姓名
+            heading: 姓名
+            api_title: 姓名
+            api_description: 姓名
+          user_first_name:
+            name: 名
+            label: 名
+            heading: 名
+            api_title: 名
+            api_description: 名
+          user_last_name:
+            name: 姓
+            label: 姓
+            heading: 姓
+            api_title: 姓
+            api_description: 姓
+          user_profile_photo_id:
+            name: 個人資料照片
+            label: 個人資料照片
+            heading: 個人資料照片
+            api_title: 個人資料照片
+            api_description: 個人資料照片
+          user_profile_photo:
+            name: 個人資料照片
+            label: 個人資料照片
+            heading: 個人資料照片
+            api_title: 個人資料照片
+            api_description: 個人資料照片
+          user_email:
+            name: 使用者信箱
+            heading: 使用者信箱
+            api_title: 使用者信箱
+            api_description: 使用者信箱
+          added_by_id:
+            name: 用戶 ID 新增
+            heading: 用戶 ID 新增
+            api_title: 用戶 ID 新增
+            api_description: 用戶 ID 新增
+          platform_agent_of_id:
+            name: 平台代理 ID
+            heading: 平台代理 ID
+            api_title: 平台代理 ID
+            api_description: 平台代理 ID
+          platform_agent:
+            name: 平台代理
+            heading: 平台代理
+            api_title: 平台代理
+            api_description: 平台代理
+          role_ids:
+            name: 角色
+            label: 角色
+            heading: 角色
+            api_title: 角色
+            api_description: 角色
+            options:
+              default:
+                label: 觀眾
+                description: 只能查看團隊數據
+              admin:
+                label: 團隊管理員
+                description: 團隊管理員可以管理帳單並管理其他使用者的特殊權限。
+              editor:
+                label: 編輯
+                description: 可以編輯此團隊中的所有資源，並允許其他人執行相同的操作。
+            none: 觀眾
+          created_at:
+            _: 創建於
+            heading: 創建於
+            api_title: 創建於
+            api_description: 創建於
+          updated_at:
+            _: 更新於
+            heading: 更新於
+            api_title: 更新於
+            api_description: 更新於
+      edit:
+        section: "%{membership_name} 在 %{team_name} 上"
+        header: 更新會員設定
+        description: 您可以在下方編輯 %{team_name} 上 %{memberships_possessive} 會員資格的設定。
+        grant_privileges_of: 授予 %{role_key} 的權限
+        remove_header: 移除團隊成員
+        remove_description: 移除 %{membership_name} 不會移除任何資源分配。相反，您可以選擇將資源重新分配給其他團隊成員。將來您也可以重新邀請 %{membership_name} 加入團隊。
+        buttons:
+          edit: 設定
+          show: 細節
+          resend: 重新發送
+          update: 更新會員資格
+          demote: 從管理員降級
+          promote: 晉升為管理員
+          destroy: 從團隊中移除
+          destroy_own: 離開這個團隊
+          reinvite: 邀請加入團隊
+          confirmations:
+            destroy: 您確定要從 %{team_name} 移除 %{membership_name} 嗎？
+            destroy_own: 你確定要從 %{team_name} 移除自己嗎？此操作無法撤銷。
+            reinvite: 你確定要邀請 %{membership_name} 到 %{team_name} 嗎？
+      show:
+        section: "%{memberships_possessive} %{team_name} 會員資格"
+        header: 會員詳情
+        invitation_header: 邀請函詳情
+        tombstone_header: 前團隊成員
+        description: 以下是 %{team_name} 上 %{memberships_possessive} 會員資格的詳細資訊。
+        buttons:
+          edit: 設定
+          show: 細節
+          resend: 重新發送
+          update: 更新會員資格
+          demote: 從管理員降級
+          promote: 晉升為管理員
+          destroy: 從團隊中移除
+          destroy_own: 離開這個團隊
+          reinvite: 邀請加入團隊
+          confirmations:
+            destroy: 您確定要從 %{team_name} 移除 %{membership_name} 嗎？
+            destroy_own: 你確定要從 %{team_name} 移除自己嗎？此操作無法撤銷。
+            reinvite: 你確定要邀請 %{membership_name} 到 %{team_name} 嗎？
+        fields:
+          id:
+            _: 會員ID
+            label: 會員ID
+            heading: 會員ID
+            api_title: 會員ID
+            api_description: 會員ID
+          user_id:
+            name: 使用者身分
+            heading: 使用者身分
+            api_title: 使用者身分
+            api_description: 使用者身分
+          team_id:
+            name: 團隊 ID
+            heading: 團隊 ID
+            api_title: 團隊 ID
+            api_description: 團隊 ID
+          invitation_id:
+            name: 邀請碼
+            heading: 邀請碼
+            api_title: 邀請碼
+            api_description: 邀請碼
+          name:
+            name: 姓名
+            heading: 姓名
+            api_title: 姓名
+            api_description: 姓名
+          user_first_name:
+            name: 名
+            label: 名
+            heading: 名
+            api_title: 名
+            api_description: 名
+          user_last_name:
+            name: 姓
+            label: 姓
+            heading: 姓
+            api_title: 姓
+            api_description: 姓
+          user_profile_photo_id:
+            name: 個人資料照片
+            label: 個人資料照片
+            heading: 個人資料照片
+            api_title: 個人資料照片
+            api_description: 個人資料照片
+          user_profile_photo:
+            name: 個人資料照片
+            label: 個人資料照片
+            heading: 個人資料照片
+            api_title: 個人資料照片
+            api_description: 個人資料照片
+          user_email:
+            name: 使用者信箱
+            heading: 使用者信箱
+            api_title: 使用者信箱
+            api_description: 使用者信箱
+          added_by_id:
+            name: 用戶 ID 新增
+            heading: 用戶 ID 新增
+            api_title: 用戶 ID 新增
+            api_description: 用戶 ID 新增
+          platform_agent_of_id:
+            name: 平台代理 ID
+            heading: 平台代理 ID
+            api_title: 平台代理 ID
+            api_description: 平台代理 ID
+          platform_agent:
+            name: 平台代理
+            heading: 平台代理
+            api_title: 平台代理
+            api_description: 平台代理
+          role_ids:
+            name: 角色
+            label: 角色
+            heading: 角色
+            api_title: 角色
+            api_description: 角色
+            options:
+              default:
+                label: 觀眾
+                description: 只能查看團隊數據
+              admin:
+                label: 團隊管理員
+                description: 團隊管理員可以管理帳單並管理其他使用者的特殊權限。
+              editor:
+                label: 編輯
+                description: 可以編輯此團隊中的所有資源，並允許其他人執行相同的操作。
+            none: 觀眾
+          created_at:
+            _: 創建於
+            heading: 創建於
+            api_title: 創建於
+            api_description: 創建於
+          updated_at:
+            _: 更新於
+            heading: 更新於
+            api_title: 更新於
+            api_description: 更新於
+      notifications:
+        updated: 會員資料已成功更新。
+        destroyed: 該用戶已成功從團隊中移除。
+        no_members: 你的團隊目前還沒有其他成員！立即發送邀請，開始組建團隊吧！
+        cant_demote: 抱歉，您無法降級團隊中最後一位管理員。請先將其他人設為管理員。
+        cant_remove: 抱歉，您無法移除團隊中的最後一位管理員。請先將其他人加入為管理員。
+        you_removed_yourself: 您已成功從 %{team_name} 移除自己。
+        reinvited: 用戶已成功受邀。他們將收到一封加入團隊的電子郵件。
+  activerecord:
+    attributes:
+      memberships:
+        user_first_name: 名
+        user_last_name: 姓

--- a/bullet_train/config/locales/zh-TW/onboarding/user_details.zh-TW.yml
+++ b/bullet_train/config/locales/zh-TW/onboarding/user_details.zh-TW.yml
@@ -1,0 +1,19 @@
+---
+zh-TW:
+  onboarding:
+    user_details:
+      buttons:
+        next: 下一個
+      edit:
+        header: 請告訴我們您的情況。
+        buttons:
+          next: 下一個
+  account:
+    onboarding:
+      user_details:
+        buttons:
+          next: 下一個
+        edit:
+          header: 告訴我們關於你的事
+          buttons:
+            next: 下一個

--- a/bullet_train/config/locales/zh-TW/teams.zh-TW.yml
+++ b/bullet_train/config/locales/zh-TW/teams.zh-TW.yml
@@ -1,0 +1,371 @@
+---
+zh-TW:
+  teams:
+    label: 團隊
+    singular: 團隊
+    breadcrumbs:
+      label: 團隊
+      team_settings: 團隊設定
+      dashboard: 儀表板
+    navigation:
+      label: 團隊
+    buttons:
+      new: 新增團隊
+      create: 創建團隊
+      edit: 編輯團隊
+      update: 更新團隊
+      destroy: 刪除團隊
+      confirmations:
+        destroy: 您確定要刪除該團隊嗎？
+    index:
+      section: 團隊
+      header: 您的團隊
+      create: 創建新團隊
+      buttons:
+        new: 新增團隊
+        create: 創建團隊
+        edit: 編輯團隊
+        update: 更新團隊
+        destroy: 刪除團隊
+        confirmations:
+          destroy: 您確定要刪除該團隊嗎？
+    show:
+      header: "%{teams_possessive} 合規性儀錶板"
+    new:
+      header: 創建新團隊
+      former_user_header: 加入團隊
+      default_team_name: 你的團隊
+      buttons:
+        new: 新增團隊
+        create: 創建團隊
+        edit: 編輯團隊
+        update: 更新團隊
+        destroy: 刪除團隊
+        confirmations:
+          destroy: 您確定要刪除該團隊嗎？
+      you_can: 您可以：
+      invitation_header: 接受邀請
+      logout_header: 登出該帳戶
+      new_team_header: 創建一個新團隊
+      alert: 帳號<b>%{user_email}</b>目前不是任何團隊的成員。
+      invitation: 如果您收到邀請您加入新團隊的電子郵件，請點擊該電子郵件中的連結以接受邀請。
+      log_out: 您可以登出此帳戶並使用屬於團隊成員的其他帳戶登入。
+      new_team: 您可以使用下面的表格來建立自己的新團隊。
+    edit:
+      section: "%{team_name}"
+      header: 編輯團隊詳情
+      description: 您可以在下面更新該團隊的詳細資訊和設定。
+    notifications:
+      created: 團隊已成功建立。
+      updated: 團隊更新已成功。
+      destroyed: 隊伍已被成功摧毀。
+      invitation_only: 目前，創建新團隊僅限於受邀搶先體驗的用戶。如果您收到了搶先造訪網址，請先造訪該網址，然後再重試。
+      cannot_delete_last_team: 您無法刪除您所屬的最後一個團隊。
+    form:
+      buttons:
+        new: 新增團隊
+        create: 創建團隊
+        edit: 編輯團隊
+        update: 更新團隊
+        destroy: 刪除團隊
+        confirmations:
+          destroy: 您確定要刪除該團隊嗎？
+    fields:
+      id:
+        _: 團隊ID
+        label: 團隊ID
+        heading: 團隊ID
+        api_title: 團隊ID
+        api_description: 團隊ID
+      name:
+        _: 團隊名稱
+        label: 團隊名稱
+        heading: 團隊名稱
+        api_title: 團隊名稱
+        api_description: 團隊名稱
+      time_zone:
+        _: 主要時區
+        label: 主要時區
+        heading: 主要時區
+        api_title: 主要時區
+        api_description: 主要時區
+      locale:
+        _: 主要語言
+        label: 主要語言
+        heading: 主要語言
+        api_title: 主要語言
+        api_description: 主要語言
+      created_at:
+        _: 註冊於
+        heading: 註冊於
+        api_title: 註冊於
+        api_description: 註冊於
+      updated_at:
+        _: 更新於
+        heading: 更新於
+        api_title: 更新於
+        api_description: 更新於
+    _:
+      name:
+        label: 你的團隊名稱
+    self:
+      id:
+        _: 團隊ID
+        label: 團隊ID
+        heading: 團隊ID
+        api_title: 團隊ID
+        api_description: 團隊ID
+      name:
+        label: 你的團隊名稱
+      time_zone:
+        _: 主要時區
+        label: 主要時區
+        heading: 主要時區
+        api_title: 主要時區
+        api_description: 主要時區
+      locale:
+        _: 語言
+        label: 主要語言
+        heading: 語言
+        api_title: 語言
+        api_description: 語言
+      created_at:
+        _: 註冊於
+        heading: 註冊於
+        api_title: 註冊於
+        api_description: 註冊於
+      updated_at:
+        _: 更新於
+        heading: 更新於
+        api_title: 更新於
+        api_description: 更新於
+    api:
+      actions: 團隊行動
+      index: 列出團隊
+      create: 新增團隊
+      show: 找回隊伍
+      update: 更新團隊
+      fields:
+        id:
+          _: 團隊ID
+          label: 團隊ID
+          heading: 團隊ID
+          api_title: 團隊ID
+          api_description: 團隊ID
+        name:
+          _: 團隊名稱
+          label: 團隊名稱
+          heading: 團隊
+          api_title: 團隊名稱
+          api_description: 團隊名稱
+        time_zone:
+          _: 主要時區
+          label: 主要時區
+          heading: 主要時區
+          api_title: 主要時區
+          api_description: 主要時區
+        locale:
+          _: 語言
+          label: 主要語言
+          heading: 語言
+          api_title: 語言
+          api_description: 語言
+        created_at:
+          _: 註冊於
+          heading: 註冊於
+          api_title: 註冊於
+          api_description: 註冊於
+        updated_at:
+          _: 更新於
+          heading: 更新於
+          api_title: 更新於
+          api_description: 更新於
+  account:
+    teams:
+      label: 團隊
+      singular: 團隊
+      breadcrumbs:
+        label: 團隊
+        team_settings: 團隊設定
+        dashboard: 儀表板
+      navigation:
+        label: 團隊
+      buttons:
+        new: 新增團隊
+        create: 創建團隊
+        edit: 編輯團隊
+        update: 更新團隊
+        destroy: 刪除團隊
+        confirmations:
+          destroy: 您確定要刪除該團隊嗎？
+      index:
+        section: 團隊
+        header: 你的團隊
+        create: 創建新團隊
+        buttons:
+          new: 新增團隊
+          create: 創建團隊
+          edit: 編輯團隊
+          update: 更新團隊
+          destroy: 刪除團隊
+          confirmations:
+            destroy: 您確定要刪除該團隊嗎？
+      show:
+        header: "%{teams_possessive} 合規性儀錶板"
+      new:
+        header: 創建一個新團隊
+        former_user_header: 加入團隊
+        default_team_name: 你的團隊
+        buttons:
+          new: 新增團隊
+          create: 創建團隊
+          edit: 編輯團隊
+          update: 更新團隊
+          destroy: 刪除團隊
+          confirmations:
+            destroy: 您確定要刪除該團隊嗎？
+        you_can: 您可以：
+        invitation_header: 接受邀請
+        logout_header: 登出該帳戶
+        new_team_header: 創建一個新團隊
+        alert: 帳號<b>%{user_email}</b>目前不是任何團隊的成員。
+        invitation: 如果您收到邀請您加入新團隊的電子郵件，請點擊該電子郵件中的連結以接受邀請。
+        log_out: 您可以登出此帳戶並使用屬於團隊成員的其他帳戶登入。
+        new_team: 您可以使用下面的表格來建立自己的新團隊。
+      edit:
+        section: "%{team_name}"
+        header: 編輯團隊詳細信息
+        description: 您可以在下面更新該團隊的詳細資訊和設定。
+      notifications:
+        created: 團隊已成功建立。
+        updated: 團隊更新已成功。
+        destroyed: 隊伍已被成功摧毀。
+        invitation_only: 目前，創建新團隊僅限於受邀搶先體驗的用戶。如果您收到了搶先造訪網址，請先造訪該網址，然後再重試。
+        cannot_delete_last_team: 您無法刪除您所屬的最後一個團隊。
+      form:
+        buttons:
+          new: 新增團隊
+          create: 創建團隊
+          edit: 編輯團隊
+          update: 更新團隊
+          destroy: 刪除團隊
+          confirmations:
+            destroy: 您確定要刪除該團隊嗎？
+      fields:
+        id:
+          _: 團隊ID
+          label: 團隊ID
+          heading: 團隊ID
+          api_title: 團隊ID
+          api_description: 團隊ID
+        name:
+          _: 團隊名稱
+          label: 團隊名稱
+          heading: 團隊名稱
+          api_title: 團隊名稱
+          api_description: 團隊名稱
+        time_zone:
+          _: 主要時區
+          label: 主要時區
+          heading: 主要時區
+          api_title: 主要時區
+          api_description: 主要時區
+        locale:
+          _: 主要語言
+          label: 主要語言
+          heading: 主要語言
+          api_title: 主要語言
+          api_description: 主要語言
+        created_at:
+          _: 註冊於
+          heading: 註冊於
+          api_title: 註冊於
+          api_description: 註冊於
+        updated_at:
+          _: 更新於
+          heading: 更新於
+          api_title: 更新於
+          api_description: 更新於
+      _:
+        name:
+          label: 你的團隊名稱
+      self:
+        id:
+          _: 團隊ID
+          label: 團隊ID
+          heading: 團隊ID
+          api_title: 團隊ID
+          api_description: 團隊ID
+        name:
+          label: 你的團隊名稱
+        time_zone:
+          _: 主要時區
+          label: 主要時區
+          heading: 主要時區
+          api_title: 主要時區
+          api_description: 主要時區
+        locale:
+          _: 語言
+          label: 主要語言
+          heading: 語言
+          api_title: 語言
+          api_description: 語言
+        created_at:
+          _: 註冊於
+          heading: 註冊於
+          api_title: 註冊於
+          api_description: 註冊於
+        updated_at:
+          _: 更新於
+          heading: 更新於
+          api_title: 更新於
+          api_description: 更新於
+      api:
+        actions: 團隊行動
+        index: 列出團隊
+        create: 新增團隊
+        show: 找回隊伍
+        update: 更新團隊
+        fields:
+          id:
+            _: 團隊ID
+            label: 團隊ID
+            heading: 團隊ID
+            api_title: 團隊ID
+            api_description: 團隊ID
+          name:
+            _: 團隊名稱
+            label: 團隊名稱
+            heading: 團隊
+            api_title: 團隊名稱
+            api_description: 團隊名稱
+          time_zone:
+            _: 主要時區
+            label: 主要時區
+            heading: 主要時區
+            api_title: 主要時區
+            api_description: 主要時區
+          locale:
+            _: 語言
+            label: 主要語言
+            heading: 語言
+            api_title: 語言
+            api_description: 語言
+          created_at:
+            _: 註冊於
+            heading: 註冊於
+            api_title: 註冊於
+            api_description: 註冊於
+          updated_at:
+            _: 更新於
+            heading: 更新於
+            api_title: 更新於
+            api_description: 更新於
+  activerecord:
+    attributes:
+      team:
+        name: 團隊名稱
+        time_zone: 主要時區
+        locale: 語言
+        created_at: 註冊於
+        updated_at: 更新於


### PR DESCRIPTION
> 🤖 This PR was generated by Claude Code.

## Summary

Bullet Train ships English locale files for the `teams`, `devise`, `memberships`, and `onboarding` namespaces but no translations, so apps running in a non-English locale fall back to English for these strings.

This adds Spanish (`es`), French (`fr`), Simplified Chinese (`zh-CN`), and Traditional Chinese (`zh-TW`) files for those four namespaces, each mirroring the corresponding `en` file's key shape 1:1.

- 16 files: 4 namespaces x 4 locales, under `bullet_train/config/locales/<locale>/`.
- Verified: every added file's flattened leaf-path set is **identical** to its `en` counterpart on `main` (no added/removed/renamed keys, interpolation placeholders preserved).

## How these were produced

Translations are machine-generated (Google Translate) as a starting point, then key-shape-verified against the English source. They were extracted from a downstream app that maintains a per-language mirror of Bullet Train's gem locale files; this PR contributes that mirror back upstream so the gem can ship translations directly.

## Review note

These are **machine translations** and would benefit from a native-speaker review pass for nuance (the structure is correct; wording may need polish). Opened as a **draft** for that reason. Follow-ups (separate PRs) can add the remaining surfaced namespaces (`base`, `fields`, `navigation`, `billing/products`) once their package paths and any version-skew are reconciled.

Co-Authored-By: Claude Opus 4.7 (1M context)