### PR TITLE
exclude platform agents from admin users

### DIFF
--- a/bullet_train/app/models/concerns/teams/base.rb
+++ b/bullet_train/app/models/concerns/teams/base.rb
@@ -45,7 +45,15 @@ module Teams::Base
   end
 
   def admin_users
-    admins.map(&:user).compact
+    # Exclude platform agents: they are synthetic service accounts (an OAuth
+    # application / team-level connection) added as admins for authorization,
+    # but they are not people. Their email is an intentionally-undeliverable
+    # noreply+<hex>@bullettrain.co placeholder, so including them here would let
+    # a machine account become a team's #primary_contact / #formatted_email_address
+    # and pull undeliverable addresses into admin notification recipients.
+    # #admins is intentionally left inclusive so authorization and the
+    # "last remaining admin" guard still count platform agents.
+    admins.excluding_platform_agents.map(&:user).compact
   end
 
   def primary_contact

--- a/bullet_train/test/models/team_test.rb
+++ b/bullet_train/test/models/team_test.rb
@@ -107,4 +107,24 @@ class TeamTest < ActiveSupport::TestCase
     @team.name_was = "Old Name"
     assert_equal "Old Name", @team.label_string # passes
   end
+
+  test "#admin_users excludes platform agents while #admins still counts them" do
+    team = Team.create!(name: "platform agents team")
+    human = User.create!(email: "human@test.com", password: "password", password_confirmation: "password")
+    agent = User.create!(email: "noreply+#{SecureRandom.hex}@bullettrain.co", password: "password", password_confirmation: "password")
+
+    Membership.create!(team: team, user: human, role_ids: [Role.admin.id])
+    agent_membership = Membership.create!(team: team, user: agent, role_ids: [Role.admin.id])
+    # Mark the membership as a platform agent (an OAuth application / team-level
+    # connection service account). platform_agent_of_id has no FK, so a sentinel
+    # value is enough to exercise the Membership.excluding_platform_agents scope.
+    agent_membership.update_column(:platform_agent_of_id, agent.id)
+
+    # #admins stays inclusive so authorization and the "last admin" guard still count agents.
+    assert_includes team.admins.map(&:user), agent
+
+    # #admin_users (team contact + admin notification recipients) excludes the agent.
+    assert_includes team.admin_users, human
+    refute_includes team.admin_users, agent
+  end
 end


### PR DESCRIPTION
Platform agents are the synthetic service accounts bullet_train-api creates to back an OAuth application or team-level connection (Platform::Application#create_user_and_membership). They're added as team admins for authorization, but they aren't people - their email is an intentionally-undeliverable noreply+<hex>@bullettrain.co placeholder.

Because `Team#admin_users` mapped every admin membership to its user, a platform agent could:
 - become a team's `#primary_contact` → `#formatted_email_address` (so a team's contact address becomes an undeliverable placeholder), 
 - be pulled into admin notification recipient lists, producing mail that bounces. (This is how we found this code)

This excludes platform agents from #admin_users via the existing `Membership.excluding_platform_agents scope`. `#admins` is intentionally left inclusive so authorization and the "last remaining admin" guard (memberships/base.rb) still count platform agents.