### PR TITLE
Fix stale obfuscated IDs on duplicated records

### DIFF
--- a/bullet_train-obfuscates_id/app/models/concerns/obfuscates_id.rb
+++ b/bullet_train-obfuscates_id/app/models/concerns/obfuscates_id.rb
@@ -51,7 +51,7 @@ module ObfuscatesId
   end
 
   def obfuscated_id
-    @obfuscated_id ||= self.class.encode_id(id)
+    self.class.encode_id(id)
   end
 
   def to_param

--- a/bullet_train-obfuscates_id/test/models/obfuscates_id_concern_test.rb
+++ b/bullet_train-obfuscates_id/test/models/obfuscates_id_concern_test.rb
@@ -27,6 +27,16 @@ class FakeModelWithNilId
   end
 end
 
+class FakeModelWithMutableId
+  include ObfuscatesId
+
+  attr_accessor :id
+
+  def initialize(id)
+    @id = id
+  end
+end
+
 class BulletTrain::ObfuscatesIdConcernTest < ActiveSupport::TestCase
   test "FakeModel has an id" do
     fake_model = FakeModel.new
@@ -45,5 +55,15 @@ class BulletTrain::ObfuscatesIdConcernTest < ActiveSupport::TestCase
 
   test "FakeModelWithNilId returns nil when id is nil" do
     assert_nil FakeModelWithNilId.new.to_param
+  end
+
+  test "a duplicate uses its own id when generating an obfuscated id" do
+    original = FakeModelWithMutableId.new(42)
+    original.obfuscated_id
+
+    duplicate = original.dup
+    duplicate.id = 43
+
+    assert_equal FakeModelWithMutableId.encode_id(43), duplicate.obfuscated_id
   end
 end


### PR DESCRIPTION
## What changed

- Stop memoizing `obfuscated_id` on model instances.
- Add a regression test for duplicating a record after its obfuscated ID has been read.

## Why

Ruby copies instance variables when an object is duplicated. If `obfuscated_id` has already been memoized, a duplicate carries the original record's encoded ID even after receiving a different database ID. Its `to_param` can therefore continue linking to the original record.

Deriving the value from the current `id` avoids that stale state. Existing records produce exactly the same encoded IDs, so published URLs remain compatible.

## Validation

- `bundle exec ruby -Itest test/models/obfuscates_id_concern_test.rb` — 5 tests, 5 assertions, 0 failures
- `bundle exec standardrb bullet_train-obfuscates_id/app/models/concerns/obfuscates_id.rb bullet_train-obfuscates_id/test/models/obfuscates_id_concern_test.rb`
